### PR TITLE
Add 'Sex and gender identity' page to Equality and Diversity

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -15,6 +15,10 @@
     },
     "disability": {
       "hasDisability": "yes"
+    },
+    "sex-and-gender": {
+      "sex": "female",
+      "genderIdentity": "no"
     }
   }
 }

--- a/integration_tests/pages/apply/sexAndGenderPage.ts
+++ b/integration_tests/pages/apply/sexAndGenderPage.ts
@@ -1,0 +1,16 @@
+import { Cas2Application as Application } from '../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from './applyPage'
+
+export default class SexAndGenderPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super('Sex and gender identity', application, 'equality-and-diversity-monitoring', 'sex-and-gender')
+  }
+
+  selectSex(): void {
+    this.checkRadioByNameAndValue('sex', 'female')
+  }
+
+  confirmGenderIdentity(): void {
+    this.checkRadioByNameAndValue('gender', 'no')
+  }
+}

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_sex_gender_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_sex_gender_page.cy.ts
@@ -1,16 +1,16 @@
-//  Feature: Referrer completes disability question page
+//  Feature: Referrer completes 'Sex and Gender identity' question page
 //    So that I can complete the 'Equality questions' task
 //    As a referrer
-//    I want to answer questions on the disability page
+//    I want to answer questions on the sex and gender page
 //
-//  Scenario: submit 'other' disability type
-//    Given I'm on the 'Do they have a disability?' page
-//    When I submit an 'other' disability type
+//  Scenario: submit sex and gender itentity answers
+//    Given I'm on the 'Sex and gender identity' task page
+//    When I give valid answers to the 'Sex and gender identity' questions
 //    Then I return to the task list page
 //    And I see that the task has been completed
 
 import Page from '../../../../pages/page'
-import DisabilityPage from '../../../../pages/apply/disabilityPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
 import SexAndGenderPage from '../../../../pages/apply/sexAndGenderPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
@@ -23,19 +23,19 @@ context('Visit "About the person" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['equality-and-diversity-monitoring'] = { 'will-answer-equality-questions': {}, disability: {} }
+      applicationData['equality-and-diversity-monitoring']['sex-and-gender'] = {}
       const application = applicationFactory.build({
         id: 'abc123',
         person,
-        data: applicationData,
       })
+      application.data = applicationData
       cy.wrap(application).as('application')
+      cy.wrap(application.data).as('applicationData')
     })
   })
 
   beforeEach(function test() {
     // And an application exists
-    // -------------------------
     cy.task('stubApplicationGet', { application: this.application })
     cy.task('stubApplicationUpdate', { application: this.application })
 
@@ -43,22 +43,26 @@ context('Visit "About the person" section', () => {
     //---------------------
     cy.signIn()
 
-    // And I am on the disability question page
+    // And I am on the sex and gender question page
     // --------------------------------
-    cy.visit('applications/abc123/tasks/equality-and-diversity-monitoring/pages/disability')
-    Page.verifyOnPage(DisabilityPage, this.application)
+    cy.visit('applications/abc123/tasks/equality-and-diversity-monitoring/pages/sex-and-gender')
+    Page.verifyOnPage(SexAndGenderPage, this.application)
   })
 
-  // Scenario: submit 'other' disability type
+  // Scenario: submit 'female' as sex
   // ----------------------------
   it('continues to task list page', function test() {
-    // I submit an 'other' disability type
-    const page = Page.verifyOnPage(DisabilityPage, this.application)
-    page.enterOtherDisabilityType()
+    // I submit my answers
+    const page = Page.verifyOnPage(SexAndGenderPage, this.application)
+    page.selectSex()
+    page.confirmGenderIdentity()
 
     page.clickSubmit()
 
-    // I am taken to the 'sex and gender' page
-    Page.verifyOnPage(SexAndGenderPage, this.application)
+    // I return to the task list page
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+
+    // I see that the task has been completed
+    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
   })
 })

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
@@ -28,7 +28,7 @@ describe('Disability', () => {
     })
   })
 
-  itShouldHaveNextValue(new Disability({ hasDisability: 'yes' }, application), '')
+  itShouldHaveNextValue(new Disability({ hasDisability: 'yes' }, application), 'sex-and-gender')
   itShouldHavePreviousValue(new Disability({ hasDisability: 'yes' }, application), 'will-answer-equality-questions')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
@@ -56,7 +56,7 @@ export default class Disability implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'sex-and-gender'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
@@ -3,10 +3,11 @@
 import { Task } from '../../../utils/decorators'
 import WillAnswer from './willAnswer'
 import Disability from './disability'
+import SexAndGender from './sexAndGender'
 
 @Task({
   name: 'Complete equality and diversity monitoring',
   slug: 'equality-and-diversity-monitoring',
-  pages: [WillAnswer, Disability],
+  pages: [WillAnswer, Disability, SexAndGender],
 })
 export default class EqualityAndDiversityMonitoring {}

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.test.ts
@@ -1,0 +1,114 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import SexAndGender from './sexAndGender'
+
+describe('SexAndGender', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new SexAndGender({ sex: 'female' }, application)
+
+      expect(page.title).toEqual('Equality and diversity questions for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new SexAndGender({ sex: 'female' }, application), '')
+  itShouldHavePreviousValue(new SexAndGender({}, application), 'disability')
+
+  describe('response', () => {
+    it('Adds selected option to page response in _translated_ form', () => {
+      const page = new SexAndGender({ sex: 'female', gender: 'yes' }, application)
+
+      expect(page.response()).toEqual({
+        "What is Roger Smith's sex?": 'Female',
+        'Is the gender Roger Smith identifies with the same as the sex registered at birth?': 'Yes',
+      })
+    })
+
+    it('Adds optional gender data to page response in _translated_ form', () => {
+      const page = new SexAndGender({ sex: 'female', gender: 'no', optionalGenderIdentity: 'example' }, application)
+
+      expect(page.response()).toEqual({
+        "What is Roger Smith's sex?": 'Female',
+        'Is the gender Roger Smith identifies with the same as the sex registered at birth?': 'No',
+        'What is their gender identity? (optional)': 'example',
+      })
+    })
+
+    it('Deletes fields where there is not an answer', () => {
+      const page = new SexAndGender({ sex: undefined, gender: undefined }, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('sexItems', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new SexAndGender({ sex: 'female' }, application)
+
+      expect(page.sexItems()).toEqual([
+        {
+          value: 'female',
+          text: 'Female',
+          checked: true,
+        },
+        {
+          value: 'male',
+          text: 'Male',
+          checked: false,
+        },
+        {
+          value: 'preferNotToSay',
+          text: 'Prefer not to say',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('genderItems', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new SexAndGender({ gender: 'yes' }, application)
+      const optionalGenderIdentity = 'example'
+
+      expect(page.genderItems(optionalGenderIdentity)).toEqual([
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: true,
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: false,
+          conditional: {
+            html: 'example',
+          },
+        },
+        {
+          value: 'preferNotToSay',
+          text: 'Prefer not to say',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when the questions are blank', () => {
+      const page = new SexAndGender({}, application)
+
+      expect(page.errors()).toEqual({
+        sex: 'Choose either Female, Male or Prefer not to say',
+        gender: 'Choose either Yes, No or Prefer not to say',
+      })
+    })
+
+    it('should not return an error when the optional question is missing', () => {
+      const page = new SexAndGender({ sex: 'female', gender: 'no' }, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.ts
@@ -1,0 +1,92 @@
+import type { Radio, TaskListErrors, YesOrNoOrPreferNotToSay } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import errorLookups from '../../../../i18n/en/errors.json'
+
+type SexAndGenderBody = {
+  sex: 'female' | 'male' | 'preferNotToSay'
+  gender: YesOrNoOrPreferNotToSay
+  optionalGenderIdentity: string
+}
+
+export const sexOptions = {
+  female: 'Female',
+  male: 'Male',
+  preferNotToSay: 'Prefer not to say',
+}
+
+const genderOptions = {
+  yes: 'Yes',
+  no: 'No',
+  preferNotToSay: 'Prefer not to say',
+}
+
+@Page({
+  name: 'sex-and-gender',
+  bodyProperties: ['sex', 'gender', 'optionalGenderIdentity'],
+})
+export default class SexAndGender implements TaskListPage {
+  title = `Equality and diversity questions for ${this.application.person.name}`
+
+  heading = 'Sex and gender identity'
+
+  questions = {
+    sex: `What is ${this.application.person.name}'s sex?`,
+    gender: `Is the gender ${this.application.person.name} identifies with the same as the sex registered at birth?`,
+    optionalGenderIdentity: 'What is their gender identity? (optional)',
+  }
+
+  body: SexAndGenderBody
+
+  constructor(
+    body: Partial<SexAndGenderBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as SexAndGenderBody
+  }
+
+  previous() {
+    return 'disability'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.sex) {
+      errors.sex = errorLookups.sexAndGender.sex
+    }
+    if (!this.body.gender) {
+      errors.gender = errorLookups.sexAndGender.gender
+    }
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.sex]: sexOptions[this.body.sex],
+      [this.questions.gender]: genderOptions[this.body.gender],
+      [this.questions.optionalGenderIdentity]: this.body.optionalGenderIdentity,
+    }
+
+    return response
+  }
+
+  sexItems() {
+    return convertKeyValuePairToRadioItems(sexOptions, this.body.sex)
+  }
+
+  genderItems(optionalGenderIdentity: string) {
+    const radioItems = convertKeyValuePairToRadioItems(genderOptions, this.body.gender) as [Radio]
+    radioItems.forEach(item => {
+      if (item.value === 'no') {
+        item.conditional = { html: optionalGenderIdentity }
+      }
+    })
+    return radioItems
+  }
+}

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -9,5 +9,9 @@
     "empty": "Choose either Yes, No or Prefer not to say",
     "otherDisability": "Enter the other disability",
     "typeOfDisability": "Choose a disability type"
+  },
+  "sexAndGender": {
+    "sex": "Choose either Female, Male or Prefer not to say",
+    "gender": "Choose either Yes, No or Prefer not to say"
   }
 }

--- a/server/views/applications/pages/equality-and-diversity-monitoring/sex-and-gender.njk
+++ b/server/views/applications/pages/equality-and-diversity-monitoring/sex-and-gender.njk
@@ -1,0 +1,54 @@
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+
+{% extends "../layout.njk" %}
+{% block questions %}
+  <span class="govuk-caption-l">{{ page.title }}</span>
+  <h1 class="govuk-heading-l">{{ page.heading }}</h1>
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "sex",
+        fieldset: {
+          legend: {
+            text: page.questions.sex,
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: page.sexItems()
+      },
+      fetchContext()
+    )
+  }}
+
+  {% set optionalGenderIdentity %}
+    {{
+      formPageInput(
+        {
+          label: { text: page.questions.optionalGenderIdentity},
+          classes: "govuk-input--width-20",
+          fieldName: "optionalGenderIdentity"
+        },
+        fetchContext()
+      )
+    }}
+  {% endset -%}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "gender",
+        fieldset: {
+          legend: {
+            text: page.questions.gender,
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: page.genderItems(optionalGenderIdentity)
+      },
+      fetchContext()
+    )
+  }}
+{% endblock %}


### PR DESCRIPTION
Adding the 'Sex and gender identity' page to the end of the Equality and Diversity task
E2E PR is here https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e/pull/14 

<img width="744" alt="Screenshot 2023-08-03 at 13 16 47" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/f868c43f-47ad-4266-9f95-82f8635c6855">


<img width="751" alt="Screenshot 2023-08-03 at 13 16 32" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/113705ba-b502-4374-9578-3a4fb0bda9a7">
