### PR TITLE
436 fix errors on API timeout when searching for CRN

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,9 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
-  
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
+
   allowlist: null
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -16,6 +16,8 @@ generic-service:
     INGRESS_URL: 'https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   allowlist: null
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -56,10 +56,10 @@ export default {
     approvedPremises: {
       url: get('APPROVED_PREMISES_API_URL', 'http://localhost:9092', requiredInProduction),
       timeout: {
-        response: 10000,
-        deadline: 10000,
+        response: Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE', 10000)),
       },
-      agent: new AgentConfig(10000),
+      agent: new AgentConfig(Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000))),
       serviceName: get('COMMUNITY_ACCOMMODATION_API_SERVICE_NAME', 'approved-premises', requiredInProduction),
     },
     hmppsAuth: {

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -77,10 +77,6 @@ export default class RestClient {
         .send(this.filterBlanksFromData(data))
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
         .auth(this.token, { type: 'bearer' })
         .set({ ...this.defaultHeaders, ...headers })
         .responseType(responseType)


### PR DESCRIPTION
[Trello 436](https://trello.com/c/LI4W8feo/436-fix-errors-on-api-timeout-when-searching-for-crn) 

There are 2 parts to this, all taken from CAS1's work in:

- https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/981/
- https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/987/
- https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/989/

### 1. Don't retry POST/PUT on a timeout 
This was causing multiple applications to be created when a request timed out due to the OASys API being unavailable.

### 2. Increase UI <-> API timeout
The timeout between the frontend and the backend must  be greater than the timeout between the API and the
OASys Context API (which are both currently 10 seconds.)
