### PR TITLE
add intial PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Context
+
+<!-- Is there a Trello ticket you can link to? -->
+<!-- Do you need to add any environment variables? -->
+<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
+
+# Changes in this PR
+
+## Screenshots of UI changes
+
+### Before
+
+### After
+
+# Release checklist
+
+As part of our continuous deployment strategy we must ensure that this work is
+ready to be released at any point. Before merging to `main` we must first
+confirm:
+
+## Pre merge checklist
+
+- [ ] Are any changes required to the e2e tests?
+- [ ] If you've added a new route, have you added a new
+  `auditEvent`? (see `server/routes/apply.ts` for examples)
+- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
+- [ ] Are there any data migrations required. Automatic or manual?
+- [ ] Does this rely on changes being deployed to the CAS API?
+
+## Post merge checklist
+
+Once we've merged it will be auto-deployed to the dev environment.
+
+[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).
+
+Should a release fail at any step, you as the author should now lead the work to
+fix it as soon as possible.


### PR DESCRIPTION
A PR to add a default template for our PRs. 

* I wanted to make sure that we don't forget to add `auditEvent`s when we add a new route - let me know if any more docs are required for that.
* Copied mostly from CAS1 but with some changes for us because we don't have preprod/prod environment.
