### PR TITLE
439 Show dead-end if person marked as ineligible

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -11,3 +11,8 @@ $govuk-page-width: $moj-page-width;
 @import './components/task-list';
 
 @import 'assets/scss/local';
+
+.govuk-panel--fail {
+  background-color: #d4351c;
+  color: #ffffff;
+}

--- a/integration_tests/pages/apply/confirmEligibilityPage.ts
+++ b/integration_tests/pages/apply/confirmEligibilityPage.ts
@@ -32,4 +32,8 @@ export default class ConfirmEligibilityPage extends ApplyPage {
   chooseYesOption = (): void => {
     this.checkRadioByNameAndValue('isEligible', 'yes')
   }
+
+  chooseNoOption = (): void => {
+    this.checkRadioByNameAndValue('isEligible', 'no')
+  }
 }

--- a/integration_tests/pages/apply/ineligiblePage.ts
+++ b/integration_tests/pages/apply/ineligiblePage.ts
@@ -1,0 +1,25 @@
+import { Cas2Application as Application } from '../../../server/@types/shared/models/Cas2Application'
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+
+export default class IneligiblePagePage extends Page {
+  constructor(private readonly application: Application) {
+    super(`${application.person.name} is not eligible for CAS-2 accommodation`)
+  }
+
+  hasGuidance(): void {
+    cy.contains('should refer them to the regional Commissioned Rehabilitative Services provider')
+  }
+
+  hasLinkToChangeAnswer(): void {
+    cy.contains('Change eligibility answer').should(
+      'have.attr',
+      'href',
+      paths.applications.pages.show({
+        id: this.application.id,
+        task: 'confirm-eligibility',
+        page: 'confirm-eligibility',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/ineligiblePage.ts
+++ b/integration_tests/pages/apply/ineligiblePage.ts
@@ -26,4 +26,8 @@ export default class IneligiblePagePage extends Page {
   chooseToChangeAnswer(): void {
     cy.get('a').contains('Change eligibility answer').click()
   }
+
+  startANewApplication(): void {
+    cy.get('a').contains('Search for a different applicant').click()
+  }
 }

--- a/integration_tests/pages/apply/ineligiblePage.ts
+++ b/integration_tests/pages/apply/ineligiblePage.ts
@@ -22,4 +22,8 @@ export default class IneligiblePagePage extends Page {
       }),
     )
   }
+
+  chooseToChangeAnswer(): void {
+    cy.get('a').contains('Change eligibility answer').click()
+  }
 }

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -151,4 +151,51 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
     // And I am provided with a way of changing the eligibility answer)
     ineligiblePage.hasLinkToChangeAnswer()
   })
+
+  //  Scenario: Changes eligibility answer: from NO to YES
+  //    Given I have confirmed that the person is not eligible
+  //    And I am on the 'person ineligible' page
+  //
+  //    When I choose to change my eligibility answer
+  //    I confirm that the person is eligible
+  //    And I continue to the next task
+  //    Then I see that the 'Confirm eligibility' task is complete
+  it('allows eligibility answer to be changed from NO to YES', function test() {
+    //  Given I have confirmed that the person is not eligible
+    const answered = {
+      ...this.application,
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'no' },
+        },
+      },
+    }
+    // And I am on the 'person ineligible' page
+    cy.task('stubApplicationGet', { application: answered })
+    cy.visit('applications/abc123')
+    const ineligiblePage = Page.verifyOnPage(IneligiblePage, this.application)
+
+    //  When I choose to change my eligibility answer
+    ineligiblePage.chooseToChangeAnswer()
+
+    //  I confirm that the person is eligible
+    const confirmEligibilityPage = new ConfirmEligibilityPage(this.application)
+    confirmEligibilityPage.chooseYesOption()
+
+    //  And I continue to the next task
+    const updated = {
+      ...this.application,
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'yes' },
+        },
+      },
+    }
+    cy.task('stubApplicationGet', { application: updated })
+    confirmEligibilityPage.clickSubmit()
+
+    // Then I see that the 'Confirm eligibility' task is complete
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Completed')
+  })
 })

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -198,4 +198,29 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
     const taskListPage = Page.verifyOnPage(TaskListPage)
     taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Completed')
   })
+
+  //  Scenario: Abandons ineligible application and starts new one
+  //    Given I have confirmed that the person is not eligible
+  //    And I am on the 'person ineligible' page
+  //
+  //    When I opt to start a new application
+  //    Then I should be able to 'Find by CRN'
+  it('allows ineligible application to be abandoned and a new one started', function test() {
+    //  Given I have confirmed that the person is not eligible
+    const answered = {
+      ...this.application,
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'no' },
+        },
+      },
+    }
+    // And I am on the 'person ineligible' page
+    cy.task('stubApplicationGet', { application: answered })
+    cy.visit('applications/abc123')
+    const ineligiblePage = Page.verifyOnPage(IneligiblePage, this.application)
+
+    // When I opt to start a new application
+    ineligiblePage.startANewApplication()
+  })
 })

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -41,6 +41,7 @@ import Page from '../../../../pages/page'
 import CRNPage from '../../../../pages/apply/crnPage'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import ConfirmEligibilityPage from '../../../../pages/apply/confirmEligibilityPage'
+import IneligiblePage from '../../../../pages/apply/ineligiblePage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Complete "Confirm eligibility" task in "Before you start" section', () => {
@@ -114,5 +115,40 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
 
     // And I see that the task is now complete
     taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Completed')
+  })
+
+  //  Scenario: Confirms that the person is NOT eligible for CAS-2
+  //    When I confirm that the person is NOT eligible
+  //    And I continue to the next task
+  //    Then I see that I have marked this person as ineligible
+  //    And I am on the 'person ineligible' page
+  //    And I am provided with a way of changing the eligibility answer
+  it('allows INELIGIBILITY to be confirmed', function test() {
+    const confirmEligibilityPage = new ConfirmEligibilityPage(this.application)
+
+    // When I select the 'NO' option and click save and continue
+    confirmEligibilityPage.chooseNoOption()
+
+    // after submission of the valid form the API will return the answered question
+    // -- note that it this case the value must be yes or no to indicate that the
+    //    'Confirm eligibility' task is complete
+    const answered = {
+      ...this.application,
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': { isEligible: 'no' },
+        },
+      },
+    }
+    cy.task('stubApplicationGet', { application: answered })
+
+    confirmEligibilityPage.clickSubmit()
+
+    // Then I see that I have marked this person as ineligible
+    // And I am on the 'person ineligible' page
+    const ineligiblePage = Page.verifyOnPage(IneligiblePage, this.application)
+    ineligiblePage.hasGuidance()
+    // And I am provided with a way of changing the eligibility answer)
+    ineligiblePage.hasLinkToChangeAnswer()
   })
 })

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -13,6 +13,29 @@
 //    When I confirm that the person is eligible
 //    And I continue to the next task
 //    Then I see that the 'Confirm eligibility' task is complete
+//
+//  Scenario: Confirms that the person is NOT eligible for CAS-2
+//    When I confirm that the person is NOT eligible
+//    And I continue to the next task
+//    Then I see that I have marked this person as ineligible
+//    And I am on the 'person ineligible' page
+//    And I am provided with a way of changing the eligibility answer
+//
+//  Scenario: Changes eligibility answer: from NO to YES
+//    Given I have confirmed that the person is not eligible
+//    And I am on the 'person ineligible' page
+//
+//    When I choose to change my eligibility answer
+//    I confirm that the person is eligible
+//    And I continue to the next task
+//    Then I see that the 'Confirm eligibility' task is complete
+//
+//  Scenario: Abandons ineligible application and starts new one
+//    Given I have confirmed that the person is not eligible
+//    And I am on the 'person ineligible' page
+//
+//    When I opt to start a new application
+//    Then I should be able to 'Find by CRN'
 
 import Page from '../../../../pages/page'
 import CRNPage from '../../../../pages/apply/crnPage'

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -56,26 +56,48 @@ describe('applicationsController', () => {
 
   describe('show', () => {
     describe('when "Confirm eligibility" task ("Before you start" section) is complete', () => {
-      it('renders the task list view', async () => {
-        const application = applicationFactory.build({
-          data: {
-            'confirm-eligibility': {
-              'confirm-eligibility': { isEligible: 'yes' },
+      describe('and the person is confirmed eligible', () => {
+        it('renders the task list view', async () => {
+          const application = applicationFactory.build({
+            data: {
+              'confirm-eligibility': {
+                'confirm-eligibility': { isEligible: 'yes' },
+              },
             },
-          },
-        })
-        const stubTaskList = jest.fn()
-        applicationService.findApplication.mockResolvedValue(application)
-        ;(TaskListService as jest.Mock).mockImplementation(() => {
-          return stubTaskList
-        })
+          })
+          const stubTaskList = jest.fn()
+          applicationService.findApplication.mockResolvedValue(application)
+          ;(TaskListService as jest.Mock).mockImplementation(() => {
+            return stubTaskList
+          })
 
-        const requestHandler = applicationsController.show()
-        await requestHandler(request, response, next)
+          const requestHandler = applicationsController.show()
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('applications/taskList', {
-          application,
-          taskList: stubTaskList,
+          expect(response.render).toHaveBeenCalledWith('applications/taskList', {
+            application,
+            taskList: stubTaskList,
+          })
+        })
+      })
+
+      describe('and the person is confirmed INELIGIBLE', () => {
+        it('renders the _ineligible_ page', async () => {
+          const application = applicationFactory.build({
+            data: {
+              'confirm-eligibility': {
+                'confirm-eligibility': { isEligible: 'no' },
+              },
+            },
+          })
+          applicationService.findApplication.mockResolvedValue(application)
+
+          const requestHandler = applicationsController.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith('applications/ineligible', {
+            application,
+          })
         })
       })
     })
@@ -83,11 +105,7 @@ describe('applicationsController', () => {
     describe('when "Confirm eligibility" task is NOT complete', () => {
       it('renders "Confirm eligibility" page from the "Before you start" section', async () => {
         const application = applicationFactory.build({ data: {} })
-        const stubTaskList = jest.fn()
         applicationService.findApplication.mockResolvedValue(application)
-        ;(TaskListService as jest.Mock).mockImplementation(() => {
-          return stubTaskList
-        })
 
         const requestHandler = applicationsController.show()
         await requestHandler(request, response, next)

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -98,6 +98,7 @@ describe('applicationsController', () => {
             task: 'confirm-eligibility',
             page: 'confirm-eligibility',
           })
+          const newApplicationPath = paths.applications.new({})
 
           applicationService.findApplication.mockResolvedValue(application)
 
@@ -108,6 +109,7 @@ describe('applicationsController', () => {
             application,
             panelText,
             changeAnswerPath,
+            newApplicationPath,
           })
         })
       })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -3,7 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { Cas2Application as Application } from '@approved-premises/api'
 import { ErrorsAndUserInput } from '@approved-premises/ui'
 
-import { applicationFactory } from '../../testutils/factories'
+import { applicationFactory, personFactory } from '../../testutils/factories'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationsController from './applicationsController'
 import { PersonService, ApplicationService, TaskListService } from '../../services'
@@ -84,12 +84,21 @@ describe('applicationsController', () => {
       describe('and the person is confirmed INELIGIBLE', () => {
         it('renders the _ineligible_ page', async () => {
           const application = applicationFactory.build({
+            person: personFactory.build({ name: 'Roger Smith' }),
             data: {
               'confirm-eligibility': {
                 'confirm-eligibility': { isEligible: 'no' },
               },
             },
           })
+
+          const panelText = `Roger Smith is not eligible for CAS-2 accommodation`
+          const changeAnswerPath = paths.applications.pages.show({
+            id: application.id,
+            task: 'confirm-eligibility',
+            page: 'confirm-eligibility',
+          })
+
           applicationService.findApplication.mockResolvedValue(application)
 
           const requestHandler = applicationsController.show()
@@ -97,6 +106,8 @@ describe('applicationsController', () => {
 
           expect(response.render).toHaveBeenCalledWith('applications/ineligible', {
             application,
+            panelText,
+            changeAnswerPath,
           })
         })
       })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -48,7 +48,9 @@ export default class ApplicationsController {
           task: 'confirm-eligibility',
           page: 'confirm-eligibility',
         })
-        return res.render('applications/ineligible', { application, panelText, changeAnswerPath })
+        const newApplicationPath = paths.applications.new({})
+
+        return res.render('applications/ineligible', { application, panelText, changeAnswerPath, newApplicationPath })
       }
 
       return res.redirect(firstPageOfBeforeYouStartSection(application))

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -2,7 +2,11 @@ import { Request, RequestHandler, Response } from 'express'
 import PersonService from '../../services/personService'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationService from '../../services/applicationService'
-import { eligibilityQuestionIsAnswered, firstPageOfBeforeYouStartSection } from '../../utils/applications/utils'
+import {
+  eligibilityIsDenied,
+  eligibilityIsConfirmed,
+  firstPageOfBeforeYouStartSection,
+} from '../../utils/applications/utils'
 import TaskListService from '../../services/taskListService'
 import paths from '../../paths/apply'
 
@@ -32,9 +36,13 @@ export default class ApplicationsController {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
 
-      if (eligibilityQuestionIsAnswered(application)) {
+      if (eligibilityIsConfirmed(application)) {
         const taskList = new TaskListService(application)
         return res.render('applications/taskList', { application, taskList })
+      }
+
+      if (eligibilityIsDenied(application)) {
+        return res.render('applications/ineligible', { application })
       }
 
       return res.redirect(firstPageOfBeforeYouStartSection(application))

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -1,4 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
+import { Cas2Application } from '@approved-premises/api'
 import PersonService from '../../services/personService'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationService from '../../services/applicationService'
@@ -42,19 +43,22 @@ export default class ApplicationsController {
       }
 
       if (eligibilityIsDenied(application)) {
-        const panelText = `${application.person.name} is not eligible for CAS-2 accommodation`
-        const changeAnswerPath = paths.applications.pages.show({
-          id: application.id,
-          task: 'confirm-eligibility',
-          page: 'confirm-eligibility',
-        })
-        const newApplicationPath = paths.applications.new({})
-
-        return res.render('applications/ineligible', { application, panelText, changeAnswerPath, newApplicationPath })
+        return res.render('applications/ineligible', this.ineligibleViewParams(application))
       }
 
       return res.redirect(firstPageOfBeforeYouStartSection(application))
     }
+  }
+
+  private ineligibleViewParams(application: Cas2Application): Record<string, string | Cas2Application> {
+    const panelText = `${application.person.name} is not eligible for CAS-2 accommodation`
+    const changeAnswerPath = paths.applications.pages.show({
+      id: application.id,
+      task: 'confirm-eligibility',
+      page: 'confirm-eligibility',
+    })
+    const newApplicationPath = paths.applications.new({})
+    return { application, panelText, changeAnswerPath, newApplicationPath }
   }
 
   create(): RequestHandler {

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -42,7 +42,13 @@ export default class ApplicationsController {
       }
 
       if (eligibilityIsDenied(application)) {
-        return res.render('applications/ineligible', { application })
+        const panelText = `${application.person.name} is not eligible for CAS-2 accommodation`
+        const changeAnswerPath = paths.applications.pages.show({
+          id: application.id,
+          task: 'confirm-eligibility',
+          page: 'confirm-eligibility',
+        })
+        return res.render('applications/ineligible', { application, panelText, changeAnswerPath })
       }
 
       return res.redirect(firstPageOfBeforeYouStartSection(application))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -1,0 +1,59 @@
+import { applicationFactory } from '../../testutils/factories'
+
+import { eligibilityQuestionIsAnswered } from './utils'
+
+describe('utils', () => {
+  describe('eligibilityQuestionIsAnswered', () => {
+    describe('when the isEligible property is _yes_', () => {
+      it('returns true', async () => {
+        const application = applicationFactory.build({
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'yes' },
+            },
+          },
+        })
+
+        expect(eligibilityQuestionIsAnswered(application)).toEqual(true)
+      })
+    })
+
+    describe('when the isEligible property is _no_', () => {
+      it('returns true', async () => {
+        const application = applicationFactory.build({
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'no' },
+            },
+          },
+        })
+
+        expect(eligibilityQuestionIsAnswered(application)).toEqual(true)
+      })
+    })
+
+    describe('when the isEligible property is something else', () => {
+      it('returns false', async () => {
+        const application = applicationFactory.build({
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'something else' },
+            },
+          },
+        })
+
+        expect(eligibilityQuestionIsAnswered(application)).toEqual(false)
+      })
+    })
+
+    describe('when the isEligible property is missing', () => {
+      it('returns false', async () => {
+        const application = applicationFactory.build({
+          data: {},
+        })
+
+        expect(eligibilityQuestionIsAnswered(application)).toEqual(false)
+      })
+    })
+  })
+})

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -12,7 +12,16 @@ export const firstPageOfBeforeYouStartSection = (application: Application) => {
 }
 
 export const eligibilityQuestionIsAnswered = (application: Application): boolean => {
-  const eligibilityAnswer = application.data?.['confirm-eligibility']?.['confirm-eligibility']?.isEligible
+  return eligibilityAnswer(application) === 'yes' || eligibilityAnswer(application) === 'no'
+}
 
-  return eligibilityAnswer === 'yes' || eligibilityAnswer === 'no'
+export const eligibilityIsConfirmed = (application: Application): boolean => {
+  return eligibilityAnswer(application) === 'yes'
+}
+export const eligibilityIsDenied = (application: Application): boolean => {
+  return eligibilityAnswer(application) === 'no'
+}
+
+const eligibilityAnswer = (application: Application): string => {
+  return application.data?.['confirm-eligibility']?.['confirm-eligibility']?.isEligible
 }

--- a/server/views/applications/ineligible.njk
+++ b/server/views/applications/ineligible.njk
@@ -1,0 +1,30 @@
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  CAS-2: Ineligible - {{application.person.name}} is not eligible for CAS-2 accommodation
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      {{ govukPanel({
+        titleText: panelText,
+        classes: "govuk-!-margin-bottom-9 govuk-panel--fail",
+        attributes: {
+          style: "background-color: #d4351c; color: #ffffff;"
+        }
+      }) }}
+
+      <p class="govuk-body-l">
+        {{application.person.name}}'s Community Offender Manager (COM) should refer them to the regional Commissioned Rehabilitative Services provider (Accommodation contractor for men and Women’s Services contractor for women).
+      </p>
+
+      {{ govukButton({
+           text: "Change eligibility answer",
+           classes: "govuk-button--secondary",
+           href: changeAnswerPath
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/ineligible.njk
+++ b/server/views/applications/ineligible.njk
@@ -9,10 +9,7 @@
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       {{ govukPanel({
         titleText: panelText,
-        classes: "govuk-!-margin-bottom-9 govuk-panel--fail",
-        attributes: {
-          style: "background-color: #d4351c; color: #ffffff;"
-        }
+        classes: "govuk-!-margin-bottom-9 govuk-panel--fail"
       }) }}
 
       <p class="govuk-body-l">

--- a/server/views/applications/ineligible.njk
+++ b/server/views/applications/ineligible.njk
@@ -20,6 +20,12 @@
       </p>
 
       {{ govukButton({
+           text: "Search for a different applicant",
+           classes: "govuk-!-margin-right-1",
+           href: newApplicationPath
+      }) }}
+
+      {{ govukButton({
            text: "Change eligibility answer",
            classes: "govuk-button--secondary",
            href: changeAnswerPath

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,6 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block head %}
   <!--[if !IE 8]><!-->


### PR DESCRIPTION
## Show dead-end if person marked as ineligible

[Trello 439](https://trello.com/c/IbeldbIT/439-eligibility-not-eligible-path)

User stories:

- Abandon ineligible application and start new one
- Change eligibility answer: from NO to YES
- Confirm that the person is NOT eligible for CAS-2

If an application has been marked as ineligible, a new "ineligible" view is now rendered. This view provides:

1. confirmation that the application is marked as ineligible
2. a link to change the eligibility answer
3. a link to start a new application

At present ineligible applications will remain in the "dashboard" list of applications but it won't be possible to do anything to them (via the task list) without changing the eligibility answer.

In the future we might choose to set the `applications.is_inapplicable` property in the db. This might be used to filter out ineligible applications from lists of applications -- but we'd need to do some additional work including to:

- set `is_inapplicable` up on the `cas_2_applications` table
- work out how / whether to allow an ineligible application to be marked as eligible

### The ineligible dead-end view

<img width="821" alt="ineligible" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/870a033d-5a27-4f29-aee5-371340a49676">
