### PR TITLE
add `generate-types` workflow

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -1,0 +1,34 @@
+name: Generate Types
+
+on:
+  workflow_dispatch:
+
+env:
+  NODE_ENV: test
+  API_CLIENT_ID: approved-premises
+  API_CLIENT_SECRET: clientsecret
+
+jobs:
+  generate-types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Generate Types
+        run: ./script/generate-types
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'API model updates'
+          commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
+          body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
+          delete-branch: true
+          branch-suffix: timestamp
+          branch: update-api-types

--- a/script/generate-types
+++ b/script/generate-types
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# script/generate-types: Generates typescript types from the OpenApi spec in the API repo
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Generating types..."
+
+npx openapi-typescript-codegen -i https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/api.yml -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
+
+echo "==> Renaming the declaration file..."
+
+mv ./server/@types/shared/index.ts ./server/@types/shared/index.d.ts
+
+


### PR DESCRIPTION
we want to re-use the Approved Premises' workflow to auto generate types from the API, using the same github app[1], so that when the API changes it opens a PR to update our types [2]

[1] https://github.com/ministryofjustice/hmpps-approved-premises-ui/commit/5b2ad74a7f12b08764698aeee9ac9ece0069b81c
[2] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/639