### PR TITLE
Unit test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest --collectCoverage",
     "test:ci": "jest --runInBand",
+    "test:nocov": "jest --collectCoverage=false",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc && tsc -p integration_tests",
-    "test": "jest",
+    "test": "jest --collectCoverage",
     "test:ci": "jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",

--- a/server/form-pages/utils/getTaskStatus.test.ts
+++ b/server/form-pages/utils/getTaskStatus.test.ts
@@ -1,6 +1,6 @@
 import { createMock } from '@golevelup/ts-jest'
 import { applicationFactory } from '../../testutils/factories'
-import getTaskStatus from './getTaskStatus'
+import getTaskStatus, { getPageData } from './getTaskStatus'
 import TaskListPage from '../taskListPage'
 
 describe('getTaskStatus', () => {
@@ -142,5 +142,16 @@ describe('getTaskStatus', () => {
     expect(Page3).toHaveBeenCalled()
     expect(page3Instance.errors).toHaveBeenCalled()
     expect(page3Instance.next).toHaveBeenCalled()
+  })
+})
+
+describe('getPageData', () => {
+  it('returns undefined when there is not a matching task name', () => {
+    const application = applicationFactory.build({ data: { nonMatchingTaskName: { page: 'page data' } } })
+    expect(getPageData(application, 'taskName', 'pageName')).toEqual(undefined)
+  })
+  it('returns undefined when there is no data', () => {
+    const application = applicationFactory.build({ data: null })
+    expect(getPageData(application, 'taskName', 'pageName')).toEqual(undefined)
   })
 })

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -3,7 +3,7 @@ import type { TaskStatus, UiTask } from '@approved-premises/ui'
 import { Cas2Application as Application } from '@approved-premises/api'
 import { TaskListPageInterface } from '../taskListPage'
 
-const getPageData = (application: Application, taskName: string, pageName: string) => {
+export const getPageData = (application: Application, taskName: string, pageName: string) => {
   return application.data?.[taskName]?.[pageName]
 }
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -1,0 +1,164 @@
+import { Request } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import 'reflect-metadata'
+
+// Use a wildcard import to allow us to use jest.spyOn on functions within this module
+import * as utils from './index'
+import { ApprovedPremisesApplication } from '../../@types/shared'
+
+import { applicationFactory } from '../../testutils/factories'
+import { TaskListPageInterface } from '../taskListPage'
+
+describe('utils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Decorator metadata utils', () => {
+    class Section {}
+
+    class Task {}
+
+    class Page1 {}
+    class Page2 {}
+
+    beforeEach(() => {
+      Reflect.defineMetadata('page:name', 'page-1', Page1)
+      Reflect.defineMetadata('page:name', 'page-2', Page2)
+
+      Reflect.defineMetadata('page:task', 'task-1', Page1)
+      Reflect.defineMetadata('page:task', 'task-2', Page2)
+
+      Reflect.defineMetadata('task:slug', 'slug', Task)
+      Reflect.defineMetadata('task:name', 'Name', Task)
+      Reflect.defineMetadata('task:pages', [Page1, Page2], Task)
+
+      Reflect.defineMetadata('section:title', 'Section', Section)
+      Reflect.defineMetadata('section:tasks', [Task], Section)
+    })
+
+    describe('getTask', () => {
+      it('fetches metadata for a specific task and pages', () => {
+        expect(utils.getTask(Task)).toEqual({ id: 'slug', title: 'Name', pages: { 'page-1': Page1, 'page-2': Page2 } })
+      })
+    })
+
+    describe('getSection', () => {
+      it('fetches metadata for a specific section and tasks', () => {
+        expect(utils.getSection(Section)).toEqual({
+          title: 'Section',
+          tasks: [utils.getTask(Task)],
+        })
+      })
+    })
+
+    describe('getPagesForSections', () => {
+      it('fetches pages for all supplied sections', () => {
+        class Section1 {}
+        class Section2 {}
+
+        jest.spyOn(utils, 'getSection').mockImplementation((section: Section1 | Section2) => {
+          if (section === Section1) {
+            return {
+              title: 'Section 1',
+              name: 'Section1',
+              tasks: [{ id: 'foo', title: 'Foo', pages: { 'page-1': Page1, 'page-2': Page2 } }],
+            }
+          }
+          return {
+            title: 'Section 2',
+            name: 'Section2',
+            tasks: [{ id: 'bar', title: 'Bar', pages: { 'page-3': Page1, 'page-4': Page2 } }],
+          }
+        })
+
+        expect(utils.getPagesForSections([Section1, Section2])).toEqual({
+          foo: {
+            'page-1': Page1,
+            'page-2': Page2,
+          },
+          bar: {
+            'page-3': Page1,
+            'page-4': Page2,
+          },
+        })
+      })
+    })
+
+    describe('viewPath', () => {
+      it('returns the view path for a page', () => {
+        const page1 = new Page1()
+
+        expect(utils.viewPath(page1, 'applications')).toEqual('applications/pages/task-1/page-1')
+      })
+    })
+
+    describe('getPageName', () => {
+      it('returns the page name', () => {
+        expect(utils.getPageName(Page1)).toEqual('page-1')
+      })
+    })
+
+    describe('getTaskName', () => {
+      it('returns the task name', () => {
+        expect(utils.getTaskName(Page1)).toEqual('task-1')
+      })
+    })
+  })
+
+  describe('getBody', () => {
+    it('if there is userInput it returns it', () => {
+      const input = { user: 'input' }
+
+      expect(
+        utils.getBody({} as TaskListPageInterface, {} as ApprovedPremisesApplication, {} as Request, input),
+      ).toEqual(input)
+    })
+
+    it('if there isnt userInput and there is a request body the request body is returned', () => {
+      const request: DeepMocked<Request> = createMock<Request>()
+
+      expect(utils.getBody({} as TaskListPageInterface, {} as ApprovedPremisesApplication, request, {}))
+    })
+
+    it('if there is neither a request body or userInput then getPageFromApplicationData is called and returns the data for that page', () => {
+      const page: DeepMocked<TaskListPageInterface> = createMock<TaskListPageInterface>()
+      const pageData = { task: { page: 'returnMe' } }
+      const application = applicationFactory.build({ data: pageData })
+
+      jest.spyOn(utils, 'getPageName').mockImplementation(() => 'page')
+      jest.spyOn(utils, 'getTaskName').mockImplementation(() => 'task')
+
+      jest.spyOn(utils, 'pageDataFromApplication').mockImplementation((_, applicationInput) => applicationInput.data)
+
+      expect(utils.getBody(page, application, { body: {} } as Request, {})).toBe('returnMe')
+    })
+  })
+
+  describe('pageDataFromApplication', () => {
+    describe('when there is not a matching task name on the application', () => {
+      it('returns an empty object', () => {
+        const page: DeepMocked<TaskListPageInterface> = createMock<TaskListPageInterface>()
+        const pageData = { taskThatDoesNotMatch: { pageThatDoNotMatch: 'notReturned' } }
+        const application = applicationFactory.build({ data: pageData })
+
+        jest.spyOn(utils, 'getPageName').mockImplementation(() => 'page')
+        jest.spyOn(utils, 'getTaskName').mockImplementation(() => 'task')
+
+        expect(utils.pageDataFromApplication(page, application)).toEqual({})
+      })
+    })
+
+    describe('when there is no data on the application', () => {
+      it('returns null', () => {
+        const page: DeepMocked<TaskListPageInterface> = createMock<TaskListPageInterface>()
+        const application = applicationFactory.build({ data: null })
+
+        jest.spyOn(utils, 'getPageName').mockImplementation(() => 'page')
+        jest.spyOn(utils, 'getTaskName').mockImplementation(() => 'task')
+
+        expect(utils.pageDataFromApplication(page, application)).toEqual({})
+      })
+    })
+  })
+})

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,0 +1,12 @@
+import { applicationFactory } from '../../testutils/factories'
+import { getApplicationUpdateData } from './getApplicationData'
+
+describe('getApplicationUpdateData', () => {
+  it('returns the application data', () => {
+    const mockApplication = applicationFactory.build()
+    expect(getApplicationUpdateData(mockApplication)).toEqual({
+      type: 'CAS2',
+      data: mockApplication.data,
+    })
+  })
+})

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -92,15 +92,6 @@ export class DateFormats {
     return dateInputObj
   }
 
-  static dateObjectToDateInputs<K extends string>(date: Date, key: K): ObjectWithDateParts<K> {
-    return {
-      [`${key}-year`]: String(date.getFullYear()),
-      [`${key}-month`]: String(date.getMonth() + 1),
-      [`${key}-day`]: String(date.getDate()),
-      [`${key}`]: DateFormats.dateObjToIsoDate(date),
-    } as ObjectWithDateParts<K>
-  }
-
   /**
    * @param date1 first day to compare.
    * @param date2 second day to compare.
@@ -108,10 +99,6 @@ export class DateFormats {
    */
   static differenceInDays(date1: Date, date2: Date): DifferenceInDays {
     return { ui: formatDistanceStrict(date1, date2, { unit: 'day' }), number: differenceInDays(date1, date2) }
-  }
-
-  static isoDateToDateInputs<K extends string>(isoDate: string, key: string): ObjectWithDateParts<K> {
-    return DateFormats.dateObjectToDateInputs(DateFormats.isoToDateObj(isoDate), key)
   }
 }
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,8 +1,146 @@
 import { Request, Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
 import type { ErrorMessages, ErrorSummary } from '@approved-premises/ui'
-import { catchAPIErrorOrPropogate, fetchErrorsAndUserInput } from './validation'
-import { TaskListAPIError } from './errors'
+import { SanitisedError } from 'server/sanitisedError'
+import TaskListPage from 'server/form-pages/taskListPage'
+import {
+  catchAPIErrorOrPropogate,
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  firstFlashItem,
+} from './validation'
+import { TaskListAPIError, ValidationError } from './errors'
+import errorLookups from '../i18n/en/errors.json'
+
+jest.mock('../i18n/en/errors.json', () => {
+  return {
+    fundingSource: {
+      empty: 'You must choose a funding source',
+    },
+  }
+})
+
+describe('catchValidationErrorOrPropogate', () => {
+  const request = createMock<Request>({})
+  const response = createMock<Response>()
+
+  const expectedErrors = {
+    fundingSource: { text: errorLookups.fundingSource.empty, attributes: { 'data-cy-error-fundingSource': true } },
+  }
+
+  const expectedErrorSummary = [{ text: errorLookups.fundingSource.empty, href: '#fundingSource' }]
+
+  beforeEach(() => {
+    request.body = {
+      some: 'field',
+    }
+  })
+
+  it('sets the errors and request body as flash messages and redirects back to the form', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [
+          {
+            propertyName: '$.fundingSource',
+            errorType: 'empty',
+          },
+        ],
+      },
+    })
+
+    catchValidationErrorOrPropogate(request, response, error, 'some/url')
+
+    expect(request.flash).toHaveBeenCalledWith('errors', expectedErrors)
+    expect(request.flash).toHaveBeenCalledWith('errorSummary', expectedErrorSummary)
+    expect(request.flash).toHaveBeenCalledWith('userInput', request.body)
+
+    expect(response.redirect).toHaveBeenCalledWith('some/url')
+  })
+
+  it('sets a generic error and redirects back to the form', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        detail: 'Some generic error',
+        'invalid-params': [],
+      },
+    })
+
+    catchValidationErrorOrPropogate(request, response, error, 'some/url')
+
+    expect(request.flash).toHaveBeenCalledWith('errorSummary', { text: 'Some generic error' })
+    expect(request.flash).toHaveBeenCalledWith('userInput', request.body)
+
+    expect(response.redirect).toHaveBeenCalledWith('some/url')
+  })
+
+  it('gets errors from a ValidationError type', () => {
+    const error = new ValidationError<TaskListPage>({
+      data: {
+        crn: 'You must enter a valid crn',
+        error: 'You must enter a valid arrival date',
+      },
+    })
+
+    catchValidationErrorOrPropogate(request, response, error, 'some/url')
+
+    expect(request.flash).toHaveBeenCalledWith('errors', expectedErrors)
+    expect(request.flash).toHaveBeenCalledWith('errorSummary', expectedErrorSummary)
+    expect(request.flash).toHaveBeenCalledWith('userInput', request.body)
+
+    expect(response.redirect).toHaveBeenCalledWith('some/url')
+  })
+
+  it('throws the error if the error is not the type we expect', () => {
+    const err = new Error('Some unhandled error')
+    err.name = 'SomeUnhandledError'
+    err.stack = 'STACK_GOES_HERE'
+
+    const result = () => catchValidationErrorOrPropogate(request, response, err, 'some/url')
+
+    expect(result).toThrowError(err)
+    expect(result).toThrowError(
+      expect.objectContaining({
+        message: 'Some unhandled error',
+        name: 'SomeUnhandledError',
+        stack: 'STACK_GOES_HERE',
+      }),
+    )
+  })
+
+  it('throws an error if the property is not found in the error lookup', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [
+          {
+            propertyName: '$.foo',
+            errorType: 'bar',
+          },
+        ],
+      },
+    })
+
+    expect(() => catchValidationErrorOrPropogate(request, response, error, 'some/url')).toThrowError(
+      'Cannot find a translation for an error at the path $.foo',
+    )
+  })
+
+  it('throws an error if the error type is not found in the error lookup', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [
+          {
+            propertyName: '$.fundingSource',
+            errorType: 'invalid',
+          },
+        ],
+      },
+    })
+
+    expect(() => catchValidationErrorOrPropogate(request, response, error, 'some/url')).toThrowError(
+      'Cannot find a translation for an error at the path $.fundingSource with the type invalid',
+    )
+  })
+})
 
 describe('catchAPIErrorOrPropogate', () => {
   const request = createMock<Request>({ headers: { referer: 'foo/bar' } })
@@ -24,6 +162,14 @@ describe('catchAPIErrorOrPropogate', () => {
     ])
 
     expect(response.redirect).toHaveBeenCalledWith(request.headers.referer)
+  })
+
+  it('throws the error if not of type TaskListAPIError', () => {
+    const error = Error('some unhandled error')
+
+    const result = () => catchAPIErrorOrPropogate(request, response, error)
+
+    expect(result).toThrowError(error)
   })
 })
 
@@ -61,5 +207,30 @@ describe('fetchErrorsAndUserInput', () => {
     const result = fetchErrorsAndUserInput(request)
 
     expect(result).toEqual({ errors, errorSummary, userInput, errorTitle })
+  })
+})
+
+describe('firstFlashItem', () => {
+  describe('when there is an item', () => {
+    it('returns the first flash item', () => {
+      const request = createMock<Request>({})
+      const flashMessage = 'flash message'
+      ;(request.flash as jest.Mock).mockImplementation(() => [flashMessage])
+
+      const result = firstFlashItem(request, 'key')
+
+      expect(result).toBe(flashMessage)
+    })
+  })
+
+  describe('when there is nothing in the flash', () => {
+    it('returns undefined', () => {
+      const request = createMock<Request>({})
+      ;(request.flash as jest.Mock).mockImplementation(() => null)
+
+      const result = firstFlashItem(request, 'key')
+
+      expect(result).toBe(undefined)
+    })
   })
 })


### PR DESCRIPTION
When we pulled in the code to [add the task list system](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/80) there were a few unit test gaps.
This PR plugs the gaps, mostly with tests from CAS1, and a few little ones of our own. 

* This also adds `--collectCoverage` to the `test` command. This means passing the 100% coverage will be part of CI, do we want to keep it at 100%?