### PR TITLE
Add 'Health needs' task within new 'Risks and needs' section

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
@@ -1,0 +1,17 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+
+export default class HealthNeedsGuidancePage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Request health information for ${application.person.name}`, application, 'health-needs', 'guidance')
+  }
+
+  hasCaption = (): void => {
+    cy.get('p').contains('To complete this section, you’ll need to enter health information about the applicant.')
+  }
+
+  hasGuidance = (): void => {
+    cy.get('p').contains('Typically, this could involve speaking to the following people')
+    cy.get('li').contains('Healthcare team')
+  }
+}

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -33,4 +33,8 @@ export default class TaskListPage extends Page {
       cy.get('.app-task-list__task-name').contains(taskTitle)
     })
   }
+
+  visitTask = (taskTitle: string): void => {
+    cy.get('.app-task-list__task-name').contains(taskTitle).click()
+  }
 }

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -1,0 +1,61 @@
+//  Feature: Referrer completes 'Health needs: guidance' page
+//    So that I can complete the first page of the "Health needs" task
+//    As a referrer
+//    I want to confirm that I've understood the guidance on that page
+//
+//  Scenario: Follows link from task list
+//    Given there is a section with a task
+//    And an application exists
+//    And I am logged in
+//    And I am viewing the application task list
+//
+//  Scenario: view "health needs" task status
+//    Then I see that the "health needs" task has not been started
+
+import Page from '../../../../pages/page'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am viewing the application
+    // --------------------------------
+    cy.visit('applications/abc123')
+    Page.verifyOnPage(TaskListPage)
+  })
+
+  // Scenario: view task status
+  // ----------------------------------------------
+  it('shows the task listed within the section', () => {
+    // I see that the task has not been started
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.shouldShowTaskStatus('health-needs', 'Not started')
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -11,9 +11,14 @@
 //
 //  Scenario: view "health needs" task status
 //    Then I see that the "health needs" task has not been started
+//
+//  Scenario: reads "health needs guidance" page
+//    When I follow the link to the first page in the "Risks and needs" section
+//    Then I see the "health needs guidance" page
 
 import Page from '../../../../pages/page'
 import TaskListPage from '../../../../pages/apply/taskListPage'
+import HealthNeedsGuidancePage from '../../../../pages/apply/risks-and-needs/healthNeedsGuidancePage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "Risks and needs" section', () => {
@@ -57,5 +62,20 @@ context('Visit "Risks and needs" section', () => {
     // I see that the task has not been started
     const taskListPage = Page.verifyOnPage(TaskListPage)
     taskListPage.shouldShowTaskStatus('health-needs', 'Not started')
+  })
+
+  //  Scenario: reads "health needs guidance" page
+  //    When I follow the link to the first page in the "Risks and needs" section
+  //    Then I see the "health needs guidance" page
+  it('provides the expected guidance content', function test() {
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+
+    //  When I follow the link to the first page in the "Risks and needs" section
+    taskListPage.visitTask('Add health needs')
+
+    //  Then I see the "health needs guidance" page
+    const page = Page.verifyOnPage(HealthNeedsGuidancePage, this.application)
+    page.hasCaption()
+    page.hasGuidance()
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -15,6 +15,10 @@
 //  Scenario: reads "health needs guidance" page
 //    When I follow the link to the first page in the "Risks and needs" section
 //    Then I see the "health needs guidance" page
+//
+//  Scenario: continues to next page in "health needs" task
+//    When I continue to the next task/page
+//    Then I should be on the task list (temporarily)
 
 import Page from '../../../../pages/page'
 import TaskListPage from '../../../../pages/apply/taskListPage'
@@ -77,5 +81,20 @@ context('Visit "Risks and needs" section', () => {
     const page = Page.verifyOnPage(HealthNeedsGuidancePage, this.application)
     page.hasCaption()
     page.hasGuidance()
+  })
+
+  //  Scenario: continues to next page in "health needs" task
+  //    When I continue to the next task/page
+  //    Then I should be on the task list (temporarily)
+  it('links back to the task list (temporarily)', function test() {
+    const taskListPage = new TaskListPage()
+    taskListPage.visitTask('Add health needs')
+
+    // When I continue to the next task/page
+    const page = new HealthNeedsGuidancePage(this.application)
+    page.clickSubmit()
+
+    //  Then I should be on the task list (temporarily)
+    Page.verifyOnPage(TaskListPage)
   })
 })

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -3,6 +3,7 @@ import BaseForm from '../baseForm'
 import BeforeYouStart from './before-you-start'
 import AreaAndFunding from './area-and-funding'
 import AboutPerson from './about-the-person'
+import RisksAndNeeds from './risks-and-needs'
 
-@Form({ sections: [BeforeYouStart, AreaAndFunding, AboutPerson] })
+@Form({ sections: [BeforeYouStart, AreaAndFunding, AboutPerson, RisksAndNeeds] })
 export default class Apply extends BaseForm {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import Guidance from './guidance'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+
+describe('Guidance', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new Guidance({}, application)
+
+      expect(page.title).toEqual('Request health information for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new Guidance({}, application), '')
+  itShouldHavePreviousValue(new Guidance({}, application), 'taskList')
+
+  describe('response', () => {
+    it('is blank as there are no questions on this guidance page', () => {
+      const page = new Guidance({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('returns no errors as this guidance page has no questions/answers', () => {
+      const page = new Guidance({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type GuidanceBody = Record<string, never>
+
+@Page({
+  name: 'health-needs-guidance',
+  bodyProperties: [],
+})
+export default class Guidance implements TaskListPage {
+  title = `Request health information for ${this.application.person.name}`
+
+  body: GuidanceBody
+
+  constructor(
+    body: Partial<GuidanceBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as GuidanceBody
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
@@ -6,7 +6,7 @@ import TaskListPage from '../../../taskListPage'
 type GuidanceBody = Record<string, never>
 
 @Page({
-  name: 'health-needs-guidance',
+  name: 'guidance',
   bodyProperties: [],
 })
 export default class Guidance implements TaskListPage {

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+
+import { Task } from '../../../utils/decorators'
+import Guidance from './guidance'
+
+@Task({
+  name: 'Add health needs',
+  slug: 'health-needs',
+  pages: [Guidance],
+})
+export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/index.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+
+import { Section } from '../../utils/decorators'
+import HealthNeeds from './health-needs'
+
+@Section({
+  title: 'Risks and needs',
+  tasks: [HealthNeeds],
+})
+export default class RisksAndNeeds {}

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -1,0 +1,21 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    To complete this section, you’ll need to enter health information about the applicant.
+  </p>
+
+  <p class="govuk-body">
+    Typically, this <strong>could</strong> involve speaking to the following people:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Healthcare team</li>
+    <li>Substance/Drugs team</li>
+    <li>Substance mis-use agency</li>
+    <li>Mental Health team</li>
+    <li>Adult social care</li>
+    <li>Nelson Trust</li>
+  </ul>
+{% endblock %}


### PR DESCRIPTION
## Read 'Health needs' guidance

See [Trello 328](https://trello.com/c/rmEOYpyy/328-health-needs-guidance-page)

The first task to be implemented in the "Risks and needs" section is 'Health needs'. The first page of this task is a guidance page which doesn't ask any questions but will (in a later PR) offer some copy-able "Get in touch" content for use in email queries to other teams.

```
Section: Risks and needs
  Task: Add health needs
    Pages:  - Guidance
            - [Substance misuse]
            - [Physical health]
            - [...]
```

### Task list with new "Risks and needs" section and "Add health needs" task
![risks_and_needs_section](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/24d7e951-e69c-4289-8e6c-2a41b602b2b2)

### Health needs guidance page

Without the copy-able "Get in touch" section and email templates

![health_needs_guidance](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/57812d6f-bdfd-4839-aa49-b3ec157f4248)


