### PR TITLE
(330) Health task: substance misuse page

### DIFF
--- a/doc/task_list_system.md
+++ b/doc/task_list_system.md
@@ -157,12 +157,56 @@ With a constructor method to define the body of the question
 A `previous` and `next` function to determine where the user is taken after the
 questions has been answered
 
-A `response` function that is called when the question is submitted, where logic
-can be added based on the answer given.
 
 An `items` function that is called by the layout to transform the json of the
 `body` into the object shape needed by the form component.
 
+A `response` function that is called when the question is submitted, where logic
+can be added based on the answer given. See next section:
+
+#### The response()
+
+The `response()` function of each page is a critical representation of the state of
+the questions and answers of that page:
+
+- the questions are captured in the current form or 'translation' as copy may be
+  tweaked from time to time and it's important to record the precise question which
+  was posed
+
+- answers should be 'translated' as needed e.g. to show 'Any other mixed or multiple
+  ethnic background' if that was the label shown against the "other" radio value.
+
+#### Used in the application submission
+
+In CAS1 the `ApplicationController.submit()` sets the read-only finalised version
+of the application (the `document`):
+
+```ts
+application.document = getResponses(application)
+```
+
+which uses the `getResponses()` utility to collate each page's `response()`:
+
+```ts
+getResponses = (formArtifact: FormArtifact): ApplicationOrAssessmentResponse => {
+  const responses = {}
+
+  const formSections = getSections(formArtifact)
+
+  formSections.forEach(section => {
+    section.tasks.forEach(task => {
+      const responsesForTask: Array<PageResponse> = []
+
+      forPagesInTask(formArtifact, task, page => responsesForTask.push(page.response()))
+      responses[task.id] = responsesForTask
+
+    })
+
+  })
+
+  return responses
+}
+```
 
 ### Form views
 

--- a/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
@@ -26,12 +26,12 @@ export default class SubstanceMisusePage extends ApplyPage {
     this.getTextInputByIdAndEnterDetails('substanceMisuseDetail', 'Injects daily')
   }
 
-  nameDrugAndAlcholService = (): void => {
+  nameDrugAndAlcoholService = (): void => {
     this.checkRadioByNameAndValue('engagedWithDrugAndAlcoholService', 'yes')
     this.getTextInputByIdAndEnterDetails('drugAndAlcoholServiceDetail', 'The Drugs Project')
   }
 
-  provideSubsituteMedicationDetails = (): void => {
+  provideSubstituteMedicationDetails = (): void => {
     this.checkRadioByNameAndValue('requiresSubstituteMedication', 'yes')
     this.getTextInputByIdAndEnterDetails('substituteMedicationDetail', 'Methadone')
   }

--- a/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/substanceMisusePage.ts
@@ -19,4 +19,20 @@ export default class SubstanceMisusePage extends ApplyPage {
       }),
     )
   }
+
+  describeIllegalSubstanceUse = (): void => {
+    this.checkRadioByNameAndValue('usesIllegalSubstances', 'yes')
+    this.getTextInputByIdAndEnterDetails('substanceMisuseHistory', 'Heroin user')
+    this.getTextInputByIdAndEnterDetails('substanceMisuseDetail', 'Injects daily')
+  }
+
+  nameDrugAndAlcholService = (): void => {
+    this.checkRadioByNameAndValue('engagedWithDrugAndAlcoholService', 'yes')
+    this.getTextInputByIdAndEnterDetails('drugAndAlcoholServiceDetail', 'The Drugs Project')
+  }
+
+  provideSubsituteMedicationDetails = (): void => {
+    this.checkRadioByNameAndValue('requiresSubstituteMedication', 'yes')
+    this.getTextInputByIdAndEnterDetails('substituteMedicationDetail', 'Methadone')
+  }
 }

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
@@ -72,8 +72,8 @@ context('Visit "Substance misuse" page', () => {
     SubstanceMisusePage.visit(this.application)
     const page = new SubstanceMisusePage(this.application)
     page.describeIllegalSubstanceUse()
-    page.nameDrugAndAlcholService()
-    page.provideSubsituteMedicationDetails()
+    page.nameDrugAndAlcoholService()
+    page.provideSubstituteMedicationDetails()
     page.clickSubmit()
 
     Page.verifyOnPage(PhysicalHealthPage, this.application)

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
@@ -11,8 +11,9 @@
 //  Scenario: view substance misuse questions
 //    Then I see the "substance misuse" page
 //
-//  Scenario: navigate to next page in health needs task
-//    When I continue to the next task / page
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the substance misuse page questions
+//    And I continue to the next task / page
 //    Then I see the "physical health" page
 
 import Page from '../../../../pages/page'
@@ -63,12 +64,16 @@ context('Visit "Substance misuse" page', () => {
     Page.verifyOnPage(SubstanceMisusePage, this.application)
   })
 
-  //  Scenario: navigate to next page in health needs task
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the substance misuse page questions
   //    When I continue to the next task / page
   //    Then I see the "physical health" page
-  it('navigates to the next page (physical health)', function test() {
+  it('navigates to the next page (physical health) when complete', function test() {
     SubstanceMisusePage.visit(this.application)
     const page = new SubstanceMisusePage(this.application)
+    page.describeIllegalSubstanceUse()
+    page.nameDrugAndAlcholService()
+    page.provideSubsituteMedicationDetails()
     page.clickSubmit()
 
     Page.verifyOnPage(PhysicalHealthPage, this.application)

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -59,10 +59,29 @@ describe('SubstanceMisuse', () => {
   })
 
   describe('errors', () => {
-    it('not implemented', () => {
+    describe('when top-level questions are unanswered', () => {
       const page = new SubstanceMisuse({}, application)
 
-      expect(page.errors()).toEqual({})
+      it('includes a validation error for _usesIllegalSubstances_', () => {
+        expect(page.errors()).toHaveProperty(
+          'usesIllegalSubstances',
+          'Confirm whether they take any illegal substances',
+        )
+      })
+
+      it('includes a validation error for _engagedWithDrugAndAlcoholService_', () => {
+        expect(page.errors()).toHaveProperty(
+          'engagedWithDrugAndAlcoholService',
+          'Confirm whether they are engaged with a drug and alcohol service',
+        )
+      })
+
+      it('includes a validation error for _requiresSubstituteMedication_', () => {
+        expect(page.errors()).toHaveProperty(
+          'requiresSubstituteMedication',
+          'Confirm whether they require substitute medication',
+        )
+      })
     })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -105,5 +105,15 @@ describe('SubstanceMisuse', () => {
         })
       })
     })
+
+    describe('when _engagedWithDrugAndAlcoholService_ is YES', () => {
+      const page = new SubstanceMisuse({ engagedWithDrugAndAlcoholService: 'yes' }, application)
+
+      describe('and _drugAndAlcoholServiceDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _drugAndAlcoholServiceDetail_', () => {
+          expect(page.errors()).toHaveProperty('drugAndAlcoholServiceDetail', 'Provide the name of the service')
+        })
+      })
+    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -13,6 +13,40 @@ describe('SubstanceMisuse', () => {
     })
   })
 
+  describe('Questions', () => {
+    const page = new SubstanceMisuse({}, application)
+
+    describe('usesIllegalSubstances', () => {
+      it('has a question', () => {
+        expect(page.questions.usesIllegalSubstances.question).toBeDefined()
+      })
+      it('has two follow-up questions, one with a hint', () => {
+        expect(page.questions.usesIllegalSubstances.substanceMisuseHistory.question).toBeDefined()
+        expect(page.questions.usesIllegalSubstances.substanceMisuseHistory.hint).toBeDefined()
+
+        expect(page.questions.usesIllegalSubstances.substanceMisuseDetail.question).toBeDefined()
+      })
+    })
+
+    describe('engagedWithDrugAndAlcoholService', () => {
+      it('has a question', () => {
+        expect(page.questions.engagedWithDrugAndAlcoholService.question).toBeDefined()
+      })
+      it('has a follow-up question', () => {
+        expect(page.questions.engagedWithDrugAndAlcoholService.drugAndAlcoholServiceDetail.question).toBeDefined()
+      })
+    })
+
+    describe('substituteMedication', () => {
+      it('has a question', () => {
+        expect(page.questions.requiresSubstituteMedication.question).toBeDefined()
+      })
+      it('has a follow-up question', () => {
+        expect(page.questions.requiresSubstituteMedication.substituteMedicationDetail.question).toBeDefined()
+      })
+    })
+  })
+
   itShouldHaveNextValue(new SubstanceMisuse({}, application), 'physical-health')
   itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'taskList')
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -115,5 +115,18 @@ describe('SubstanceMisuse', () => {
         })
       })
     })
+
+    describe('when _requiresSubstituteMedication_ is YES', () => {
+      const page = new SubstanceMisuse({ requiresSubstituteMedication: 'yes' }, application)
+
+      describe('and _substituteMedicationDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _substituteMedicationDetail_', () => {
+          expect(page.errors()).toHaveProperty(
+            'substituteMedicationDetail',
+            'Provide details of their substitute medication',
+          )
+        })
+      })
+    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -51,10 +51,29 @@ describe('SubstanceMisuse', () => {
   itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'taskList')
 
   describe('response', () => {
-    it('not implemented', () => {
-      const page = new SubstanceMisuse({}, application)
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new SubstanceMisuse(
+        {
+          usesIllegalSubstances: 'yes',
+          substanceMisuseHistory: 'Heroin',
+          substanceMisuseDetail: 'Injects daily',
+          engagedWithDrugAndAlcoholService: 'yes',
+          drugAndAlcoholServiceDetail: 'The Drugs Project',
+          requiresSubstituteMedication: 'yes',
+          substituteMedicationDetail: 'Methadone',
+        },
+        application,
+      )
 
-      expect(page.response()).toEqual({})
+      expect(page.response()).toEqual({
+        'Do they take any illegal substances?': 'Yes',
+        'What substances do they take?': 'Heroin',
+        'How often do they take these substances, by what method, and how much?': 'Injects daily',
+        'Are they engaged with a drug and alcohol service?': 'Yes',
+        'Name the drug and alcohol service': 'The Drugs Project',
+        'Do they require any substitute medication for misused substances?': 'Yes',
+        'What substitute medication do they take?': 'Methadone',
+      })
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -83,5 +83,27 @@ describe('SubstanceMisuse', () => {
         )
       })
     })
+
+    describe('when _usesIllegalSubstances_ is YES', () => {
+      const page = new SubstanceMisuse({ usesIllegalSubstances: 'yes' }, application)
+
+      describe('and _substanceMisuseHistory_ is UNANSWERED', () => {
+        it('includes a validation error for _substanceMisuseHistory_', () => {
+          expect(page.errors()).toHaveProperty(
+            'substanceMisuseHistory',
+            'Provide details of their recent history of substance abuse',
+          )
+        })
+      })
+
+      describe('and _substanceMisuseDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _substanceMisuseDetail_', () => {
+          expect(page.errors()).toHaveProperty(
+            'substanceMisuseDetail',
+            'Provide details of how often they take these substances',
+          )
+        })
+      })
+    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -97,6 +97,10 @@ export default class SubstanceMisuse implements TaskListPage {
       errors.requiresSubstituteMedication = `Confirm whether they require substitute medication`
     }
 
+    if (this.body.requiresSubstituteMedication === 'yes' && !this.body.substituteMedicationDetail) {
+      errors.substituteMedicationDetail = 'Provide details of their substitute medication'
+    }
+
     return errors
   }
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -77,6 +77,14 @@ export default class SubstanceMisuse implements TaskListPage {
       errors.usesIllegalSubstances = `Confirm whether they take any illegal substances`
     }
 
+    if (this.body.usesIllegalSubstances === 'yes' && !this.body.substanceMisuseHistory) {
+      errors.substanceMisuseHistory = 'Provide details of their recent history of substance abuse'
+    }
+
+    if (this.body.usesIllegalSubstances === 'yes' && !this.body.substanceMisuseDetail) {
+      errors.substanceMisuseDetail = 'Provide details of how often they take these substances'
+    }
+
     if (!this.body.engagedWithDrugAndAlcoholService) {
       errors.engagedWithDrugAndAlcoholService = `Confirm whether they are engaged with a drug and alcohol service`
     }

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -1,5 +1,6 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2Application as Application } from '@approved-premises/api'
+import { sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 
@@ -105,7 +106,21 @@ export default class SubstanceMisuse implements TaskListPage {
   }
 
   response() {
-    const response = {}
+    const response = {
+      [this.questions.usesIllegalSubstances.question]: sentenceCase(this.body.usesIllegalSubstances),
+      [this.questions.usesIllegalSubstances.substanceMisuseHistory.question]: this.body.substanceMisuseHistory,
+      [this.questions.usesIllegalSubstances.substanceMisuseDetail.question]: this.body.substanceMisuseDetail,
+
+      [this.questions.engagedWithDrugAndAlcoholService.question]: sentenceCase(
+        this.body.engagedWithDrugAndAlcoholService,
+      ),
+      [this.questions.engagedWithDrugAndAlcoholService.drugAndAlcoholServiceDetail.question]:
+        this.body.drugAndAlcoholServiceDetail,
+
+      [this.questions.requiresSubstituteMedication.question]: sentenceCase(this.body.requiresSubstituteMedication),
+      [this.questions.requiresSubstituteMedication.substituteMedicationDetail.question]:
+        this.body.substituteMedicationDetail,
+    }
 
     return response
   }

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -1,16 +1,57 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2Application as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 
-type SubstanceMisuseBody = Record<string, never>
+type SubstanceMisuseBody = {
+  usesIllegalSubstances: YesOrNo
+  substanceMisuseHistory: string
+  substanceMisuseDetail: string
+  engagedWithDrugAndAlcoholService: YesOrNo
+  drugAndAlcoholServiceDetail: string
+  requiresSubstituteMedication: YesOrNo
+  substituteMedicationDetail: string
+}
 
 @Page({
   name: 'substance-misuse',
-  bodyProperties: [],
+  bodyProperties: [
+    'usesIllegalSubstances',
+    'substanceMisuseHistory',
+    'substanceMisuseDetail',
+    'engagedWithDrugAndAlcoholService',
+    'drugAndAlcoholServiceDetail',
+    'requiresSubstituteMedication',
+    'substituteMedicationDetail',
+  ],
 })
 export default class SubstanceMisuse implements TaskListPage {
   title = `Health needs for ${this.application.person.name}`
+
+  questions = {
+    usesIllegalSubstances: {
+      question: 'Do they take any illegal substances?',
+      substanceMisuseHistory: {
+        question: 'What substances do they take?',
+        hint: 'Please describe their recent history of substance misuse.',
+      },
+      substanceMisuseDetail: {
+        question: 'How often do they take these substances, by what method, and how much?',
+      },
+    },
+    engagedWithDrugAndAlcoholService: {
+      question: 'Are they engaged with a drug and alcohol service?',
+      drugAndAlcoholServiceDetail: {
+        question: 'Name the drug and alcohol service',
+      },
+    },
+    requiresSubstituteMedication: {
+      question: 'Do they require any substitute medication for misused substances?',
+      substituteMedicationDetail: {
+        question: 'What substitute medication do they take?',
+      },
+    },
+  }
 
   body: SubstanceMisuseBody
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -73,6 +73,18 @@ export default class SubstanceMisuse implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
+    if (!this.body.usesIllegalSubstances) {
+      errors.usesIllegalSubstances = `Confirm whether they take any illegal substances`
+    }
+
+    if (!this.body.engagedWithDrugAndAlcoholService) {
+      errors.engagedWithDrugAndAlcoholService = `Confirm whether they are engaged with a drug and alcohol service`
+    }
+
+    if (!this.body.requiresSubstituteMedication) {
+      errors.requiresSubstituteMedication = `Confirm whether they require substitute medication`
+    }
+
     return errors
   }
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -89,6 +89,10 @@ export default class SubstanceMisuse implements TaskListPage {
       errors.engagedWithDrugAndAlcoholService = `Confirm whether they are engaged with a drug and alcohol service`
     }
 
+    if (this.body.engagedWithDrugAndAlcoholService === 'yes' && !this.body.drugAndAlcoholServiceDetail) {
+      errors.drugAndAlcoholServiceDetail = 'Provide the name of the service'
+    }
+
     if (!this.body.requiresSubstituteMedication) {
       errors.requiresSubstituteMedication = `Confirm whether they require substitute medication`
     }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,9 +1,17 @@
 import qs, { IStringifyOptions } from 'qs'
+import Case from 'case'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
 const isBlank = (str: string): boolean => !str || /^\s*$/.test(str)
+
+/**
+ * Converts a string from any case to Sentence case
+ * @param string string to be converted.
+ * @returns name converted to sentence case.
+ */
+export const sentenceCase = (string: string) => Case.sentence(string)
 
 /**
  * Converts a name (first name, last name, middle name, etc.) to proper case equivalent, handling double-barreled names

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -3,8 +3,148 @@
 
 {% block questions %}
 
-  <p class="govuk-body">
-    Substance misuse page
-  </p>
+  {% set illegalSubstancesFollowUp %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'substanceMisuseHistory',
+          label: {
+            text: page.questions.usesIllegalSubstances.substanceMisuseHistory.question,
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: page.questions.usesIllegalSubstances.substanceMisuseHistory.hint
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'substanceMisuseDetail',
+          label: {
+            text: page.questions.usesIllegalSubstances.substanceMisuseDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {% set drugAndAlcoholFollowUp %}
+  {{
+      formPageInput(
+        {
+          fieldName: 'drugAndAlcoholServiceDetail',
+          label: {
+            text: page.questions.engagedWithDrugAndAlcoholService.drugAndAlcoholServiceDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {% set substituteMedicationFollowUp %}
+  {{
+      formPageInput(
+        {
+          fieldName: 'substituteMedicationDetail',
+          label: {
+            text: page.questions.substituteMedication.substituteMedicationDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "usesIllegalSubstances",
+        fieldset: {
+          legend: {
+            text: page.questions.usesIllegalSubstances.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: illegalSubstancesFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "engagedWithDrugAndAlcoholService",
+        fieldset: {
+          legend: {
+            text: page.questions.engagedWithDrugAndAlcoholService.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: drugAndAlcoholFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "requiresSubstituteMedication",
+        fieldset: {
+          legend: {
+            text: page.questions.requiresSubstituteMedication.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: substituteMedicationFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
 
 {% endblock %}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
+{% from "../../components/formFields/form-page-text-area/macro.njk" import formPageTextArea %}
+{% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}


### PR DESCRIPTION
This PR implements the first real form page in the "Health needs" task: "Substance misuse". (The initial page is a guidance page, and is not included in the left hand navigation).

See [Trello 330](https://trello.com/c/Qg994Nnx/330-health-subsection-substance-misuse)

<img width="884" alt="substance_misuse" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/dd51cb49-184b-4f4a-a1cd-d49d10b60f17">
