### PR TITLE
E2E test setup for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   hmpps: ministryofjustice/hmpps@7.2.1
   slack: circleci/slack@4.12.1
+  node: circleci/node@4.5.2
 
 parameters:
   alerts-slack-channel:
@@ -56,6 +57,33 @@ jobs:
             - dist
             - .cache/Cypress
 
+  e2e_environment_test:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.34.1-focal
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e.git .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@latest'
+      - node/install-packages
+      - run:
+          name: E2E Check
+          command: |
+            npm run test
+      - store_artifacts:
+          path: playwright-report
+          destination: playwright-report
+      - store_artifacts:
+          path: test-results
+          destination: test-results
+      - slack/notify:
+          event: fail
+          channel: << pipeline.parameters.alerts-slack-channel >>
+          template: basic_fail_1
 workflows:
   version: 2
   build-test-and-deploy:
@@ -85,6 +113,14 @@ workflows:
             - helm_lint
             - build_docker
           helm_timeout: 5m
+      - e2e_environment_test:
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
   #      - request-preprod-approval:
   #          type: approval
   #          requires:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Or run tests with the cypress UI:
 
 `npm run test:integration:ui`
 
+## Running e2e tests
+
+End to end tests for this project can be found [in a seperate repo](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e).
+
 
 ## Manage infrastructure & view logs
 


### PR DESCRIPTION
This PR adds the CI job to run the e2e tests after the dev environment has been deployed on `main`, and will alert our `hmpps-cas-2-team-events` channel on failure.

Also added link to the e2e repo in the Readme doc.