### PR TITLE
Add religion page to Equality & Diversity 

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -28,6 +28,9 @@
     },
     "white-background": {
       "whiteBackground": "english"
+    },
+    "religion": {
+      "religion": "atheist"
     }
   }
 }

--- a/integration_tests/pages/apply/about_the_person/equality_and_diversity/index.ts
+++ b/integration_tests/pages/apply/about_the_person/equality_and_diversity/index.ts
@@ -4,6 +4,7 @@ import DisabilityPage from './disabilityPage'
 import EthnicGroupPage from './ethnicGroupPage'
 import MixedBackgroundPage from './mixedBackgroundPage'
 import OtherBackgroundPage from './otherBackgroundPage'
+import ReligionPage from './religionPage'
 import SexAndGenderPage from './sexAndGenderPage'
 import SexualOrientationPage from './sexualOrientationPage'
 import WhiteBackgroundPage from './whiteBackgroundPage'
@@ -16,6 +17,7 @@ export {
   EthnicGroupPage,
   MixedBackgroundPage,
   OtherBackgroundPage,
+  ReligionPage,
   SexAndGenderPage,
   SexualOrientationPage,
   WhiteBackgroundPage,

--- a/integration_tests/pages/apply/about_the_person/equality_and_diversity/religionPage.ts
+++ b/integration_tests/pages/apply/about_the_person/equality_and_diversity/religionPage.ts
@@ -1,0 +1,28 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import paths from '../../../../../server/paths/apply'
+import ApplyPage from '../../applyPage'
+
+export default class ReligionPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `What is ${application.person.name}'s religion?`,
+      application,
+      'equality-and-diversity-monitoring',
+      'religion',
+    )
+  }
+
+  selectReligion(): void {
+    this.checkRadioByNameAndValue('religion', 'atheist')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'equality-and-diversity-monitoring',
+        page: 'religion',
+      }),
+    )
+  }
+}

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_asian_background.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_asian_background.cy.ts
@@ -6,12 +6,10 @@
 //  Scenario: submits a valid answer to asian background page
 //    Given I'm on the 'asian background' question page
 //    When I give a valid answer
-//    Then I return to the task list page
-//    And I see that the task has been completed
+//    Then I am taken to the religion page
 
+import { AsianBackgroundPage, ReligionPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
-import AsianBackgroundPage from '../../../../pages/apply/about_the_person/equality_and_diversity/asianBackgroundPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -51,25 +49,14 @@ context('Visit "About the person" section', () => {
 
   // Scenario: select asian background type
   // ----------------------------
-  it('continues to task list page', function test() {
+  it('continues to the religion page', function test() {
     // I submit my answers
     const page = Page.verifyOnPage(AsianBackgroundPage, this.application)
     page.selectAsianBackground()
 
-    // after submission of the valid form the API will return the answered question
-
-    const answered = {
-      ...this.application,
-    }
-    answered.data['equality-and-diversity-monitoring']['asian-background'] = { asianBackground: 'english' }
-    cy.task('stubApplicationGet', { application: answered })
-
     page.clickSubmit()
 
-    // I return to the task list page
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // I see that the task has been completed
-    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
+    // I am taken to the relgion page
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_black_background.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_black_background.cy.ts
@@ -6,12 +6,10 @@
 //  Scenario: submits a valid answer to black background page
 //    Given I'm on the 'black background' question page
 //    When I give a valid answer
-//    Then I return to the task list page
-//    And I see that the task has been completed
+//    Then I am taken to the religion page
 
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
-import BlackBackgroundPage from '../../../../pages/apply/about_the_person/equality_and_diversity/blackBackgroundPage'
+import { BlackBackgroundPage, ReligionPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -51,25 +49,14 @@ context('Visit "About the person" section', () => {
 
   // Scenario: select black background type
   // ----------------------------
-  it('continues to task list page', function test() {
+  it('continues to the religion page', function test() {
     // I submit my answers
     const page = Page.verifyOnPage(BlackBackgroundPage, this.application)
     page.selectBlackBackground()
 
-    // after submission of the valid form the API will return the answered question
-
-    const answered = {
-      ...this.application,
-    }
-    answered.data['equality-and-diversity-monitoring']['black-background'] = { blackBackground: 'african' }
-    cy.task('stubApplicationGet', { application: answered })
-
     page.clickSubmit()
 
-    // I return to the task list page
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // I see that the task has been completed
-    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
+    // I am taken to the relgion page
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_ethnic_group_page.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_ethnic_group_page.cy.ts
@@ -31,11 +31,9 @@
 //  Scenario: submit 'Prefer not to say' as ethnic group answer
 //    Given I'm on the 'Ethnic group' question page
 //    When I answer 'Prefer not to say'
-//    Then I return to the task list page
-//    And I see that the task has been completed
+//    Then I am taken to the religion page
 
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
 import {
   EthnicGroupPage,
   WhiteBackgroundPage,
@@ -43,6 +41,7 @@ import {
   AsianBackgroundPage,
   BlackBackgroundPage,
   OtherBackgroundPage,
+  ReligionPage,
 } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
@@ -148,23 +147,14 @@ context('Visit "About the person" section', () => {
 
   // Scenario: select 'Prefer not to say'
   // ----------------------------
-  it('continues to task list page', function test() {
+  it('continues to the religion page', function test() {
     // I submit my answers
     const page = Page.verifyOnPage(EthnicGroupPage, this.application)
     page.selectEthnicGroup('preferNotToSay')
 
-    const answered = {
-      ...this.application,
-    }
-    answered.data['equality-and-diversity-monitoring']['ethnic-group'] = { ethnicGroup: 'preferNotToSay' }
-    cy.task('stubApplicationGet', { application: answered })
-
     page.clickSubmit()
 
-    // I return to the task list page
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // I see that the task has been completed
-    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
+    // I am taken to the relgion page
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_mixed_background.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_mixed_background.cy.ts
@@ -6,12 +6,10 @@
 //  Scenario: submits a valid answer to mixed background page
 //    Given I'm on the 'mixed background' question page
 //    When I give a valid answer
-//    Then I return to the task list page
-//    And I see that the task has been completed
+//    Then I am taken to the religion page
 
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
-import MixedBackgroundPage from '../../../../pages/apply/about_the_person/equality_and_diversity/mixedBackgroundPage'
+import { MixedBackgroundPage, ReligionPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -51,25 +49,14 @@ context('Visit "About the person" section', () => {
 
   // Scenario: select mixed background type
   // ----------------------------
-  it('continues to task list page', function test() {
+  it('continues to the religion page', function test() {
     // I submit my answers
     const page = Page.verifyOnPage(MixedBackgroundPage, this.application)
     page.selectMixedBackground()
 
-    // after submission of the valid form the API will return the answered question
-
-    const answered = {
-      ...this.application,
-    }
-    answered.data['equality-and-diversity-monitoring']['mixed-background'] = { mixedBackground: 'english' }
-    cy.task('stubApplicationGet', { application: answered })
-
     page.clickSubmit()
 
-    // I return to the task list page
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // I see that the task has been completed
-    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
+    // I am taken to the relgion page
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_other_background.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_other_background.cy.ts
@@ -6,12 +6,10 @@
 //  Scenario: submits a valid answer to other background page
 //    Given I'm on the 'other background' question page
 //    When I give a valid answer
-//    Then I return to the task list page
-//    And I see that the task has been completed
+//    Then I am taken to the religion page
 
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
-import OtherBackgroundPage from '../../../../pages/apply/about_the_person/equality_and_diversity/otherBackgroundPage'
+import { OtherBackgroundPage, ReligionPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -51,25 +49,14 @@ context('Visit "About the person" section', () => {
 
   // Scenario: select other background type
   // ----------------------------
-  it('continues to task list page', function test() {
+  it('continues to the religion page', function test() {
     // I submit my answers
     const page = Page.verifyOnPage(OtherBackgroundPage, this.application)
     page.selectOtherBackground()
 
-    // after submission of the valid form the API will return the answered question
-
-    const answered = {
-      ...this.application,
-    }
-    answered.data['equality-and-diversity-monitoring']['other-background'] = { otherBackground: 'african' }
-    cy.task('stubApplicationGet', { application: answered })
-
     page.clickSubmit()
 
-    // I return to the task list page
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // I see that the task has been completed
-    taskListPage.shouldShowTaskStatus('equality-and-diversity-monitoring', 'Completed')
+    // I am taken to the relgion page
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_religion.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/equality_and_diversity/complete_religion.cy.ts
@@ -1,15 +1,16 @@
-//  Feature: Referrer completes 'White background' question page
+//  Feature: Referrer completes 'religion' question page
 //    So that I can complete the 'Equality questions' task
 //    As a referrer
-//    I want to answer questions on the white background page
+//    I want to answer questions on the religion page
 //
-//  Scenario: submits a valid answer to white background page
-//    Given I'm on the 'White background' question page
+//  Scenario: submits a valid answer to religion page
+//    Given I'm on the 'religion' question page
 //    When I give a valid answer
-//    Then I am taken to the religion page
+//    Then I am taken to the task page (temporarily)
 
+import { ReligionPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
+import TaskListPage from '../../../../pages/apply/taskListPage'
 import Page from '../../../../pages/page'
-import { ReligionPage, WhiteBackgroundPage } from '../../../../pages/apply/about_the_person/equality_and_diversity'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
 context('Visit "About the person" section', () => {
@@ -41,22 +42,23 @@ context('Visit "About the person" section', () => {
     //---------------------
     cy.signIn()
 
-    // And I am on the white background page
+    // And I am on the religion page
     // --------------------------------
-    cy.visit('applications/abc123/tasks/equality-and-diversity-monitoring/pages/white-background')
-    Page.verifyOnPage(WhiteBackgroundPage, this.application)
+    ReligionPage.visit(this.application)
+
+    Page.verifyOnPage(ReligionPage, this.application)
   })
 
-  // Scenario: select white background type
+  // Scenario: select religion type
   // ----------------------------
-  it('continues to the religion page', function test() {
+  it('continues to the task list page', function test() {
     // I submit my answers
-    const page = Page.verifyOnPage(WhiteBackgroundPage, this.application)
-    page.selectWhiteBackground()
+    const page = Page.verifyOnPage(ReligionPage, this.application)
+    page.selectReligion()
 
     page.clickSubmit()
 
-    // I am taken to the relgion page
-    Page.verifyOnPage(ReligionPage, this.application)
+    // I am taken to the task list page (temporarily)
+    Page.verifyOnPage(TaskListPage, this.application)
   })
 })

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/asianBackground.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/asianBackground.test.ts
@@ -13,7 +13,7 @@ describe('AsianBackground', () => {
     })
   })
 
-  itShouldHaveNextValue(new AsianBackground({}, application), '')
+  itShouldHaveNextValue(new AsianBackground({}, application), 'religion')
   itShouldHavePreviousValue(new AsianBackground({}, application), 'ethnic-group')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/asianBackground.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/asianBackground.ts
@@ -45,7 +45,7 @@ export default class AsianBackground implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/blackBackground.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/blackBackground.test.ts
@@ -13,7 +13,7 @@ describe('BlackBackground', () => {
     })
   })
 
-  itShouldHaveNextValue(new BlackBackground({}, application), '')
+  itShouldHaveNextValue(new BlackBackground({}, application), 'religion')
   itShouldHavePreviousValue(new BlackBackground({}, application), 'ethnic-group')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/blackBackground.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/blackBackground.ts
@@ -43,7 +43,7 @@ export default class BlackBackground implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/ethnicGroup.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/ethnicGroup.test.ts
@@ -15,7 +15,8 @@ describe('EthnicGroup', () => {
 
   describe('next', () => {
     const backgroundPages = [
-      [undefined, ''],
+      [undefined, 'religion'],
+      ['preferNotToSay', 'religion'],
       ['white', 'white-background'],
       ['mixed', 'mixed-background'],
       ['asian', 'asian-background'],

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/ethnicGroup.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/ethnicGroup.ts
@@ -53,7 +53,7 @@ export default class EthnicGroup implements TaskListPage {
     if (ethnicGroupNext[this.body.ethnicGroup]) {
       return ethnicGroupNext[this.body.ethnicGroup]
     }
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/index.ts
@@ -11,6 +11,7 @@ import MixedBackground from './mixedBackground'
 import AsianBackground from './asianBackground'
 import BlackBackground from './blackBackground'
 import OtherBackground from './otherBackground'
+import Religion from './religion'
 
 @Task({
   name: 'Complete equality and diversity monitoring',
@@ -26,6 +27,7 @@ import OtherBackground from './otherBackground'
     AsianBackground,
     BlackBackground,
     OtherBackground,
+    Religion,
   ],
 })
 export default class EqualityAndDiversityMonitoring {}

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/mixedBackground.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/mixedBackground.test.ts
@@ -13,7 +13,7 @@ describe('MixedBackground', () => {
     })
   })
 
-  itShouldHaveNextValue(new MixedBackground({}, application), '')
+  itShouldHaveNextValue(new MixedBackground({}, application), 'religion')
   itShouldHavePreviousValue(new MixedBackground({}, application), 'ethnic-group')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/mixedBackground.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/mixedBackground.ts
@@ -44,7 +44,7 @@ export default class MixedBackground implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/otherBackground.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/otherBackground.test.ts
@@ -13,7 +13,7 @@ describe('OtherBackground', () => {
     })
   })
 
-  itShouldHaveNextValue(new OtherBackground({}, application), '')
+  itShouldHaveNextValue(new OtherBackground({}, application), 'religion')
   itShouldHavePreviousValue(new OtherBackground({}, application), 'ethnic-group')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/otherBackground.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/otherBackground.ts
@@ -42,7 +42,7 @@ export default class OtherBackground implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.test.ts
@@ -1,0 +1,131 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import Religion from './religion'
+
+describe('Religion', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new Religion({}, application)
+
+      expect(page.title).toEqual('Equality and diversity questions for Roger Smith')
+    })
+  })
+
+  itShouldHaveNextValue(new Religion({}, application), '')
+  itShouldHavePreviousValue(new Religion({}, application), 'ethnic-group')
+
+  describe('response', () => {
+    it('Adds selected option to page response in _translated_ form', () => {
+      const page = new Religion({ religion: 'atheist' }, application)
+
+      expect(page.response()).toEqual({
+        "What is Roger Smith's religion?": 'Atheist or Humanist',
+        'What is their religion? (optional)': undefined,
+      })
+    })
+
+    it('Adds optional gender data to page response in _translated_ form', () => {
+      const page = new Religion({ religion: 'other', otherReligion: 'example' }, application)
+
+      expect(page.response()).toEqual({
+        "What is Roger Smith's religion?": 'Any other religion',
+        'What is their religion? (optional)': 'example',
+      })
+    })
+
+    it('Deletes fields where there is not an answer', () => {
+      const page = new Religion({ religion: undefined, otherReligion: undefined }, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new Religion({ religion: 'agnostic' }, application)
+      const conditional = 'example'
+      expect(page.items(conditional)).toEqual([
+        {
+          checked: false,
+          text: 'No religion',
+          value: 'noReligion',
+        },
+        {
+          checked: false,
+          text: 'Atheist or Humanist',
+          value: 'atheist',
+        },
+        {
+          checked: true,
+          text: 'Agnostic',
+          value: 'agnostic',
+        },
+        {
+          checked: false,
+          text: 'Christian',
+          value: 'christian',
+          hint: {
+            text: 'Including Church of England, Catholic, Protestant and all other Christian denominations.',
+          },
+        },
+        {
+          checked: false,
+          text: 'Buddhist',
+          value: 'buddhist',
+        },
+        {
+          checked: false,
+          text: 'Hindu',
+          value: 'hindu',
+        },
+        {
+          checked: false,
+          text: 'Jewish',
+          value: 'jewish',
+        },
+        {
+          checked: false,
+          text: 'Muslim',
+          value: 'muslim',
+        },
+        {
+          checked: false,
+          text: 'Sikh',
+          value: 'sikh',
+        },
+        {
+          checked: false,
+          conditional: {
+            html: 'example',
+          },
+          text: 'Any other religion',
+          value: 'other',
+        },
+        { divider: 'or' },
+        {
+          value: 'preferNotToSay',
+          text: 'Prefer not to say',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when the questions are blank', () => {
+      const page = new Religion({}, application)
+
+      expect(page.errors()).toEqual({
+        religion: "Select a religion or 'Prefer not to say'",
+      })
+    })
+
+    it('should not return an error when the optional question is missing', () => {
+      const page = new Religion({ religion: 'other' }, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.ts
@@ -1,0 +1,99 @@
+import type { Radio, TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import errorLookups from '../../../../i18n/en/errors.json'
+
+type ReligionBody = {
+  religion:
+    | 'noReligion'
+    | 'atheist'
+    | 'agnostic'
+    | 'christian'
+    | 'buddhist'
+    | 'hindu'
+    | 'jewish'
+    | 'muslim'
+    | 'sikh'
+    | 'other'
+    | 'preferNotToSay'
+  otherReligion: string
+}
+
+export const religionOptions = {
+  noReligion: 'No religion',
+  atheist: 'Atheist or Humanist',
+  agnostic: 'Agnostic',
+  christian: 'Christian',
+  buddhist: 'Buddhist',
+  hindu: 'Hindu',
+  jewish: 'Jewish',
+  muslim: 'Muslim',
+  sikh: 'Sikh',
+  other: 'Any other religion',
+  preferNotToSay: 'Prefer not to say',
+}
+
+@Page({
+  name: 'religion',
+  bodyProperties: ['religion', 'otherReligion'],
+})
+export default class Religion implements TaskListPage {
+  title = `Equality and diversity questions for ${this.application.person.name}`
+
+  questions = {
+    religion: `What is ${this.application.person.name}'s religion?`,
+    otherReligion: 'What is their religion? (optional)',
+  }
+
+  body: ReligionBody
+
+  constructor(
+    body: Partial<ReligionBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as ReligionBody
+  }
+
+  previous() {
+    return 'ethnic-group'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.religion) {
+      errors.religion = errorLookups.religion.empty
+    }
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.religion]: religionOptions[this.body.religion],
+      [this.questions.otherReligion]: this.body.otherReligion,
+    }
+
+    return response
+  }
+
+  items(otherReligionHtml: string) {
+    const items = convertKeyValuePairToRadioItems(religionOptions, this.body.religion) as [Radio]
+
+    items.forEach(item => {
+      if (item.value === 'other') {
+        item.conditional = { html: otherReligionHtml }
+      }
+      if (item.value === 'christian') {
+        item.hint = { text: 'Including Church of England, Catholic, Protestant and all other Christian denominations.' }
+      }
+    })
+    const preferNotToSay = items.pop()
+
+    return [...items, { divider: 'or' }, { ...preferNotToSay }]
+  }
+}

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/whiteBackground.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/whiteBackground.test.ts
@@ -13,7 +13,7 @@ describe('WhiteBackground', () => {
     })
   })
 
-  itShouldHaveNextValue(new WhiteBackground({}, application), '')
+  itShouldHaveNextValue(new WhiteBackground({}, application), 'religion')
   itShouldHavePreviousValue(new WhiteBackground({}, application), 'ethnic-group')
 
   describe('response', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/whiteBackground.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/whiteBackground.ts
@@ -44,7 +44,7 @@ export default class WhiteBackground implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'religion'
   }
 
   errors() {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -22,5 +22,8 @@
   },
   "background": {
     "empty": "Select a background or 'Prefer not to say'"
+  },
+  "religion": {
+    "empty": "Select a religion or 'Prefer not to say'"
   }
 }

--- a/server/views/applications/pages/equality-and-diversity-monitoring/religion.njk
+++ b/server/views/applications/pages/equality-and-diversity-monitoring/religion.njk
@@ -1,0 +1,36 @@
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+
+{% extends "../layout.njk" %}
+{% block questions %}
+  <span class="govuk-caption-l">{{ page.title }}</span>
+
+  {% set optionalReligion %}
+    {{
+      formPageInput(
+        {
+          label: { text: page.questions.otherReligion},
+          classes: "govuk-input--width-20",
+          fieldName: "optionalReligion"
+        },
+        fetchContext()
+      )
+    }}
+  {% endset -%}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "religion",
+        fieldset: {
+          legend: {
+            text: page.questions.religion,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: page.items(optionalReligion)
+      },
+      fetchContext()
+    )
+  }}
+{% endblock %}


### PR DESCRIPTION
Adds the next page in the E&D task, which is structured like this:

![Screenshot 2023-08-08 at 14 26 25](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/5b5e8f28-634e-4995-b41d-7aaeee3f2a34)

So all of the background pages had to have their `next` logic updated, and there will shortly be a new 'military' page added after this page. 

e2e test is here, but will be failing because missing health section atm https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e/pull/19 


![Screenshot 2023-08-08 at 14 24 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/0ea2542e-e466-49ee-8cd3-d8d7dc31d3dd)
