### PR TITLE
Add back button on form pages

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -35,4 +35,8 @@ export default abstract class Page {
   checkRadioByNameAndValue(name: string, option: string): void {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }
+
+  clickBack(): void {
+    cy.get('a').contains('Back').click()
+  }
 }

--- a/integration_tests/tests/apply/view_tasklist.cy.ts
+++ b/integration_tests/tests/apply/view_tasklist.cy.ts
@@ -102,6 +102,20 @@ context('New', () => {
     )
   })
 
+  // When I click the back button
+  //-------------------------------------------
+  it('takes me back to the task list page', function test() {
+    // I click the link to the first page of the task
+    cy.get('a').contains('Funding information').click()
+
+    // I click the back button
+    const page = Page.verifyOnPage(FundingInformationPage, this.application)
+    page.clickBack()
+
+    // I'm on the task list page
+    Page.verifyOnPage(TaskListPage)
+  })
+
   // When I try to continue without answer the question
   // -------------------------------------------
   it('enforces answer', function test() {

--- a/server/form-pages/apply/area-and-funding/fundingInformation.test.ts
+++ b/server/form-pages/apply/area-and-funding/fundingInformation.test.ts
@@ -108,7 +108,7 @@ describe('FundingInformation', () => {
   })
 
   itShouldHaveNextValue(new FundingInformation({ fundingSource: 'personalSavings' }, application), '')
-  itShouldHavePreviousValue(new FundingInformation({ fundingSource: 'personalSavings' }, application), 'dashboard')
+  itShouldHavePreviousValue(new FundingInformation({ fundingSource: 'personalSavings' }, application), 'taskList')
 
   describe('errors', () => {
     it('should return errors when yes/no questions are blank', () => {

--- a/server/form-pages/apply/area-and-funding/fundingInformation.ts
+++ b/server/form-pages/apply/area-and-funding/fundingInformation.ts
@@ -38,7 +38,7 @@ export default class FundingInformation implements TaskListPage {
   }
 
   previous() {
-    return 'dashboard'
+    return 'taskList'
   }
 
   next() {

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 
 {% extends "../../partials/layout.njk" %}
@@ -7,6 +8,21 @@
 
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {% if page.previous() === 'taskList' %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.show({ id: applicationId })
+    }) }}
+  {% elif page.previous() %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">


### PR DESCRIPTION
This PR copies over the form page back button functionality from CAS-1, which will render a back button to either the task list page or the previous task page, based on what is returned from the previous() method on the form page class.

In the case of the back button, CAS-1 refer to their task list page as a 'dashboard' I have replaced this with 'taskList'.

### Before

![Screenshot 2023-07-20 at 15 33 54](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/f26a7614-e00e-4db2-8d59-4ef2db5ed084)

### After

![Screenshot 2023-07-20 at 15 34 30](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/760a3b82-96f4-4329-9040-d61dba20ac5e)
