### PR TITLE
Add Sexual orientation page to Equality and Diversity task

### DIFF
--- a/doc/task_list_system.md
+++ b/doc/task_list_system.md
@@ -1,8 +1,13 @@
 # The CAS UI "task list" system
 
-The CAS1 team have developed code for developing a multi-stage questionnaire which is presented using the GOV.UK ["task list" pattern](https://design-system.service.gov.uk/patterns/task-list-pages/).
+The CAS1 team have developed code for developing a multi-stage questionnaire
+which is presented using the GOV.UK ["task list"
+pattern](https://design-system.service.gov.uk/patterns/task-list-pages/).
 
-Questions (and their answers) are the 'grain' of the system. They live within the following hierarchy:
+[Skip to the TLDR below if you want step-by-step instructions for adding one page](#tldr-adding-a-questionpage-to-an-existing-task)
+
+Questions (and their answers) are the 'grain' of the system. They live within
+the following hierarchy:
 
 ```
 sections
@@ -15,7 +20,9 @@ sections
 
 ### Form pages
 
-The clever plumbing for this system uses the [reflect-metadata](https://github.com/rbuckton/reflect-metadata) library to build a list of sections, tasks and pages for a given form. See the decorators:
+The clever plumbing for this system uses the
+[reflect-metadata](https://github.com/rbuckton/reflect-metadata) library to
+build a list of sections, tasks and pages for a given form. See the decorators:
 
 ```
 server/form-pages/
@@ -38,9 +45,11 @@ A present we only need one `JourneyType`:
 export type JourneyType = 'applications'
 ```
 
-but as is the case with the other CAS services, there may in time be a need for additional task lists.
+but as is the case with the other CAS services, there may in time be a need for
+additional task lists.
 
-A basic 'Apply' journey task list can be defined as below within an `apply` directory:
+A basic 'Apply' journey task list can be defined as below within an `apply`
+directory:
 
 ```
 server/form-pages/
@@ -78,7 +87,8 @@ The task list is defined in `apply.index.ts`, for example:
 
 #### more than one task in section
 
-An example 'Health needs' section with two tasks, e.g. at `apply/health-needs/index.ts`, could look like:
+An example 'Health needs' section with two tasks, e.g. at
+`apply/health-needs/index.ts`, could look like:
 
 ```ts
 @Section({
@@ -89,7 +99,9 @@ An example 'Health needs' section with two tasks, e.g. at `apply/health-needs/in
 
 ### Task
 
-Tasks should be defined in sub-directories e.g. `apply/health-needs/physical-health/index.ts` and may list multiple pages defined within the same directory, from which the overall task is comprised:
+Tasks should be defined in sub-directories e.g.
+`apply/health-needs/physical-health/index.ts` and may list multiple pages
+defined within the same directory, from which the overall task is comprised:
 
 ```ts
 @Task({
@@ -99,7 +111,8 @@ Tasks should be defined in sub-directories e.g. `apply/health-needs/physical-hea
 })
 ```
 
-NB: pages don't appear in the task list: only sections and their tasks are displayed.
+NB: pages don't appear in the task list: only sections and their tasks are
+displayed.
 
 Tasks are also declared in `server/@types/ui/index.d.ts`:
 
@@ -115,7 +128,9 @@ export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 
 This was an attempt to have strict typing on the task names, but it isn't [caught by typechecking at the moment](https://mojdt.slack.com/archives/C03K0HB0LBE/p1689685378372169?thread_ts=1689684800.189759&cid=C03K0HB0LBE), so in CAS1 not all task names are defined by the type.
 
-We also have a `GetTaskStatus` utility (`server/form-pages/utils/getTaskStatus.ts`) to indicate the status of a given task by examining the stored page data for that task.
+We also have a `GetTaskStatus` utility
+(`server/form-pages/utils/getTaskStatus.ts`) to indicate the status of a given
+task by examining the stored page data for that task.
 
 ### Page
 
@@ -139,16 +154,20 @@ With a constructor method to define the body of the question
 
 ```
 
-A `previous` and `next` function to determine where the user is taken after the questions has been answered
+A `previous` and `next` function to determine where the user is taken after the
+questions has been answered
 
-A `response` function that is called when the question is submitted, where logic can be added based on the answer given.
+A `response` function that is called when the question is submitted, where logic
+can be added based on the answer given.
 
-An `items` function that is called by the layout to transform the json of the `body` into the object shape needed by the form component.
+An `items` function that is called by the layout to transform the json of the
+`body` into the object shape needed by the form component.
 
 
 ### Form views
 
-Each 'form page' needs a corresponding Nunjucks view within the appropriate "journey" namespace:
+Each 'form page' needs a corresponding Nunjucks view within the appropriate
+"journey" namespace:
 
 ```
 server/views/{:journey}/pages/
@@ -158,11 +177,14 @@ e.g.
 server/views/applications/pages/health-needs/substance-misuse.njk
 ```
 
-These views need to be rendered by a `PagesController` (`server/controllers/apply/applications/pagesController.ts`), whose `show` action is passed a `taskName` and a `pageName`.
+These views need to be rendered by a `PagesController`
+(`server/controllers/apply/applications/pagesController.ts`), whose `show`
+action is passed a `taskName` and a `pageName`.
 
 ### Routing
 
-Our "apply" journey applies a routing pattern for pages as defined in `server/routes/apply.ts`:
+Our "apply" journey applies a routing pattern for pages as defined in
+`server/routes/apply.ts`:
 
 ```ts
 const { pattern } =
@@ -209,11 +231,14 @@ const paths = {
 
 ### View templates
 
-A number of utilities are added to the nunjucks setup (`server/utils/nunjucksSetup.ts`) including `TasklistUtils` and `mapApiPersonRisksForUi`
+A number of utilities are added to the nunjucks setup
+(`server/utils/nunjucksSetup.ts`) including `TasklistUtils` and
+`mapApiPersonRisksForUi`
 
 #### Form components
 
-Some enhanced GOV.UK form components are required and can be copied over from CAS1:
+Some enhanced GOV.UK form components are required and can be copied over from
+CAS1:
 
 ```
 server/views/components/formFields/form-page-checkboxes/
@@ -272,4 +297,46 @@ server/views/components/formFields/form-page-textarea/
 }}
 ```
 
-If I choose the 'yes' radio option to the 'substance misuse?' question, then a `substancesHistory` textarea input asking for more details is inserted into the form.
+If I choose the 'yes' radio option to the 'substance misuse?' question, then a
+`substancesHistory` textarea input asking for more details is inserted into the
+form.
+
+
+## TLDR: adding a question/page to an existing task
+
+* If this is NOT the first page in a task:
+  * Update the previous question page's `next` function, including the page’s
+    unit tests to return the string value of the page you are adding, eg
+    `sexual-orientation` 
+
+* Add integration test and class for your page (like the `sexAndGender.ts`, and
+  `complete_sex_gender_page.cy.ts`)
+    * Using the `applicationData.json` fixture
+        * add your answer data to the `applicationData.json` file. This json
+          file has all the data (sections/tasks/pages/answers) needed to have a
+          'complete' application
+        * If the page under test is the first page in a task - In your test,
+          edit the data for the task and assign it a blank object, in order to
+          remove the answers and thus have that task in the 'not started'
+          status. e.g. `applicationData['equality-and-diversity-monitoring'] =
+          {}`
+        * If the page is NOT the first page in a task - edit the data for the
+          task so that on your question data is blank, e.g.
+          `applicationData['equality-and-diversity-monitoring']['sex-and-gender']
+          = {}`
+    * You do not need to write integration tests for error messages/back button,
+      only the happy path(s)
+
+* Create your `Page` file, see
+  `server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.ts`
+  as an example
+    * The `response` function should return all of your response data
+    * Add error scenarios in, putting error copy into the shared `errorLookups.json`
+    * Add `next`/`previous` logic and tests
+
+* Add your page class to the `@Task` list of `pages`, e.g.
+  `server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts` 
+
+* Create nunjucks template, see
+  `server/views/applications/pages/equality-and-diversity-monitoring/disability.njk`
+  as an example

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -19,6 +19,9 @@
     "sex-and-gender": {
       "sex": "female",
       "genderIdentity": "no"
+    },
+    "sexual-orientation": {
+      "orientation": "gay"
     }
   }
 }

--- a/integration_tests/pages/apply/sexualOrientationPage.ts
+++ b/integration_tests/pages/apply/sexualOrientationPage.ts
@@ -1,0 +1,17 @@
+import { Cas2Application as Application } from '../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from './applyPage'
+
+export default class SexualOrientationPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Which of the following best describes ${application.person.name}'s sexual orientation?`,
+      application,
+      'equality-and-diversity-monitoring',
+      'sexual-orientation',
+    )
+  }
+
+  selectOrientation(): void {
+    this.checkRadioByNameAndValue('orientation', 'gay')
+  }
+}

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_sexual_orientation_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_sexual_orientation_page.cy.ts
@@ -1,16 +1,17 @@
-//  Feature: Referrer completes 'Sex and Gender identity' question page
+//  Feature: Referrer completes 'Sexual orientation' question page
 //    So that I can complete the 'Equality questions' task
 //    As a referrer
-//    I want to answer questions on the sex and gender page
+//    I want to answer questions on the sexual orientation page
 //
-//  Scenario: submit sex and gender itentity answers
-//    Given I'm on the 'Sex and gender identity' question page
-//    When I give valid answers to the 'Sex and gender identity' questions
-//    Then I am taken to the 'Sexual orientation' page
+//  Scenario: submit sexual orientation answers
+//    Given I'm on the 'Sexual orientation' question page
+//    When I give valid answers to the 'Sexual orientation' questions
+//    Then I return to the task list page
+//    And I see that the task has been completed
 
 import Page from '../../../../pages/page'
+import TaskListPage from '../../../../pages/apply/taskListPage'
 import SexualOrientationPage from '../../../../pages/apply/sexualOrientationPage'
-import SexAndGenderPage from '../../../../pages/apply/sexAndGenderPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -22,7 +23,7 @@ context('Visit "About the person" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['equality-and-diversity-monitoring']['sex-and-gender'] = {}
+      applicationData['equality-and-diversity-monitoring']['sexual-orientation'] = {}
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -42,23 +43,25 @@ context('Visit "About the person" section', () => {
     //---------------------
     cy.signIn()
 
-    // And I am on the sex and gender question page
+    // And I am on the sexual orientation page
     // --------------------------------
-    cy.visit('applications/abc123/tasks/equality-and-diversity-monitoring/pages/sex-and-gender')
-    Page.verifyOnPage(SexAndGenderPage, this.application)
+    cy.visit('applications/abc123/tasks/equality-and-diversity-monitoring/pages/sexual-orientation')
+    Page.verifyOnPage(SexualOrientationPage, this.application)
   })
 
-  // Scenario: submit sex and gender identity
+  // Scenario: select orientation
   // ----------------------------
   it('continues to task list page', function test() {
     // I submit my answers
-    const page = Page.verifyOnPage(SexAndGenderPage, this.application)
-    page.selectSex()
-    page.confirmGenderIdentity()
+    const page = Page.verifyOnPage(SexualOrientationPage, this.application)
+    page.selectOrientation()
 
     page.clickSubmit()
 
-    // I am taken to the 'sexual orientation' page
-    Page.verifyOnPage(SexualOrientationPage, this.application)
+    // I return to the task list page
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+
+    // I see that the task has been completed
+    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
   })
 })

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
@@ -4,10 +4,11 @@ import { Task } from '../../../utils/decorators'
 import WillAnswer from './willAnswer'
 import Disability from './disability'
 import SexAndGender from './sexAndGender'
+import SexualOrientation from './sexualOrientation'
 
 @Task({
   name: 'Complete equality and diversity monitoring',
   slug: 'equality-and-diversity-monitoring',
-  pages: [WillAnswer, Disability, SexAndGender],
+  pages: [WillAnswer, Disability, SexAndGender, SexualOrientation],
 })
 export default class EqualityAndDiversityMonitoring {}

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.test.ts
@@ -13,7 +13,7 @@ describe('SexAndGender', () => {
     })
   })
 
-  itShouldHaveNextValue(new SexAndGender({ sex: 'female' }, application), '')
+  itShouldHaveNextValue(new SexAndGender({ sex: 'female' }, application), 'sexual-orientation')
   itShouldHavePreviousValue(new SexAndGender({}, application), 'disability')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexAndGender.ts
@@ -52,7 +52,7 @@ export default class SexAndGender implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'sexual-orientation'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexualOrientation.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexualOrientation.test.ts
@@ -1,0 +1,102 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import SexualOrientation from './sexualOrientation'
+
+describe('SexualOrientation', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new SexualOrientation({}, application)
+
+      expect(page.title).toEqual('Equality and diversity questions for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new SexualOrientation({}, application), '')
+  itShouldHavePreviousValue(new SexualOrientation({}, application), 'sex-and-gender')
+
+  describe('response', () => {
+    it('Adds selected option to page response in _translated_ form', () => {
+      const page = new SexualOrientation({ orientation: 'gay' }, application)
+
+      expect(page.response()).toEqual({
+        "Which of the following best describes Roger Smith's sexual orientation?": 'Gay',
+        'How would they describe their sexual orientation? (optional)': undefined,
+      })
+    })
+
+    it('Adds optional gender data to page response in _translated_ form', () => {
+      const page = new SexualOrientation({ orientation: 'other', otherOrientation: 'example' }, application)
+
+      expect(page.response()).toEqual({
+        "Which of the following best describes Roger Smith's sexual orientation?": 'Other',
+        'How would they describe their sexual orientation? (optional)': 'example',
+      })
+    })
+
+    it('Deletes fields where there is not an answer', () => {
+      const page = new SexualOrientation({ orientation: undefined, otherOrientation: undefined }, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new SexualOrientation({ orientation: 'gay' }, application)
+      const conditional = 'example'
+      expect(page.items(conditional)).toEqual([
+        {
+          checked: false,
+          text: 'Heterosexual or straight',
+          value: 'heterosexual',
+        },
+        {
+          text: 'Gay',
+          value: 'gay',
+          checked: true,
+        },
+        {
+          text: 'Lesbian',
+          value: 'lesbian',
+          checked: false,
+        },
+        {
+          checked: false,
+          text: 'Bisexual',
+          value: 'bisexual',
+        },
+        {
+          checked: false,
+          conditional: {
+            html: 'example',
+          },
+          text: 'Other',
+          value: 'other',
+        },
+        {
+          value: 'preferNotToSay',
+          text: 'Prefer not to say',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when the questions are blank', () => {
+      const page = new SexualOrientation({}, application)
+
+      expect(page.errors()).toEqual({
+        orientation: 'Select an orientation, or choose Prefer not to say',
+      })
+    })
+
+    it('should not return an error when the optional question is missing', () => {
+      const page = new SexualOrientation({ orientation: 'other' }, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexualOrientation.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/sexualOrientation.ts
@@ -1,0 +1,78 @@
+import type { Radio, TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import errorLookups from '../../../../i18n/en/errors.json'
+
+type SexualOrientationBody = {
+  orientation: 'heterosexual' | 'gay' | 'lesbian' | 'bisexual' | 'other' | 'preferNotToSay'
+  otherOrientation: string
+}
+
+export const orientationOptions = {
+  heterosexual: 'Heterosexual or straight',
+  gay: 'Gay',
+  lesbian: 'Lesbian',
+  bisexual: 'Bisexual',
+  other: 'Other',
+  preferNotToSay: 'Prefer not to say',
+}
+
+@Page({
+  name: 'sexual-orientation',
+  bodyProperties: ['orientation', 'otherOrientation'],
+})
+export default class SexualOrientation implements TaskListPage {
+  title = `Equality and diversity questions for ${this.application.person.name}`
+
+  questions = {
+    orientation: `Which of the following best describes ${this.application.person.name}'s sexual orientation?`,
+    otherOrientation: 'How would they describe their sexual orientation? (optional)',
+  }
+
+  body: SexualOrientationBody
+
+  constructor(
+    body: Partial<SexualOrientationBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as SexualOrientationBody
+  }
+
+  previous() {
+    return 'sex-and-gender'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.orientation) {
+      errors.orientation = errorLookups.sexualOrientation.orientation
+    }
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.orientation]: orientationOptions[this.body.orientation],
+      [this.questions.otherOrientation]: this.body.otherOrientation,
+    }
+
+    return response
+  }
+
+  items(otherOrientationHtml: string) {
+    const items = convertKeyValuePairToRadioItems(orientationOptions, this.body.orientation) as [Radio]
+    items.forEach(item => {
+      if (item.value === 'other') {
+        item.conditional = { html: otherOrientationHtml }
+      }
+    })
+
+    return items
+  }
+}

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -13,5 +13,8 @@
   "sexAndGender": {
     "sex": "Choose either Female, Male or Prefer not to say",
     "gender": "Choose either Yes, No or Prefer not to say"
+  },
+  "sexualOrientation": {
+    "orientation": "Select an orientation, or choose Prefer not to say"
   }
 }

--- a/server/views/applications/pages/equality-and-diversity-monitoring/sexual-orientation.njk
+++ b/server/views/applications/pages/equality-and-diversity-monitoring/sexual-orientation.njk
@@ -1,0 +1,31 @@
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+
+{% extends "../layout.njk" %}
+{% block questions %}
+  <span class="govuk-caption-l">{{ page.title }}</span>
+  <h1 class="govuk-heading-l">{{ page.questions.orientation }}</h1>
+
+  {% set otherOrientation %}
+    {{
+      formPageInput(
+        {
+          label: { text: page.questions.otherOrientation},
+          classes: "govuk-input--width-20",
+          fieldName: "otherOrientation"
+        },
+        fetchContext()
+      )
+    }}
+  {% endset -%}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "orientation",
+        items: page.items(otherOrientation)
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}


### PR DESCRIPTION
This adds the sexual orientation page to the E&D task, following disability.
I've also added some bare bones instructions to follow when adding a page - I think we can update them as we go, but I found them helpful to follow so adding for future use!

<img width="855" alt="Screenshot 2023-08-03 at 15 21 47" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/6bfbc2a7-07f4-46b6-b0b1-8c33d5e6b20d">

<img width="704" alt="Screenshot 2023-08-03 at 15 21 13" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/d99a7a56-62e4-4d75-9b99-91f6ad804288">
