### PR TITLE
Sentry integration

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -49,6 +49,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
+      SENTRY_DSN: 'SENTRY_DSN'
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/integration_tests/tests/health.cy.ts
+++ b/integration_tests/tests/health.cy.ts
@@ -27,4 +27,13 @@ context('Healthcheck', () => {
       })
     })
   })
+
+  context('Sentry check', () => {
+    it('Throws a test error', () => {
+      cy.request({ url: '/debug-sentry', method: 'GET', failOnStatusCode: false }).then(response => {
+        expect(response.status).to.equal(500)
+        expect(response.body).to.contain('Test Sentry error thrown.')
+      })
+    })
+  })
 })

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -60,7 +60,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubAuthUser', { name: 'bobby brown' })
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@faker-js/faker": "^8.0.0",
         "@golevelup/ts-jest": "^0.3.3",
         "@ministryofjustice/frontend": "^1.6.6",
+        "@sentry/node": "^7.57.0",
         "@types/qs": "^6.9.7",
         "agentkeepalive": "^4.3.0",
         "applicationinsights": "^2.5.1",
@@ -2993,6 +2994,79 @@
       "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==",
+      "dependencies": {
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+      "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
+      "dependencies": {
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.57.0.tgz",
+      "integrity": "sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.57.0",
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
+      "dependencies": {
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sideway/address": {
@@ -10040,6 +10114,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   "dependencies": {
     "@faker-js/faker": "^8.0.0",
     "@ministryofjustice/frontend": "^1.6.6",
+    "@sentry/node": "^7.57.0",
     "@types/qs": "^6.9.7",
     "agentkeepalive": "^4.3.0",
     "applicationinsights": "^2.5.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import setUpStaticResources from './middleware/setUpStaticResources'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
+import { setUpSentryErrorHandler, setUpSentryRequestHandler } from './middleware/setUpSentry'
 
 import routes from './routes'
 import type { Services } from './services'
@@ -30,6 +31,8 @@ export default function createApp(controllers: Controllers, services: Services):
   app.set('json spaces', 2)
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
+
+  setUpSentryRequestHandler(app)
 
   app.use(metricsMiddleware)
   app.use(setUpHealthChecks())
@@ -53,6 +56,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(routes(controllers))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
+  setUpSentryErrorHandler(app)
   app.use(errorHandler(process.env.NODE_ENV === 'production'))
 
   return app

--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -3,9 +3,20 @@
 
 import fs from 'fs'
 
-const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const buildNumber = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString()).buildNumber
-  : packageData.version
+function getBuild() {
+  try {
+    // eslint-disable-next-line import/no-unresolved,global-require
+    return require('../build-info.json')
+  } catch (ex) {
+    return null
+  }
+}
 
-export default { buildNumber, packageData }
+const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
+
+const { buildNumber, gitRef } = getBuild() || {
+  buildNumber: packageData.version,
+  gitRef: 'unknown',
+}
+
+export default { buildNumber, gitRef, packageData }

--- a/server/config.ts
+++ b/server/config.ts
@@ -44,6 +44,10 @@ export default {
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },
+  environment: process.env.ENVIRONMENT || 'local',
+  sentry: {
+    dsn: get('SENTRY_DSN', null, requiredInProduction),
+  },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -20,5 +20,9 @@ export default function setUpHealthChecks(): Router {
     }),
   )
 
+  router.get('/debug-sentry', (_req, res) => {
+    throw new Error('Test Sentry error thrown.')
+  })
+
   return router
 }

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -1,0 +1,63 @@
+import * as Sentry from '@sentry/node'
+import express from 'express'
+import applicationVersion from '../applicationVersion'
+import config from '../config'
+
+export function setUpSentryRequestHandler(app: express.Express): void {
+  if (config.sentry.dsn) {
+    // Prevent usernames which are PII from being sent to Sentry
+    // https://docs.sentry.io/platforms/python/guides/logging/data-management/sensitive-data/#examples
+    const anonymousId = Math.random().toString()
+    Sentry.setUser({ id: anonymousId })
+
+    Sentry.init({
+      dsn: config.sentry.dsn,
+      environment: config.environment,
+      release: applicationVersion.gitRef,
+      integrations: [
+        // enable HTTP calls tracing
+        new Sentry.Integrations.Http({ tracing: true }),
+        // enable Express.js middleware tracing
+        new Sentry.Integrations.Express({ app }),
+      ],
+      tracesSampler: samplingContext => {
+        const transactionName = samplingContext?.transactionContext?.name
+        if (
+          transactionName?.includes('ping') ||
+          transactionName?.includes('health') ||
+          transactionName?.includes('assets')
+        ) {
+          return 0
+        }
+
+        if (config.environment === 'prod') {
+          return 1
+        }
+
+        // Default sample rate
+        return 0.05
+      },
+      beforeSend(event) {
+        if (event.user) {
+          // Don't send username
+          // eslint-disable-next-line no-param-reassign
+          delete event.user.username
+        }
+        return event
+      },
+    })
+    app.use(
+      Sentry.Handlers.requestHandler({
+        ip: false,
+        user: false,
+      }) as express.RequestHandler,
+    )
+    app.use(Sentry.Handlers.tracingHandler())
+  }
+}
+
+export function setUpSentryErrorHandler(app: express.Express): void {
+  if (config.sentry.dsn) {
+    app.use(Sentry.Handlers.errorHandler() as express.ErrorRequestHandler)
+  }
+}


### PR DESCRIPTION
We will be using Sentry to track errors in the app. We're following the
[same implementation as CAS1 + 2](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/f4fd6ce072799d559d13c307a05229f35ac19ed7), with slight difference that we do not
[need to use the `@sentry/tracing` package because it is being
deprecated](https://docs.sentry.io/product/sentry-basics/tracing/).

I've tested this out locally by creating an error [and it has been logged here](https://ministryofjustice.sentry.io/issues/4293405489/?project=4505442489729024&referrer=project-issue-stream)