### PR TITLE
Show in progress applications for user

### DIFF
--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -4,7 +4,7 @@ import { Cas2Application as Application, Cas2ApplicationSummary } from '../../..
 
 export default class ListPage extends Page {
   constructor(private readonly inProgressApplications: Array<Cas2ApplicationSummary>) {
-    super('Applications')
+    super('Short-Term Accommodation (CAS-2) applications')
   }
 
   static visit(inProgressApplications: Array<Cas2ApplicationSummary>): ListPage {

--- a/server/@types/shared/models/Cas2ApplicationSummary.ts
+++ b/server/@types/shared/models/Cas2ApplicationSummary.ts
@@ -3,11 +3,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { ApplicationStatus } from './ApplicationStatus';
 import type { ApplicationSummary } from './ApplicationSummary';
 import type { PersonRisks } from './PersonRisks';
 
 export type Cas2ApplicationSummary = (ApplicationSummary & {
     createdByUserId: string;
+    status: ApplicationStatus;
     risks?: PersonRisks;
 });
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -99,3 +99,7 @@ export interface RadioItem {
     html?: string
   }
 }
+
+export interface GroupedApplications {
+  inProgress: Array<ApplicationSummary>
+}

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -24,9 +24,9 @@ describe('applicationsController', () => {
 
   let applicationsController: ApplicationsController
 
-  const applications = applicationFactory.buildList(3)
+  const applications = { inProgress: applicationFactory.buildList(3) }
 
-  applicationService.getAllApplications.mockResolvedValue(applications)
+  applicationService.getAllForLoggedInUser.mockResolvedValue(applications)
 
   beforeEach(() => {
     applicationsController = new ApplicationsController(personService, applicationService)

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -13,7 +13,7 @@ export default class ApplicationsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const applications = await this.applicationService.getAllApplications(req.user.token)
+      const applications = await this.applicationService.getAllForLoggedInUser(req.user.token)
 
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,4 @@
-import { Cas2Application as Application, UpdateApplication } from '@approved-premises/api'
+import { Cas2Application as Application, Cas2ApplicationSummary, UpdateApplication } from '@approved-premises/api'
 import { UpdateCas2Application } from '../@types/shared/models/UpdateCas2Application'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -24,7 +24,7 @@ export default class ApplicationClient {
     })) as Application
   }
 
-  async all(): Promise<Array<Application>> {
+  async all(): Promise<Array<Cas2ApplicationSummary>> {
     return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Application>
   }
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express'
 import { Cas2Application as Application } from '@approved-premises/api'
-import type { DataServices } from '@approved-premises/ui'
+import type { DataServices, GroupedApplications } from '@approved-premises/ui'
 import { getBody, getPageName, getTaskName } from '../form-pages/utils'
 import type { ApplicationClient, RestClientBuilder } from '../data'
 import { getApplicationUpdateData } from '../utils/applications/getApplicationData'
@@ -26,12 +26,22 @@ export default class ApplicationService {
     return application
   }
 
-  async getAllApplications(token: string): Promise<Array<Application>> {
+  async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {
     const applicationClient = this.applicationClientFactory(token)
 
     const allApplications = await applicationClient.all()
 
-    return allApplications
+    const result = {
+      inProgress: [],
+    } as GroupedApplications
+
+    allApplications.map(async application => {
+      if (application.status === 'inProgress') {
+        result.inProgress.push(application)
+      }
+    })
+
+    return result
   }
 
   async save(page: TaskListPage, request: Request) {

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -5,9 +5,11 @@ describe('dashboardTableRows', () => {
   it('returns an array of applications as table rows', async () => {
     const applicationA = applicationFactory.build({
       person: { name: 'A' },
+      createdAt: '2022-11-10T21:47:28Z',
     })
     const applicationB = applicationFactory.build({
       person: { name: 'B' },
+      createdAt: '2022-11-11T21:47:28Z',
     })
 
     const result = dashboardTableRows([applicationA, applicationB])
@@ -20,6 +22,9 @@ describe('dashboardTableRows', () => {
         {
           text: applicationA.person.crn,
         },
+        {
+          text: '10 November 2022',
+        },
       ],
       [
         {
@@ -27,6 +32,9 @@ describe('dashboardTableRows', () => {
         },
         {
           text: applicationB.person.crn,
+        },
+        {
+          text: '11 November 2022',
         },
       ],
     ])

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,10 +1,15 @@
 import type { Cas2Application as Application } from '@approved-premises/api'
 import type { TableRow } from '@approved-premises/ui'
 import paths from '../paths/apply'
+import { DateFormats } from './dateUtils'
 
 export const dashboardTableRows = (applications: Array<Application>): Array<TableRow> => {
   return applications.map(application => {
-    return [nameAnchorElement(application.person.name, application.id), textValue(application.person.crn)]
+    return [
+      nameAnchorElement(application.person.name, application.id),
+      textValue(application.person.crn),
+      textValue(DateFormats.isoDateToUIDate(application.createdAt, { format: 'medium' })),
+    ]
   })
 }
 const htmlValue = (value: string) => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
-import { differenceInDays, formatDistanceStrict, getUnixTime, formatISO, parseISO, format, isPast } from 'date-fns'
+import { differenceInDays, formatDistanceStrict, formatISO, parseISO, format } from 'date-fns'
 
 type DifferenceInDays = { ui: string; number: number }
 export class DateFormats {
@@ -25,10 +25,14 @@ export class DateFormats {
    * @param date JS Date object.
    * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
    */
-  static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {
+  static dateObjtoUIDate(date: Date, options: { format: 'short' | 'medium' | 'long' } = { format: 'long' }) {
     if (options.format === 'long') {
       return format(date, 'cccc d MMMM y')
-    } else {
+    } 
+    if (options.format === 'medium') {
+      return format(date, 'd MMMM y')
+    }
+    else {
       return format(date, 'dd/LL/y')
     }
   }
@@ -53,7 +57,7 @@ export class DateFormats {
    * @param isoDate an ISO date string.
    * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
    */
-  static isoDateToUIDate(isoDate: string, options: { format: 'short' | 'long' } = { format: 'long' }) {
+  static isoDateToUIDate(isoDate: string, options: { format: 'short' | 'long' | 'medium' } = { format: 'long' }) {
     return DateFormats.dateObjtoUIDate(DateFormats.isoToDateObj(isoDate), options)
   }
 

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro applicationsTable(title, rows) %}
+  {% if rows %}
+    {{
+        govukTable({
+          caption: title,
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Person"
+            },
+            {
+              text: "Case reference number (CRN)"
+            },
+            {
+              text: "Date started"
+            }
+          ],
+          rows: rows
+        })
+      }}
+  {% endif %}
+{% endmacro %}

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -1,9 +1,11 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "./_table.njk" import applicationsTable %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -14,35 +16,22 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Applications</h1>
+      <h1 class="govuk-heading-l">Short-Term Accommodation (CAS-2) applications</h1>
 
-      {% if applications.length %}
+      {{ govukTabs({
+        items: [
+          {
+            label: "In progress",
+            id: "applications",
+            panel: {
+              html: applicationsTable("In progress", dashboardTableRows(applications.inProgress))
+              }
+          }
+        ]
+        })
+      }}
 
-        <h2>Current applications</h2>
-            {{
-              govukTable({
-                  caption: title,
-                  captionClasses: "govuk-table__caption--m",
-                  firstCellIsHeader: true,
-                  head: [
-                    {
-                      text: "Person"
-                    },
-                    {
-                      text: "CRN"
-                    }
-                  ],
-                  rows: dashboardTableRows(applications)
-                })
-            }}
-      
-      {% endif %}
-
-        <h2 class="govuk-heading-m">Start a new application</h2>
-
-        <p>Start a new application for a Short-Term Accommodation placement by clicking on the start button below.</p>
-      
-        <a class="govuk-button" href="{{ paths.applications.new() }}">Start a new application</a>
+      <a class="govuk-button" href="{{ paths.applications.new() }}">Start a new application</a>
     </div>
   </div>
 


### PR DESCRIPTION
we would like to be able to render applications a user has
created, and indicate the ones that are still in progress.

The API work [to add status to an application summary has been merged.](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/840)
This PR:
* updates the API type to reflect status
* updated the applicationService to add logic (taken from CAS1/3) to group applications by statys
* adds the `govUkTabs` component to the applications dashboard page
* copy tweaks [based on content design](https://trello.com/c/5p2Qf1G2/427-multiple-applications-start-new-application) (note that having copy in the tabs when no applications are there is a bit of complexity that I've said we will shelve for now)

## before

![Screenshot 2023-07-28 at 16 15 23](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/895e99f2-58b0-47ef-b763-6edf228c0e4a)


## after

![Screenshot 2023-07-28 at 16 13 08](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/f543b2b6-1de9-4000-a3bb-8f246e8d8ffd)

![Screenshot 2023-07-28 at 16 12 50](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/1556a4ea-98c7-4d97-8f81-cc112be3652c)



