### PR TITLE
Update Typescript to 5.1.6

### DIFF
--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress"],
     "esModuleInterop": true,
-    "typeRoots": ["../server/@types", "../node_modules/@types"],
+    "typeRoots": ["../node_modules", "../server/@types", "../node_modules/@types"],
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "baseUrl": ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "start-server-and-test": "^2.0.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": "^18",
@@ -13447,16 +13447,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/uid-safe": {

--- a/package.json
+++ b/package.json
@@ -199,6 +199,6 @@
     "start-server-and-test": "^2.0.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
We can now update Typescript - it was previously broken with Cypress for those using `typeRoots` but the fix is to specify the node_modules folder so it can find Cypress.[1]

[1] https://github.com/cypress-io/cypress/issues/26930