### PR TITLE
Upgrade Cypress/request against vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "audit-ci": "^6.6.1",
         "concurrently": "^8.0.1",
         "cookie-session": "^2.0.0",
-        "cypress": "^12.17.1",
+        "cypress": "^12.17.4",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv": "^16.0.3",
         "eslint": "^8.38.0",
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -4540,9 +4540,9 @@
       "dev": true
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -6200,9 +6200,9 @@
       }
     },
     "node_modules/common-tags": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
@@ -6698,9 +6698,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
       "dev": true
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "audit-ci": "^6.6.1",
     "concurrently": "^8.0.1",
     "cookie-session": "^2.0.0",
-    "cypress": "^12.17.1",
+    "cypress": "^12.17.4",
     "cypress-multi-reporters": "^1.6.3",
     "dotenv": "^16.0.3",
     "eslint": "^8.38.0",
@@ -215,6 +215,7 @@
     "typescript": "^5.1.6"
   },
   "overrides": {
-    "tough-cookie": "^4.1.3"
+    "tough-cookie": "^4.1.3",
+    "@cypress/request": "3.0.0"
   }
 }


### PR DESCRIPTION
In response to our security audit script we:

- manually override @cypress/request to v 3.0.0
- upgrade cypress to 12.17.4

Ref:
https://github.com/advisories/GHSA-p8p7-x288-28g6