### PR TITLE
Update playwright version to 1.36.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   e2e_environment_test:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.34.1-focal
+      - image: mcr.microsoft.com/playwright:v1.36.2-focal
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:


### PR DESCRIPTION
This updates the docker image used in CI to have the same version of playwright that we are using the E2E repo itself, updated in: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e/commit/8f265f26f3179ee832249aab83b9bee55db9955c