### PR TITLE
459 tech task setup health needs skeleton pages

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/brainInjuryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/brainInjuryPage.ts
@@ -1,10 +1,13 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class BrainInjuryPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Brain injury needs for ${application.person.name}`, application, 'health-needs', 'brain-injury')
+
+    pageIsActiveInNavigation('Brain injury')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/brainInjuryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/brainInjuryPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class BrainInjuryPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Brain injury needs for ${application.person.name}`, application, 'health-needs', 'brain-injury')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'brain-injury',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/communicationAndLanguagePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/communicationAndLanguagePage.ts
@@ -1,0 +1,24 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class CommunicationAndLanguagePage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Communication and language needs for ${application.person.name}`,
+      application,
+      'health-needs',
+      'communication-and-language',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'communication-and-language',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/communicationAndLanguagePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/communicationAndLanguagePage.ts
@@ -1,6 +1,7 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class CommunicationAndLanguagePage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -10,6 +11,8 @@ export default class CommunicationAndLanguagePage extends ApplyPage {
       'health-needs',
       'communication-and-language',
     )
+
+    pageIsActiveInNavigation('Communication and language')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
@@ -1,9 +1,20 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
 
 export default class HealthNeedsGuidancePage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Request health information for ${application.person.name}`, application, 'health-needs', 'guidance')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'guidance',
+      }),
+    )
   }
 
   hasCaption = (): void => {

--- a/integration_tests/pages/apply/risks-and-needs/learningDifficultiesPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/learningDifficultiesPage.ts
@@ -1,6 +1,7 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class LearningDifficultiesPage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -10,6 +11,8 @@ export default class LearningDifficultiesPage extends ApplyPage {
       'health-needs',
       'learning-difficulties',
     )
+
+    pageIsActiveInNavigation('Learning difficulties')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/learningDifficultiesPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/learningDifficultiesPage.ts
@@ -1,0 +1,24 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class LearningDifficultiesPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Learning difficulties and neurodiversity for ${application.person.name}`,
+      application,
+      'health-needs',
+      'learning-difficulties',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'learning-difficulties',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
@@ -1,10 +1,13 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class MentalHealthPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Mental health needs for ${application.person.name}`, application, 'health-needs', 'mental-health')
+
+    pageIsActiveInNavigation('Mental health')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class MentalHealthPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Mental health needs for ${application.person.name}`, application, 'health-needs', 'mental-health')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'mental-health',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/otherHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/otherHealthPage.ts
@@ -1,10 +1,13 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class OtherHealthPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Other health needs for ${application.person.name}`, application, 'health-needs', 'other-health')
+
+    pageIsActiveInNavigation('Other health')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/otherHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/otherHealthPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class OtherHealthPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Other health needs for ${application.person.name}`, application, 'health-needs', 'other-health')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'other-health',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/physicalHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/physicalHealthPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class PhysicalHealthPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Physical health needs for ${application.person.name}`, application, 'health-needs', 'physical-health')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'physical-health',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/physicalHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/physicalHealthPage.ts
@@ -1,10 +1,13 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class PhysicalHealthPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Physical health needs for ${application.person.name}`, application, 'health-needs', 'physical-health')
+
+    pageIsActiveInNavigation('Physical health')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../applyPage'
+import paths from '../../../../server/paths/apply'
+
+export default class SubstanceMisusePage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(`Health needs for ${application.person.name}`, application, 'health-needs', 'substance-misuse')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'substance-misuse',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
@@ -1,10 +1,13 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
+import { pageIsActiveInNavigation } from './utils'
 
 export default class SubstanceMisusePage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(`Health needs for ${application.person.name}`, application, 'health-needs', 'substance-misuse')
+
+    pageIsActiveInNavigation('Substance misuse')
   }
 
   static visit(application: Application): void {

--- a/integration_tests/pages/apply/risks-and-needs/utils.ts
+++ b/integration_tests/pages/apply/risks-and-needs/utils.ts
@@ -1,0 +1,3 @@
+export const pageIsActiveInNavigation = (linkText: string): void => {
+  cy.get('.moj-side-navigation__item--active a').contains(linkText)
+}

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/brain_injury.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/brain_injury.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: brain injury' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'brain injury' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the brain injury page
+//
+//  Scenario: view brain injury questions
+//    Then I see the "brain injury" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "other health" page
+
+import Page from '../../../../pages/page'
+import BrainInjuryPage from '../../../../pages/apply/risks-and-needs/brainInjuryPage'
+import OtherHealthPage from '../../../../pages/apply/risks-and-needs/otherHealthPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "brain injury" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the brain injury page
+    // --------------------------------
+    BrainInjuryPage.visit(this.application)
+  })
+
+  //  Scenario: view brain injury questions
+  //    Then I see the "brain injury" page
+  it('presents brain injury page', function test() {
+    Page.verifyOnPage(BrainInjuryPage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "other health" page
+  it('navigates to the next page (other health)', function test() {
+    BrainInjuryPage.visit(this.application)
+    const page = new BrainInjuryPage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(OtherHealthPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/communication_and_language.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/communication_and_language.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: communication and language' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'communication and language' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the communication and language page
+//
+//  Scenario: view communication and language questions
+//    Then I see the "communication and language" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "learning difficulties" page
+
+import Page from '../../../../pages/page'
+import CommunicationAndLanguage from '../../../../pages/apply/risks-and-needs/communicationAndLanguagePage'
+import LearningDifficultiesPage from '../../../../pages/apply/risks-and-needs/learningDifficultiesPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "communication and language" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the communication and language page
+    // --------------------------------
+    CommunicationAndLanguage.visit(this.application)
+  })
+
+  //  Scenario: view communication and language questions
+  //    Then I see the "communication and language" page
+  it('presents communication and language page', function test() {
+    Page.verifyOnPage(CommunicationAndLanguage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "learning difficulties" page
+  it('navigates to the next page (learning difficulties)', function test() {
+    CommunicationAndLanguage.visit(this.application)
+    const page = new CommunicationAndLanguage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(LearningDifficultiesPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -18,8 +18,9 @@
 //
 //  Scenario: continues to next page in "health needs" task
 //    When I continue to the next task/page
-//    Then I should be on the task list (temporarily)
+//    Then I should be on the substance misuse page
 
+import SubstanceMisusePage from '../../../../pages/apply/risks-and-needs/substanceMisusePage'
 import Page from '../../../../pages/page'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import HealthNeedsGuidancePage from '../../../../pages/apply/risks-and-needs/healthNeedsGuidancePage'
@@ -85,8 +86,8 @@ context('Visit "Risks and needs" section', () => {
 
   //  Scenario: continues to next page in "health needs" task
   //    When I continue to the next task/page
-  //    Then I should be on the task list (temporarily)
-  it('links back to the task list (temporarily)', function test() {
+  //    Then I should be on the substance misuse page
+  it('links back to the substance misuse page', function test() {
     const taskListPage = new TaskListPage()
     taskListPage.visitTask('Add health needs')
 
@@ -94,7 +95,7 @@ context('Visit "Risks and needs" section', () => {
     const page = new HealthNeedsGuidancePage(this.application)
     page.clickSubmit()
 
-    //  Then I should be on the task list (temporarily)
-    Page.verifyOnPage(TaskListPage)
+    //  Then I should be on the substance misuse page
+    Page.verifyOnPage(SubstanceMisusePage, this.application)
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/learning_difficulties.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/learning_difficulties.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: learning difficulties' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'learning difficulties' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the learning difficulties page
+//
+//  Scenario: view learning difficulties questions
+//    Then I see the "learning difficulties" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "brain injury" page
+
+import Page from '../../../../pages/page'
+import BrainInjuryPage from '../../../../pages/apply/risks-and-needs/brainInjuryPage'
+import LearningDifficultiesPage from '../../../../pages/apply/risks-and-needs/learningDifficultiesPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "learning difficulties" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the learning difficulties page
+    // --------------------------------
+    LearningDifficultiesPage.visit(this.application)
+  })
+
+  //  Scenario: view learning difficulties questions
+  //    Then I see the "learning difficulties" page
+  it('presents learning difficulties page', function test() {
+    Page.verifyOnPage(LearningDifficultiesPage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "brain injury" page
+  it('navigates to the next page (brain injury)', function test() {
+    LearningDifficultiesPage.visit(this.application)
+    const page = new LearningDifficultiesPage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(BrainInjuryPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/mental_health.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/mental_health.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: mental health' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'mental health' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the mental health page
+//
+//  Scenario: view mental health questions
+//    Then I see the "mental health" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "communication and language" page
+
+import Page from '../../../../pages/page'
+import MentalHealthPage from '../../../../pages/apply/risks-and-needs/mentalHealthPage'
+import CommunicationAndLanguagePage from '../../../../pages/apply/risks-and-needs/communicationAndLanguagePage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "mental health" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the mental health page
+    // --------------------------------
+    MentalHealthPage.visit(this.application)
+  })
+
+  //  Scenario: view mental health questions
+  //    Then I see the "mental health" page
+  it('presents mental health page', function test() {
+    Page.verifyOnPage(MentalHealthPage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "communication and language" page
+  it('navigates to the next page (communication and language)', function test() {
+    MentalHealthPage.visit(this.application)
+    const page = new MentalHealthPage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(CommunicationAndLanguagePage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/other_health.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/other_health.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: brain injury' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'other health' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the other health page
+//
+//  Scenario: view other health questions
+//    Then I see the "other health" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I am returned to the task list
+
+import Page from '../../../../pages/page'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import OtherHealthPage from '../../../../pages/apply/risks-and-needs/otherHealthPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "other health" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the "other health" page
+    // -----------------------------------
+    OtherHealthPage.visit(this.application)
+  })
+
+  //  Scenario: view "other health" questions
+  //    Then I see the "other health" page
+  it('presents "other health" page', function test() {
+    Page.verifyOnPage(OtherHealthPage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I am returned to the task list
+  it('navigates to the next page (back to task list)', function test() {
+    OtherHealthPage.visit(this.application)
+    const page = new OtherHealthPage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(TaskListPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/physical_health.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/physical_health.cy.ts
@@ -1,0 +1,73 @@
+//  Feature: Referrer completes 'Health needs: physical health' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'physical health' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the physical health page
+//
+//  Scenario: view physical health questions
+//    Then I see the "physical health" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "mental health" page
+
+import Page from '../../../../pages/page'
+import MentalHealthPage from '../../../../pages/apply/risks-and-needs/mentalHealthPage'
+import PhysicalHealthPage from '../../../../pages/apply/risks-and-needs/physicalHealthPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Physical health" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the physical health page
+    // --------------------------------
+    PhysicalHealthPage.visit(this.application)
+  })
+
+  //  Scenario: view physical health questions
+  //    Then I see the "physical health" page
+  it('presents physical health page', function test() {
+    Page.verifyOnPage(PhysicalHealthPage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "mental health" page
+  it('navigates to the next page (mental health)', function test() {
+    PhysicalHealthPage.visit(this.application)
+    const page = new PhysicalHealthPage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(MentalHealthPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Health needs: substance misuse' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the 'substance misuse' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I have read the health needs guidance page
+//
+//  Scenario: view substance misuse questions
+//    Then I see the "substance misuse" page
+//
+//  Scenario: navigate to next page in health needs task
+//    When I continue to the next task / page
+//    Then I see the "physical health" page
+
+import Page from '../../../../pages/page'
+import HealthNeedsGuidancePage from '../../../../pages/apply/risks-and-needs/healthNeedsGuidancePage'
+import SubstanceMisusePage from '../../../../pages/apply/risks-and-needs/substanceMisusePage'
+import PhysicalHealthPage from '../../../../pages/apply/risks-and-needs/physicalHealthPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Substance misuse" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I have read the health needs guidance page
+    // --------------------------------
+    HealthNeedsGuidancePage.visit(this.application)
+    const guidancePage = new HealthNeedsGuidancePage(this.application)
+    guidancePage.clickSubmit()
+  })
+
+  //  Scenario: view substance misuse questions
+  //    Then I see the "substance misuse" page
+  it('presents substance misuse page', function test() {
+    Page.verifyOnPage(SubstanceMisusePage, this.application)
+  })
+
+  //  Scenario: navigate to next page in health needs task
+  //    When I continue to the next task / page
+  //    Then I see the "physical health" page
+  it('navigates to the next page (physical health)', function test() {
+    SubstanceMisusePage.visit(this.application)
+    const page = new SubstanceMisusePage(this.application)
+    page.clickSubmit()
+
+    Page.verifyOnPage(PhysicalHealthPage, this.application)
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import BrainInjury from './brainInjury'
+
+describe('BrainInjury', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new BrainInjury({}, application)
+
+      expect(page.title).toEqual('Brain injury needs for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new BrainInjury({}, application), 'other-health')
+  itShouldHavePreviousValue(new BrainInjury({}, application), 'learning-difficulties')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new BrainInjury({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new BrainInjury({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type BrainInjuryBody = Record<string, never>
+
+@Page({
+  name: 'brain-injury',
+  bodyProperties: [],
+})
+export default class BrainInjury implements TaskListPage {
+  title = `Brain injury needs for ${this.application.person.name}`
+
+  body: BrainInjuryBody
+
+  constructor(
+    body: Partial<BrainInjuryBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as BrainInjuryBody
+  }
+
+  previous() {
+    return 'learning-difficulties'
+  }
+
+  next() {
+    return 'other-health'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import CommunicationAndLanguage from './communicationAndLanguage'
+
+describe('CommunicationAndLanguage', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new CommunicationAndLanguage({}, application)
+
+      expect(page.title).toEqual('Communication and language needs for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new CommunicationAndLanguage({}, application), 'learning-difficulties')
+  itShouldHavePreviousValue(new CommunicationAndLanguage({}, application), 'mental-health')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new CommunicationAndLanguage({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new CommunicationAndLanguage({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type CommunicationAndLanguageBody = Record<string, never>
+
+@Page({
+  name: 'communication-and-language',
+  bodyProperties: [],
+})
+export default class CommunicationAndLanguage implements TaskListPage {
+  title = `Communication and language needs for ${this.application.person.name}`
+
+  body: CommunicationAndLanguageBody
+
+  constructor(
+    body: Partial<CommunicationAndLanguageBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as CommunicationAndLanguageBody
+  }
+
+  previous() {
+    return 'mental-health'
+  }
+
+  next() {
+    return 'learning-difficulties'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
@@ -13,7 +13,7 @@ describe('Guidance', () => {
     })
   })
 
-  itShouldHaveNextValue(new Guidance({}, application), '')
+  itShouldHaveNextValue(new Guidance({}, application), 'substance-misuse')
   itShouldHavePreviousValue(new Guidance({}, application), 'taskList')
 
   describe('response', () => {

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -2,12 +2,13 @@
 
 import { Task } from '../../../utils/decorators'
 import Guidance from './guidance'
+import MentalHealth from './mentalHealth'
 import PhysicalHealth from './physicalHealth'
 import SubstanceMisuse from './substanceMisuse'
 
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance, SubstanceMisuse, PhysicalHealth],
+  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import { Task } from '../../../utils/decorators'
+import BrainInjury from './brainInjury'
 import CommunicationAndLanguage from './communicationAndLanguage'
 import Guidance from './guidance'
 import LearningDifficulties from './learningDifficulties'
@@ -11,6 +12,14 @@ import SubstanceMisuse from './substanceMisuse'
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth, CommunicationAndLanguage, LearningDifficulties],
+  pages: [
+    Guidance,
+    SubstanceMisuse,
+    PhysicalHealth,
+    MentalHealth,
+    CommunicationAndLanguage,
+    LearningDifficulties,
+    BrainInjury,
+  ],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -6,6 +6,7 @@ import CommunicationAndLanguage from './communicationAndLanguage'
 import Guidance from './guidance'
 import LearningDifficulties from './learningDifficulties'
 import MentalHealth from './mentalHealth'
+import OtherHealth from './otherHealth'
 import PhysicalHealth from './physicalHealth'
 import SubstanceMisuse from './substanceMisuse'
 
@@ -20,6 +21,7 @@ import SubstanceMisuse from './substanceMisuse'
     CommunicationAndLanguage,
     LearningDifficulties,
     BrainInjury,
+    OtherHealth,
   ],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -3,6 +3,7 @@
 import { Task } from '../../../utils/decorators'
 import CommunicationAndLanguage from './communicationAndLanguage'
 import Guidance from './guidance'
+import LearningDifficulties from './learningDifficulties'
 import MentalHealth from './mentalHealth'
 import PhysicalHealth from './physicalHealth'
 import SubstanceMisuse from './substanceMisuse'
@@ -10,6 +11,6 @@ import SubstanceMisuse from './substanceMisuse'
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth, CommunicationAndLanguage],
+  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth, CommunicationAndLanguage, LearningDifficulties],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -2,10 +2,11 @@
 
 import { Task } from '../../../utils/decorators'
 import Guidance from './guidance'
+import SubstanceMisuse from './substanceMisuse'
 
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance],
+  pages: [Guidance, SubstanceMisuse],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -2,11 +2,12 @@
 
 import { Task } from '../../../utils/decorators'
 import Guidance from './guidance'
+import PhysicalHealth from './physicalHealth'
 import SubstanceMisuse from './substanceMisuse'
 
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance, SubstanceMisuse],
+  pages: [Guidance, SubstanceMisuse, PhysicalHealth],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/index.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import { Task } from '../../../utils/decorators'
+import CommunicationAndLanguage from './communicationAndLanguage'
 import Guidance from './guidance'
 import MentalHealth from './mentalHealth'
 import PhysicalHealth from './physicalHealth'
@@ -9,6 +10,6 @@ import SubstanceMisuse from './substanceMisuse'
 @Task({
   name: 'Add health needs',
   slug: 'health-needs',
-  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth],
+  pages: [Guidance, SubstanceMisuse, PhysicalHealth, MentalHealth, CommunicationAndLanguage],
 })
 export default class HealthNeeds {}

--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import LearningDifficulties from './learningDifficulties'
+
+describe('LearningDifficulties', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new LearningDifficulties({}, application)
+
+      expect(page.title).toEqual('Learning difficulties and neurodiversity for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new LearningDifficulties({}, application), 'brain-injury')
+  itShouldHavePreviousValue(new LearningDifficulties({}, application), 'communication-and-language')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new LearningDifficulties({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new LearningDifficulties({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type LearningDifficultiesBody = Record<string, never>
+
+@Page({
+  name: 'learning-difficulties',
+  bodyProperties: [],
+})
+export default class LearningDifficulties implements TaskListPage {
+  title = `Learning difficulties and neurodiversity for ${this.application.person.name}`
+
+  body: LearningDifficultiesBody
+
+  constructor(
+    body: Partial<LearningDifficultiesBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as LearningDifficultiesBody
+  }
+
+  previous() {
+    return 'communication-and-language'
+  }
+
+  next() {
+    return 'brain-injury'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import MentalHealth from './mentalHealth'
+
+describe('MentalHealth', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new MentalHealth({}, application)
+
+      expect(page.title).toEqual('Mental health needs for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new MentalHealth({}, application), 'communication-and-language')
+  itShouldHavePreviousValue(new MentalHealth({}, application), 'physical-health')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new MentalHealth({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new MentalHealth({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type MentalHealthBody = Record<string, never>
+
+@Page({
+  name: 'mental-health',
+  bodyProperties: [],
+})
+export default class MentalHealth implements TaskListPage {
+  title = `Mental health needs for ${this.application.person.name}`
+
+  body: MentalHealthBody
+
+  constructor(
+    body: Partial<MentalHealthBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as MentalHealthBody
+  }
+
+  previous() {
+    return 'physical-health'
+  }
+
+  next() {
+    return 'communication-and-language'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/otherHealth.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/otherHealth.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import OtherHealth from './otherHealth'
+
+describe('OtherHealth', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new OtherHealth({}, application)
+
+      expect(page.title).toEqual('Other health needs for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new OtherHealth({}, application), '')
+  itShouldHavePreviousValue(new OtherHealth({}, application), 'brain-injury')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new OtherHealth({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new OtherHealth({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/otherHealth.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/otherHealth.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type OtherHealthBody = Record<string, never>
+
+@Page({
+  name: 'other-health',
+  bodyProperties: [],
+})
+export default class OtherHealth implements TaskListPage {
+  title = `Other health needs for ${this.application.person.name}`
+
+  body: OtherHealthBody
+
+  constructor(
+    body: Partial<OtherHealthBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as OtherHealthBody
+  }
+
+  previous() {
+    return 'brain-injury'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/physicalHealth.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/physicalHealth.test.ts
@@ -1,24 +1,24 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import SubstanceMisuse from './substanceMisuse'
+import PhysicalHealth from './physicalHealth'
 
-describe('SubstanceMisuse', () => {
+describe('PhysicalHealth', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
 
   describe('title', () => {
     it('personalises the page title', () => {
-      const page = new SubstanceMisuse({}, application)
+      const page = new PhysicalHealth({}, application)
 
-      expect(page.title).toEqual('Health needs for Roger Smith')
+      expect(page.title).toEqual('Physical health needs for Roger Smith')
     })
   })
 
-  itShouldHaveNextValue(new SubstanceMisuse({}, application), 'physical-health')
-  itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'taskList')
+  itShouldHaveNextValue(new PhysicalHealth({}, application), 'mental-health')
+  itShouldHavePreviousValue(new PhysicalHealth({}, application), 'substance-misuse')
 
   describe('response', () => {
     it('not implemented', () => {
-      const page = new SubstanceMisuse({}, application)
+      const page = new PhysicalHealth({}, application)
 
       expect(page.response()).toEqual({})
     })
@@ -26,7 +26,7 @@ describe('SubstanceMisuse', () => {
 
   describe('errors', () => {
     it('not implemented', () => {
-      const page = new SubstanceMisuse({}, application)
+      const page = new PhysicalHealth({}, application)
 
       expect(page.errors()).toEqual({})
     })

--- a/server/form-pages/apply/risks-and-needs/health-needs/physicalHealth.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/physicalHealth.ts
@@ -3,30 +3,30 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 
-type SubstanceMisuseBody = Record<string, never>
+type PhysicalHealthBody = Record<string, never>
 
 @Page({
-  name: 'substance-misuse',
+  name: 'physical-health',
   bodyProperties: [],
 })
-export default class SubstanceMisuse implements TaskListPage {
-  title = `Health needs for ${this.application.person.name}`
+export default class PhysicalHealth implements TaskListPage {
+  title = `Physical health needs for ${this.application.person.name}`
 
-  body: SubstanceMisuseBody
+  body: PhysicalHealthBody
 
   constructor(
-    body: Partial<SubstanceMisuseBody>,
+    body: Partial<PhysicalHealthBody>,
     private readonly application: Application,
   ) {
-    this.body = body as SubstanceMisuseBody
+    this.body = body as PhysicalHealthBody
   }
 
   previous() {
-    return 'taskList'
+    return 'substance-misuse'
   }
 
   next() {
-    return 'physical-health'
+    return 'mental-health'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -1,0 +1,34 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import SubstanceMisuse from './substanceMisuse'
+
+describe('SubstanceMisuse', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new SubstanceMisuse({}, application)
+
+      expect(page.title).toEqual('Health needs for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new SubstanceMisuse({}, application), '')
+  itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'taskList')
+
+  describe('response', () => {
+    it('not implemented', () => {
+      const page = new SubstanceMisuse({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('not implemented', () => {
+      const page = new SubstanceMisuse({}, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -3,22 +3,22 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 
-type GuidanceBody = Record<string, never>
+type SubstanceMisuseBody = Record<string, never>
 
 @Page({
-  name: 'guidance',
+  name: 'substance-misuse',
   bodyProperties: [],
 })
-export default class Guidance implements TaskListPage {
-  title = `Request health information for ${this.application.person.name}`
+export default class SubstanceMisuse implements TaskListPage {
+  title = `Health needs for ${this.application.person.name}`
 
-  body: GuidanceBody
+  body: SubstanceMisuseBody
 
   constructor(
-    body: Partial<GuidanceBody>,
+    body: Partial<SubstanceMisuseBody>,
     private readonly application: Application,
   ) {
-    this.body = body as GuidanceBody
+    this.body = body as SubstanceMisuseBody
   }
 
   previous() {
@@ -26,7 +26,7 @@ export default class Guidance implements TaskListPage {
   }
 
   next() {
-    return 'substance-misuse'
+    return ''
   }
 
   errors() {

--- a/server/views/applications/pages/health-needs/_health-needs-screen.njk
+++ b/server/views/applications/pages/health-needs/_health-needs-screen.njk
@@ -1,0 +1,62 @@
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="{{ pageName }}">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
+
+      <a
+        href="{{paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'guidance' })}}"
+        class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19"
+        >
+        Who do I need to contact for health care information?
+      </a>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-4">
+    <div class="govuk-grid-column-one-third">
+      {{ mojSideNavigation({
+          label: 'Health needs navigation',
+          items: [{
+            text: 'Substance misuse',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'substance-misuse' }),
+            active: (pageName === 'substance-misuse')
+          }, {
+            text: 'Physical health',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'physical-health' }),
+            active: (pageName === 'physical-health')
+          }, {
+            text: 'Mental health',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'mental-health' }),
+            active: (pageName === 'mental-health')
+          }, {
+            text: 'Communication and language needs',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'communication-and-language' }),
+            active: (pageName === 'communication-and-language')
+          }, {
+            text: 'Learning difficulties and neurodiversity',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'learning-difficulties' }),
+            active: (pageName === 'learning-difficulties')
+          }, {
+            text: 'Brain injury',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'brain-injury' }),
+            active: (pageName === 'brain-injury')
+          }, {
+            text: 'Other health',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'other-health' }),
+            active: (pageName === 'other-health')
+          }]
+        }) }}
+    </div>
+
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-top-4">
+      {{ super() }}
+    </div>
+
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/health-needs/brain-injury.njk
+++ b/server/views/applications/pages/health-needs/brain-injury.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Brain injury page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/brain-injury.njk
+++ b/server/views/applications/pages/health-needs/brain-injury.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "brain-injury" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Brain injury page

--- a/server/views/applications/pages/health-needs/communication-and-language.njk
+++ b/server/views/applications/pages/health-needs/communication-and-language.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Communication and language needs page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/communication-and-language.njk
+++ b/server/views/applications/pages/health-needs/communication-and-language.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "communication-and-language" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Communication and language needs page

--- a/server/views/applications/pages/health-needs/learning-difficulties.njk
+++ b/server/views/applications/pages/health-needs/learning-difficulties.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "learning-difficulties" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Learning difficulties page

--- a/server/views/applications/pages/health-needs/learning-difficulties.njk
+++ b/server/views/applications/pages/health-needs/learning-difficulties.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Learning difficulties page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/mental-health.njk
+++ b/server/views/applications/pages/health-needs/mental-health.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "mental-health" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Mental health page

--- a/server/views/applications/pages/health-needs/mental-health.njk
+++ b/server/views/applications/pages/health-needs/mental-health.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Mental health page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/other-health.njk
+++ b/server/views/applications/pages/health-needs/other-health.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Other health page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/other-health.njk
+++ b/server/views/applications/pages/health-needs/other-health.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "other-health" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Other health page

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "physical-health" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Physical health page

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Physical health page
+  </p>
+
+{% endblock %}

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -1,6 +1,7 @@
-{% extends "../layout.njk" %}
+{% extends "./_health-needs-screen.njk" %}
+{% set pageName = "substance-misuse" %}
+
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   <p class="govuk-body">
     Substance misuse page

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -1,0 +1,9 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <p class="govuk-body">
+    Substance misuse page
+  </p>
+
+{% endblock %}


### PR DESCRIPTION
In this PR we implement a basic (or 'skeleton') code scaffold for the 7 new pages of the "Health needs" task. The initial guidance page doesn't have the sidebar navigation.

There are now minimal integration test files in place which will be fleshed out to describe the actual behaviour required to complete each page.

It should be straightforward to implement these pages in parallel, their PRs not conflicting with each other.

![health_task_skelton_pages](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/771c13c1-320e-4ac4-9973-64183e547c0c)
