### PR TITLE
Patch npm package 'tough-cookie' version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@faker-js/faker": "^8.0.0",
         "@golevelup/ts-jest": "^0.4.0",
         "@ministryofjustice/frontend": "^1.6.6",
-        "@sentry/node": "^7.60.0",
+        "@sentry/node": "^7.57.0",
         "@types/jsonpath": "^0.2.0",
         "@types/method-override": "^0.0.32",
         "@types/qs": "^6.9.7",
@@ -52,7 +52,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@pact-foundation/pact": "^12.1.0",
+        "@pact-foundation/pact": "^12.0.0",
         "@types/bunyan": "^1.8.8",
         "@types/bunyan-format": "^0.2.5",
         "@types/compression": "^1.7.2",
@@ -63,22 +63,22 @@
         "@types/http-errors": "^2.0.1",
         "@types/jest": "^29.5.0",
         "@types/jsonwebtoken": "^9.0.1",
-        "@types/node": "^18.17.0",
+        "@types/node": "^18.15.11",
         "@types/nunjucks": "^3.2.2",
         "@types/passport": "^1.0.12",
         "@types/passport-oauth2": "^1.4.12",
         "@types/superagent": "^4.1.16",
         "@types/supertest": "^2.0.12",
         "@types/uuid": "^9.0.1",
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
-        "@typescript-eslint/parser": "^6.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
         "audit-ci": "^6.6.1",
         "concurrently": "^8.0.1",
         "cookie-session": "^2.0.0",
-        "cypress": "^12.17.2",
+        "cypress": "^12.17.1",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv": "^16.0.3",
-        "eslint": "^8.45.0",
+        "eslint": "^8.38.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-typescript": "^3.5.5",
@@ -94,10 +94,10 @@
         "jsonwebtoken": "^9.0.0",
         "lint-staged": "^13.2.1",
         "mocha-junit-reporter": "^2.2.0",
-        "nock": "^13.3.2",
+        "nock": "^13.3.0",
         "nodemon": "^3.0.0",
         "prettier": "^3.0.0",
-        "sass": "^1.64.1",
+        "sass": "^1.62.0",
         "shellcheck": "^2.0.0",
         "start-server-and-test": "^2.0.0",
         "supertest": "^6.3.3",
@@ -2030,7 +2030,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -11886,6 +11886,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13445,16 +13451,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -13847,6 +13864,16 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-value-parser": {

--- a/package.json
+++ b/package.json
@@ -206,5 +206,8 @@
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.6"
+  },
+  "overrides": {
+    "tough-cookie": "^4.1.3"
   }
 }


### PR DESCRIPTION
The recently upgraded cypress installation (`12.7.1` -> `12.7.2`) has resulted in a [vulnerability warning](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui/519/workflows/4ea28190-5859-4266-87de-6c4ff38d402d/jobs/1381)

This is [CWE 1321](https://github.com/advisories?query=cwe%3A1321):

[tough-cookie Prototype Pollution vulnerability](https://github.com/advisories/GHSA-72xf-g2v4-qvf3)

and comes from cypress' `@cypress/request` package

This has not yet been fixed in cypress though there's a PR waiting to be merged:

https://github.com/cypress-io/request/pull/32

We declare a temporary 'override' in `package.json` to force this upgrade.