### PR TITLE
[315] Confirm eligibility before you start

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -1,4 +1,9 @@
 {
+  "confirm-eligibility": {
+    "confirm-eligibility": {
+      "isEligible": "yes"
+    }
+  },
   "funding-information": {
     "funding-source": {
       "fundingSource": "benefits"

--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -12,7 +12,7 @@ export default class ApplyPage extends Page {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const Class = Apply.pages[taskName][pageName] as any
-    this.taskListPage = new Class(application.data?.[taskName]?.[pageName], application)
+    this.taskListPage = new Class(!!application.data?.[taskName]?.[pageName], application)
 
     // if (backLink) {
     //   this.checkForBackButton(backLink)

--- a/integration_tests/pages/apply/confirmEligibilityPage.ts
+++ b/integration_tests/pages/apply/confirmEligibilityPage.ts
@@ -1,0 +1,13 @@
+import { Cas2Application as Application } from '../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from './applyPage'
+
+export default class ConfirmEligibilityPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Is ${application.person.name} eligible for Short-Term Accommodation (CAS-2)`,
+      application,
+      'confirm-eligibility',
+      'confirm-eligibility',
+    )
+  }
+}

--- a/integration_tests/pages/apply/confirmEligibilityPage.ts
+++ b/integration_tests/pages/apply/confirmEligibilityPage.ts
@@ -10,4 +10,26 @@ export default class ConfirmEligibilityPage extends ApplyPage {
       'confirm-eligibility',
     )
   }
+
+  hasCaption = (): void => {
+    cy.get('p').contains(
+      `Check ${this.application.person.name} meets the requirements for Short-Term Accommodation (CAS-2)`,
+    )
+  }
+
+  hasQuestionsAndAnswers = (): void => {
+    cy.get('label').contains(`Yes, I confirm ${this.application.person.name} is eligible`)
+    cy.get('label').contains(`No, ${this.application.person.name} is not eligible`)
+  }
+
+  hasGuidance = (): void => {
+    cy.get('.govuk-inset-text').within(() => {
+      cy.get('p').contains('The applicant must:')
+      cy.get('li').contains('be 18 years old or older')
+    })
+  }
+
+  chooseYesOption = (): void => {
+    this.checkRadioByNameAndValue('isEligible', 'yes')
+  }
 }

--- a/integration_tests/pages/apply/disabilityPage.ts
+++ b/integration_tests/pages/apply/disabilityPage.ts
@@ -12,7 +12,7 @@ export default class DisabilityPage extends ApplyPage {
   }
 
   enterOtherDisabilityType(): void {
-    this.checkRadioButtonFromPageBody('hasDisability')
+    this.checkRadioByNameAndValue('hasDisability', 'yes')
     this.checkCheckboxByLabel('other')
     this.getTextInputByIdAndEnterDetails('otherDisability', 'a different disability')
   }

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -23,4 +23,14 @@ export default class TaskListPage extends Page {
   shouldShowTaskStatus = (task: string, status: string): void => {
     cy.get(`#${task}-status`).should('contain', status)
   }
+
+  shouldShowTaskWithinSection = (taskTitle: string, sectionTitle: string): void => {
+    cy.get(`[data-section_name="${sectionTitle}"]`).within(() => {
+      // And I see the expected SECTION title
+      cy.get('.app-task-list__section').contains(sectionTitle)
+
+      // And I see each expected TASK title
+      cy.get('.app-task-list__task-name').contains(taskTitle)
+    })
+  }
 }

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_disability_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_disability_page.cy.ts
@@ -23,36 +23,21 @@ context('Visit "About the person" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['equality-and-diversity-monitoring'] = { 'will-answer-equality-questions': {}, disability: {} }
       const application = applicationFactory.build({
+        id: 'abc123',
         person,
+        data: applicationData,
       })
-      application.data = applicationData
       cy.wrap(application).as('application')
-      cy.wrap(application.data).as('applicationData')
     })
   })
 
   beforeEach(function test() {
     // And an application exists
     // -------------------------
-    const application = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: 'yes' },
-        },
-        'funding-information': {
-          'funding-source': {},
-        },
-        'equality-and-diversity-monitoring': {
-          'will-answer-equality-questions': {},
-          disability: {},
-        },
-      },
-      person,
-    })
-    cy.task('stubApplicationGet', { application })
-    cy.task('stubApplicationUpdate', { application })
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
 
     // Given I am logged in
     //---------------------

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_disability_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_disability_page.cy.ts
@@ -38,6 +38,9 @@ context('Visit "About the person" section', () => {
     const application = applicationFactory.build({
       id: 'abc123',
       data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
         'funding-information': {
           'funding-source': {},
         },

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_equality_questions_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_equality_questions_page.cy.ts
@@ -46,20 +46,23 @@ context('Visit "About the person" section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    cy.fixture('applicationData.json').then(applicationData => {
-      const application = applicationFactory.build({
-        id: 'abc123',
-        data: {
-          'funding-information': {
-            'funding-source': { fundingSource: 'personalSavings' },
-          },
+    const application = applicationFactory.build({
+      id: 'abc123',
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
         },
-        person,
-      })
-      application.data = applicationData
-      cy.wrap(application).as('application')
-      cy.wrap(application.data).as('applicationData')
+        'funding-information': {
+          'funding-source': { fundingSource: 'personalSavings' },
+        },
+        'equality-and-diversity-monitoring': {
+          'will-answer-equality-questions': {},
+          disability: {},
+        },
+      },
+      person,
     })
+    cy.wrap(application).as('application')
   })
 
   beforeEach(function test() {
@@ -68,6 +71,9 @@ context('Visit "About the person" section', () => {
     const newApplication = applicationFactory.build({
       id: 'abc123',
       data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
         'funding-information': {
           'funding-source': { fundingSource: 'personalSavings' },
         },
@@ -152,15 +158,19 @@ context('Visit "About the person" section', () => {
     cy.get('a').contains('Complete equality and diversity monitoring').click()
     const page = Page.verifyOnPage(WillAnswerEqualityQuestionsPage, this.application)
 
-    // When I select 'yes' and continue
-    page.checkRadioButtonFromPageBody('willAnswer')
+    // When I select the 'Yes' option and click save and continue
+    page.checkRadioByNameAndValue('willAnswer', 'yes')
 
     // after submission of the valid form the API will return the answered question
     // -- note that the presence of the _page_ only is required in application.data
-    //    to signify that the page is complete
+    //    to signify that the page is complete,
+    //    apart from the eligibility question which must be answered
     const answered = {
       ...this.application,
       data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
         'funding-information': {
           'funding-source': {},
         },

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_equality_questions_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_equality_questions_page.cy.ts
@@ -46,42 +46,22 @@ context('Visit "About the person" section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    const application = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: 'yes' },
-        },
-        'funding-information': {
-          'funding-source': { fundingSource: 'personalSavings' },
-        },
-        'equality-and-diversity-monitoring': {
-          'will-answer-equality-questions': {},
-          disability: {},
-        },
-      },
-      person,
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['equality-and-diversity-monitoring'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
     })
-    cy.wrap(application).as('application')
   })
 
   beforeEach(function test() {
     // And an application exists
     // -------------------------
-    const newApplication = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: 'yes' },
-        },
-        'funding-information': {
-          'funding-source': { fundingSource: 'personalSavings' },
-        },
-      },
-      person,
-    })
-    cy.task('stubApplicationGet', { application: newApplication })
-    cy.task('stubApplicationUpdate', { application: newApplication })
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
 
     // Given I am logged in
     //---------------------

--- a/integration_tests/tests/apply/area_and_funding/funding_information/complete_area_and_funding_section.cy.ts
+++ b/integration_tests/tests/apply/area_and_funding/funding_information/complete_area_and_funding_section.cy.ts
@@ -46,18 +46,33 @@ context('Visit area and funding section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    cy.fixture('applicationData.json').then(applicationData => {
-      const application = applicationFactory.build({ id: 'abc123', person })
-      application.data = applicationData
-      cy.wrap(application).as('application')
-      cy.wrap(application.data).as('applicationData')
+    const application = applicationFactory.build({
+      id: 'abc123',
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
+        'funding-information': {
+          'funding-source': {},
+        },
+      },
+      person,
     })
+    cy.wrap(application).as('application')
   })
 
   beforeEach(function test() {
     // And an application exists
     // -------------------------
-    const newApplication = applicationFactory.build({ id: 'abc123', person })
+    const newApplication = applicationFactory.build({
+      id: 'abc123',
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
+      },
+      person,
+    })
     cy.task('stubApplicationGet', { application: newApplication })
     cy.task('stubApplicationUpdate', { application: newApplication })
 
@@ -137,14 +152,18 @@ context('Visit area and funding section', () => {
     const page = Page.verifyOnPage(FundingSourcePage, this.application)
 
     // When I select an option and click save and continue
-    page.checkRadioButtonFromPageBody('fundingSource')
+    page.checkRadioByNameAndValue('fundingSource', 'personalSavings')
 
     // after submission of the valid form the API will return the answered question
     // -- note that the presence of the _page_ only is required in application.data
-    //    to signify that the page is complete
+    //    to signify that the page is complete,
+    //    apart from the eligibility question which must be answered
     const answered = {
       ...this.application,
       data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
         'funding-information': {
           'funding-source': {},
         },

--- a/integration_tests/tests/apply/area_and_funding/funding_information/complete_area_and_funding_section.cy.ts
+++ b/integration_tests/tests/apply/area_and_funding/funding_information/complete_area_and_funding_section.cy.ts
@@ -46,35 +46,22 @@ context('Visit area and funding section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    const application = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: 'yes' },
-        },
-        'funding-information': {
-          'funding-source': {},
-        },
-      },
-      person,
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['funding-information'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
     })
-    cy.wrap(application).as('application')
   })
 
   beforeEach(function test() {
     // And an application exists
     // -------------------------
-    const newApplication = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: 'yes' },
-        },
-      },
-      person,
-    })
-    cy.task('stubApplicationGet', { application: newApplication })
-    cy.task('stubApplicationUpdate', { application: newApplication })
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
 
     // Given I am logged in
     //---------------------

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Confirm eligibility' task
+//    So that I can complete the 'Confirm eligibility' task
+//    As a referrer
+//    I want to answer questions within that task
+//
+//  Scenario: Follows link from task list
+//    Given there is a section with a task
+//    And an application exists
+//    And I am logged in
+//    And I am viewing the application task list
+//
+//  Scenario: view task within task list
+//    Then I see that the task has not been started
+
+import Page from '../../../../pages/page'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "About the person" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({
+        id: 'abc123',
+        data: {
+          'funding-information': {
+            'funding-source': { fundingSource: 'personalSavings' },
+          },
+        },
+        person,
+      })
+      application.data = applicationData
+      cy.wrap(application).as('application')
+      cy.wrap(application.data).as('applicationData')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    const newApplication = applicationFactory.build({
+      id: 'abc123',
+      data: {
+        'funding-information': {
+          'funding-source': { fundingSource: 'personalSavings' },
+        },
+      },
+      person,
+    })
+    cy.task('stubApplicationGet', { application: newApplication })
+    cy.task('stubApplicationUpdate', { application: newApplication })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am viewing the application
+    // --------------------------------
+    cy.visit('applications/abc123')
+    Page.verifyOnPage(TaskListPage)
+  })
+
+  // Scenario: view task within task list
+  // ------------------------------------
+  it('shows the task listed within the section', () => {
+    // I see that the task has not been started
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Not started')
+    taskListPage.shouldShowTaskWithinSection('Check eligibility for CAS-2', 'Before you start')
+  })
+})

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -28,22 +28,16 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    const application = applicationFactory.build({
-      id: 'abc123',
-      data: {
-        foo: 'bar',
-        'confirm-eligibility': {
-          'confirm-eligibility': { isEligible: null },
-        },
-        'funding-information': {
-          'funding-source': { fundingSource: 'personalSavings' },
-        },
-      },
-      person,
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['confirm-eligibility'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
     })
     cy.task('stubFindPerson', { person })
-
-    cy.wrap(application).as('application')
   })
 
   beforeEach(function test() {

--- a/integration_tests/tests/apply/view_task_list.cy.ts
+++ b/integration_tests/tests/apply/view_task_list.cy.ts
@@ -6,6 +6,7 @@
 //  Scenario: view list of tasks
 //    Given I am logged in
 //    And an application exists
+//    And the 'Before you start' tasks are complete
 //    When I visit the task list page
 //    Then I see the task listed by section
 
@@ -14,7 +15,14 @@ import Page from '../../pages/page'
 import TaskListPage from '../../pages/apply/taskListPage'
 
 context('Visit task list', () => {
-  const application = applicationFactory.build({ id: 'abc123' })
+  const application = applicationFactory.build({
+    id: 'abc123',
+    data: {
+      'confirm-eligibility': {
+        'confirm-eligibility': { isEligible: 'yes' },
+      },
+    },
+  })
 
   beforeEach(function test() {
     cy.task('reset')

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -12,7 +12,9 @@ export type FormSection = {
 }
 
 export type FormSections = Array<FormSection>
-export type TaskNames = 'funding-information' | 'equality-and-diversity-monitoring'
+
+export type TaskNames = 'funding-information' | 'confirm-eligibility' | 'equality-and-diversity-monitoring'
+
 export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 
 export type TaskStatus = 'not_started' | 'in_progress' | 'complete' | 'cannot_start'

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -55,20 +55,50 @@ describe('applicationsController', () => {
   })
 
   describe('show', () => {
-    it('renders the task list view', async () => {
-      const application = applicationFactory.build()
-      const stubTaskList = jest.fn()
-      applicationService.findApplication.mockResolvedValue(application)
-      ;(TaskListService as jest.Mock).mockImplementation(() => {
-        return stubTaskList
+    describe('when "Confirm eligibility" task ("Before you start" section) is complete', () => {
+      it('renders the task list view', async () => {
+        const application = applicationFactory.build({
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'yes' },
+            },
+          },
+        })
+        const stubTaskList = jest.fn()
+        applicationService.findApplication.mockResolvedValue(application)
+        ;(TaskListService as jest.Mock).mockImplementation(() => {
+          return stubTaskList
+        })
+
+        const requestHandler = applicationsController.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/taskList', {
+          application,
+          taskList: stubTaskList,
+        })
       })
+    })
 
-      const requestHandler = applicationsController.show()
-      await requestHandler(request, response, next)
+    describe('when "Confirm eligibility" task is NOT complete', () => {
+      it('renders "Confirm eligibility" page from the "Before you start" section', async () => {
+        const application = applicationFactory.build({ data: {} })
+        const stubTaskList = jest.fn()
+        applicationService.findApplication.mockResolvedValue(application)
+        ;(TaskListService as jest.Mock).mockImplementation(() => {
+          return stubTaskList
+        })
 
-      expect(response.render).toHaveBeenCalledWith('applications/taskList', {
-        application,
-        taskList: stubTaskList,
+        const requestHandler = applicationsController.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          paths.applications.pages.show({
+            id: application.id,
+            task: 'confirm-eligibility',
+            page: 'confirm-eligibility',
+          }),
+        )
       })
     })
   })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -2,6 +2,7 @@ import { Request, RequestHandler, Response } from 'express'
 import PersonService from '../../services/personService'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationService from '../../services/applicationService'
+import { eligibilityQuestionIsAnswered, firstPageOfBeforeYouStartSection } from '../../utils/applications/utils'
 import TaskListService from '../../services/taskListService'
 import paths from '../../paths/apply'
 
@@ -30,9 +31,13 @@ export default class ApplicationsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
-      const taskList = new TaskListService(application)
 
-      return res.render('applications/taskList', { application, taskList })
+      if (eligibilityQuestionIsAnswered(application)) {
+        const taskList = new TaskListService(application)
+        return res.render('applications/taskList', { application, taskList })
+      }
+
+      return res.redirect(firstPageOfBeforeYouStartSection(application))
     }
   }
 

--- a/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.test.ts
+++ b/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.test.ts
@@ -1,0 +1,73 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import ConfirmEligibility from './confirmEligibility'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+
+describe('ConfirmEligibility', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('question', () => {
+    it('personalises the question', () => {
+      const page = new ConfirmEligibility({ isEligible: 'yes' }, application)
+
+      expect(page.questions).toEqual({
+        isEligible: 'Is Roger Smith eligible for Short-Term Accommodation (CAS-2)?',
+      })
+    })
+  })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new ConfirmEligibility({ isEligible: 'yes' }, application)
+
+      expect(page.title).toEqual('Check Roger Smith is eligible for Short-Term Accommodation (CAS-2)')
+    })
+  })
+
+  itShouldHaveNextValue(new ConfirmEligibility({ isEligible: 'yes' }, application), '')
+  itShouldHavePreviousValue(new ConfirmEligibility({ isEligible: 'yes' }, application), 'taskList')
+
+  describe('response', () => {
+    it('Adds selected option to page response in _translated_ form', () => {
+      const page = new ConfirmEligibility({ isEligible: 'yes' }, application)
+
+      expect(page.response()).toEqual({
+        'Is Roger Smith eligible for Short-Term Accommodation (CAS-2)?': 'Yes, I can confirm Roger Smith is eligible',
+      })
+    })
+
+    it('Deletes fields where there is not an answer', () => {
+      const page = new ConfirmEligibility({ isEligible: undefined }, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new ConfirmEligibility({ isEligible: 'yes' }, application)
+
+      expect(page.items()).toEqual([
+        {
+          value: 'yes',
+          text: 'Yes, I can confirm Roger Smith is eligible',
+          checked: true,
+        },
+        {
+          value: 'no',
+          text: 'No, Roger Smith is not eligible',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when yes/no questions are blank', () => {
+      const page = new ConfirmEligibility({}, application)
+
+      expect(page.errors()).toEqual({
+        isEligible: 'Choose either Yes or No',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.test.ts
+++ b/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.test.ts
@@ -31,7 +31,7 @@ describe('ConfirmEligibility', () => {
       const page = new ConfirmEligibility({ isEligible: 'yes' }, application)
 
       expect(page.response()).toEqual({
-        'Is Roger Smith eligible for Short-Term Accommodation (CAS-2)?': 'Yes, I can confirm Roger Smith is eligible',
+        'Is Roger Smith eligible for Short-Term Accommodation (CAS-2)?': 'Yes, I confirm Roger Smith is eligible',
       })
     })
 
@@ -49,12 +49,12 @@ describe('ConfirmEligibility', () => {
       expect(page.items()).toEqual([
         {
           value: 'yes',
-          text: 'Yes, I can confirm Roger Smith is eligible',
+          text: `Yes, I confirm ${application.person.name} is eligible`,
           checked: true,
         },
         {
           value: 'no',
-          text: 'No, Roger Smith is not eligible',
+          text: `No, ${application.person.name} is not eligible`,
           checked: false,
         },
       ])

--- a/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.ts
+++ b/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.ts
@@ -1,0 +1,63 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+
+type ConfirmEligibilityBody = {
+  isEligible: YesOrNo
+}
+
+export const options = {
+  yes: 'Yes, I can confirm Roger Smith is eligible',
+  no: 'No, Roger Smith is not eligible',
+}
+
+@Page({
+  name: 'confirm-eligibility',
+  bodyProperties: ['isEligible'],
+})
+export default class ConfirmEligibility implements TaskListPage {
+  title = `Check ${this.application.person.name} is eligible for Short-Term Accommodation (CAS-2)`
+
+  questions = {
+    isEligible: `Is ${this.application.person.name} eligible for Short-Term Accommodation (CAS-2)?`,
+  }
+
+  body: ConfirmEligibilityBody
+
+  constructor(
+    body: Partial<ConfirmEligibilityBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as ConfirmEligibilityBody
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.isEligible) {
+      errors.isEligible = 'Choose either Yes or No'
+    }
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.isEligible]: options[this.body.isEligible],
+    }
+
+    return response
+  }
+
+  items() {
+    return convertKeyValuePairToRadioItems(options, this.body.isEligible)
+  }
+}

--- a/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.ts
+++ b/server/form-pages/apply/before-you-start/confirm-eligibility/confirmEligibility.ts
@@ -7,12 +7,6 @@ import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 type ConfirmEligibilityBody = {
   isEligible: YesOrNo
 }
-
-export const options = {
-  yes: 'Yes, I can confirm Roger Smith is eligible',
-  no: 'No, Roger Smith is not eligible',
-}
-
 @Page({
   name: 'confirm-eligibility',
   bodyProperties: ['isEligible'],
@@ -22,6 +16,11 @@ export default class ConfirmEligibility implements TaskListPage {
 
   questions = {
     isEligible: `Is ${this.application.person.name} eligible for Short-Term Accommodation (CAS-2)?`,
+  }
+
+  options = {
+    yes: `Yes, I confirm ${this.application.person.name} is eligible`,
+    no: `No, ${this.application.person.name} is not eligible`,
   }
 
   body: ConfirmEligibilityBody
@@ -51,13 +50,13 @@ export default class ConfirmEligibility implements TaskListPage {
 
   response() {
     const response = {
-      [this.questions.isEligible]: options[this.body.isEligible],
+      [this.questions.isEligible]: this.options[this.body.isEligible],
     }
 
     return response
   }
 
   items() {
-    return convertKeyValuePairToRadioItems(options, this.body.isEligible)
+    return convertKeyValuePairToRadioItems(this.options, this.body.isEligible)
   }
 }

--- a/server/form-pages/apply/before-you-start/confirm-eligibility/index.ts
+++ b/server/form-pages/apply/before-you-start/confirm-eligibility/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+
+import { Task } from '../../../utils/decorators'
+import ConfirmEligibilityPage from './confirmEligibility'
+
+@Task({
+  name: 'Check eligibility for CAS-2',
+  slug: 'confirm-eligibility',
+  pages: [ConfirmEligibilityPage],
+})
+export default class ConfirmEligibility {}

--- a/server/form-pages/apply/before-you-start/index.ts
+++ b/server/form-pages/apply/before-you-start/index.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+
+import { Section } from '../../utils/decorators'
+import ConfirmEligibility from './confirm-eligibility'
+
+@Section({
+  title: 'Before you start',
+  tasks: [ConfirmEligibility],
+})
+export default class BeforeYouStart {}

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -1,7 +1,8 @@
 import { Form } from '../utils/decorators'
 import BaseForm from '../baseForm'
+import BeforeYouStart from './before-you-start'
 import AreaAndFunding from './area-and-funding'
 import AboutPerson from './about-the-person'
 
-@Form({ sections: [AreaAndFunding, AboutPerson] })
+@Form({ sections: [BeforeYouStart, AreaAndFunding, AboutPerson] })
 export default class Apply extends BaseForm {}

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -1,6 +1,18 @@
 import type { FormPages, JourneyType } from '@approved-premises/ui'
+import type { Cas2Application as Application } from '@approved-premises/api'
 import Apply from '../../form-pages/apply'
+import paths from '../../paths/apply'
 
 export const journeyPages = (_journeyType: JourneyType): FormPages => {
   return Apply.pages
+}
+
+export const firstPageOfBeforeYouStartSection = (application: Application) => {
+  return paths.applications.pages.show({ id: application.id, task: 'confirm-eligibility', page: 'confirm-eligibility' })
+}
+
+export const eligibilityQuestionIsAnswered = (application: Application): boolean => {
+  const eligibilityAnswer = application.data?.['confirm-eligibility']?.['confirm-eligibility']?.isEligible
+
+  return eligibilityAnswer === 'yes' || eligibilityAnswer === 'no'
 }

--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -1,0 +1,21 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</span>
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "isEligible",
+        fieldset: {
+          legend: {
+            text: page.questions.isEligible,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: page.items()
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}

--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -2,6 +2,35 @@
 {% block questions %}
   <h1 class="govuk-heading-l">{{ page.title }}</span>
 
+  <div class="govuk-inset-text">
+    <p class="govuk-body">Check {{ page.application.person.name }} meets the requirements for Short-Term Accommodation (CAS-2)</p>
+
+    <p class="govuk-body">The applicant must:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+      <li>
+        be 18 years old or older
+      </li>
+      <li>
+        not be currently serving a sentence of 4 years or more for any offence
+      </li>
+      <li>
+        not be currently charged with, or have any past convictions of cautions, or current allegations of any sexual offences in Schedule 3 of the Sexual Offences Act 2003
+      </li>
+      <li>
+        not be assessed as high or very high risk of serious harm
+      </li>
+      <li>
+        not have breached immigration law (other than over staying on approved period of leave to enter or remain in UK)
+      </li>
+      <li>
+        not have the ‘no recourse to public funds’ (NRPF) condition applied to their permission to enter or stay in the UK
+      </li>
+      <li>
+        if a Home Detention Curfew (HDC) applicant, not be currently in prison having been recalled for failing to comply with HDC licence conditions
+      </li>
+    </ul>
+  </div>
+
   {{
     formPageRadios(
       {


### PR DESCRIPTION
## Insert "Confirm eligibility" task in between "Find by CRN" and task list

In this PR we insert a task into the the applicant journey, in between "Find by CRN" and seeing the task list for the first time:

```
section: Before you start
 task: Check eligibility
   page: Check eligibility
```

### After "Find by CRN", before first sight of task list
![confirm_eligibility](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/cc390a23-c341-493e-aa4f-9d3dc49e1e0f)


### Redirected to task list after confirming eligibility
![before_you_start_on_tasklist](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/05657e2b-bdc7-42e3-ba99-832be51e93e6)

