### PR TITLE
Add `test` environment configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,26 @@ workflows:
                 - main
           requires:
             - deploy_dev
+      - request-test-approval:
+          type: approval
+          requires:
+            - deploy_dev
+            - e2e_environment_test
+      - hmpps/deploy_env:
+          name: deploy_test
+          env: 'test'
+          jira_update: true
+          context:
+            - hmpps-common-vars
+            - hmpps-community-accommodation-tier-2-ui-stage
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - helm_lint
+            - build_docker
+            - request-test-approval
   #      - request-preprod-approval:
   #          type: approval
   #          requires:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,0 +1,23 @@
+---
+# Per environment values which override defaults in approved-premises-ui/values.yaml
+
+generic-service:
+  replicaCount: 2
+
+  ingress:
+    hosts:
+      - community-accommodation-tier-2-test.hmpps.service.justice.gov.uk
+    contextColour: green
+    tlsSecretName: hmpps-community-accommodation-tier-2-test-cert
+
+  env:
+    ENVIRONMENT: test
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-test.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+
+  allowlist: null
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
We would like to create a test environment for CAS2 so that we can easily demo features.
The [bootstrap](https://github.com/ministryofjustice/dps-project-bootstrap/pull/468) and [cloud PRs](https://github.com/ministryofjustice/cloud-platform-environments/pull/14813) have been merged.
Like CAS1 and 3, deployment to test will be manual, so that we have control over what features are released there. 
