### PR TITLE
Mark application as submitted

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,4 +1,4 @@
-import type { Cas2Application as Application } from '@approved-premises/api'
+import type { Cas2Application as Application, Cas2Application } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 
 export default {
@@ -59,6 +59,17 @@ export default {
         }
         `,
         transformers: ['response-template'],
+      },
+    }),
+  stubApplicationSubmit: (args: { application: Cas2Application }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/applications/${args.application.id}/submission`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       },
     }),
 }

--- a/integration_tests/pages/apply/applicationSubmittedPage.ts
+++ b/integration_tests/pages/apply/applicationSubmittedPage.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class ApplicationSubmittedPage extends Page {
+  constructor() {
+    super('Application complete')
+  }
+}

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -1,9 +1,17 @@
 import Page from '../page'
 import Apply from '../../../server/form-pages/apply'
+import paths from '../../../server/paths/apply'
+import { Cas2Application } from '../../../server/@types/shared/models/Cas2Application'
 
 export default class TaskListPage extends Page {
   constructor() {
     super('CAS 2: Refer for Accommodation')
+  }
+
+  static visit(application: Cas2Application): TaskListPage {
+    cy.visit(paths.applications.show({ id: application.id }))
+
+    return new TaskListPage()
   }
 
   shouldShowTasksWithinTheirSections = (): void => {

--- a/integration_tests/tests/apply/submit.cy.ts
+++ b/integration_tests/tests/apply/submit.cy.ts
@@ -1,0 +1,46 @@
+//  Feature: Referrer submits an application
+//
+//  Scenario: submit an application
+//    Given I am logged in
+//    And I have created an appliation
+//    And I am on the Task List
+//    When I click submit
+//    Then I should see a confirmation page
+
+import ApplicationSubmittedPage from '../../pages/apply/applicationSubmittedPage'
+import Page from '../../pages/page'
+import TaskListPage from '../../pages/apply/taskListPage'
+import { applicationFactory } from '../../../server/testutils/factories'
+
+context('Applications dashboard', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    // I have created an application
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({ id: 'abc123', data: applicationData, status: 'inProgress' })
+      cy.wrap(application).as('application')
+    })
+
+    // Given I am logged in
+    cy.signIn()
+  })
+
+  //  Scenario: submit an application
+  // ----------------------------------------------
+  it('shows the dashboard', function test() {
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationSubmit', { application: this.application })
+
+    // I visit the Task List Page
+    const page = TaskListPage.visit(this.application)
+
+    // I click submit
+    page.clickSubmit()
+
+    // Then I see a confirmation page
+    Page.verifyOnPage(ApplicationSubmittedPage)
+  })
+})

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -178,6 +178,7 @@ export type { SortOrder } from './models/SortOrder';
 export type { StaffMember } from './models/StaffMember';
 export type { SubmitApplication } from './models/SubmitApplication';
 export type { SubmitApprovedPremisesApplication } from './models/SubmitApprovedPremisesApplication';
+export type { SubmitCas2Application } from './models/SubmitCas2Application';
 export type { SubmitPlacementApplication } from './models/SubmitPlacementApplication';
 export type { SubmitTemporaryAccommodationApplication } from './models/SubmitTemporaryAccommodationApplication';
 export type { SupervisingOfficer } from './models/SupervisingOfficer';

--- a/server/@types/shared/models/SubmitCas2Application.ts
+++ b/server/@types/shared/models/SubmitCas2Application.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { SubmitApplication } from './SubmitApplication';
+
+export type SubmitCas2Application = SubmitApplication;
+

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -8,9 +8,11 @@ import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationsController from './applicationsController'
 import { PersonService, ApplicationService, TaskListService } from '../../services'
 import paths from '../../paths/apply'
+import { getResponses } from '../../utils/applications/getResponses'
 
 jest.mock('../../utils/validation')
 jest.mock('../../services/taskListService')
+jest.mock('../../utils/applications/getResponses')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -192,6 +194,21 @@ describe('applicationsController', () => {
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
       })
+    })
+  })
+
+  describe('submit', () => {
+    it('renders the application submission confirmation page', async () => {
+      const application = applicationFactory.build()
+      request.params.id = 'some-id'
+      applicationService.findApplication.mockResolvedValue(application)
+
+      const requestHandler = applicationsController.submit()
+      await requestHandler(request, response, next)
+
+      expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
+      expect(getResponses).toHaveBeenCalledWith(application)
+      expect(response.render).toHaveBeenCalledWith('applications/confirm', { pageHeading: 'Application confirmation' })
     })
   })
 })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/applications/utils'
 import TaskListService from '../../services/taskListService'
 import paths from '../../paths/apply'
+import { getResponses } from '../../utils/applications/getResponses'
 
 export default class ApplicationsController {
   constructor(
@@ -81,6 +82,26 @@ export default class ApplicationsController {
         ...userInput,
         pageHeading: "Enter the person's CRN",
       })
+    }
+  }
+
+  submit(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+      application.document = getResponses(application)
+
+      // TODO: validate that the user has confirmed information is complete
+      // if (req.body?.confirmation !== 'submit') {
+      //   addErrorMessageToFlash(
+      //     req,
+      //     'You must confirm the information provided is complete, accurate and up to date.',
+      //     'confirmation',
+      //   )
+      //   return res.redirect(paths.applications.show({ id: application.id }))
+      // }
+
+      await this.applicationService.submit(req.user.token, application)
+      return res.render('applications/confirm', { pageHeading: 'Application confirmation' })
     }
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,4 +1,4 @@
-import { UpdateApplication } from '@approved-premises/api'
+import { SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
 import ApplicationClient from './applicationClient'
 import { applicationFactory } from '../testutils/factories'
 import paths from '../paths/api'
@@ -122,6 +122,34 @@ describeClient('ApplicationClient', provider => {
       const result = await applicationClient.update(application.id, data)
 
       expect(result).toEqual(application)
+    })
+  })
+
+  describe('submit', () => {
+    it('should submit an application', async () => {
+      const application = applicationFactory.build()
+      const data = {
+        translatedDocument: application.document,
+        type: 'CAS2',
+      } as SubmitCas2Application
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to submit an application',
+        withRequest: {
+          method: 'POST',
+          path: paths.applications.submission({ id: application.id }),
+          body: data,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await applicationClient.submit(application.id, data)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,9 @@
-import { Cas2Application as Application, Cas2ApplicationSummary, UpdateApplication } from '@approved-premises/api'
+import {
+  Cas2Application as Application,
+  Cas2ApplicationSummary,
+  SubmitApplication,
+  UpdateApplication,
+} from '@approved-premises/api'
 import { UpdateCas2Application } from '../@types/shared/models/UpdateCas2Application'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -33,5 +38,12 @@ export default class ApplicationClient {
       path: paths.applications.update({ id: applicationId }),
       data: { ...updateData, type: 'CAS2' } as UpdateApplication,
     })) as Application
+  }
+
+  async submit(applicationId: string, submissionData: SubmitApplication): Promise<void> {
+    await this.restClient.post({
+      path: paths.applications.submission({ id: applicationId }),
+      data: { ...submissionData, type: 'CAS2' },
+    })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -18,5 +18,6 @@ export default {
     index: applicationsPath,
     show: singleApplicationPath,
     update: singleApplicationPath,
+    submission: singleApplicationPath.path('submission'),
   },
 }

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -14,6 +14,7 @@ const paths = {
       find: peoplePath.path('find'),
     },
     show: singleApplicationPath,
+    submission: singleApplicationPath.path('submission'),
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -10,13 +10,14 @@ import { actions } from './utils'
 
 export default function applyRoutes(controllers: Controllers, router: Router, services: Services): Router {
   const { pages } = Apply
-  const { get, put } = actions(router, services.auditService)
+  const { get, post, put } = actions(router, services.auditService)
 
   const { applicationsController, pagesController } = controllers
 
   get(paths.applications.new.pattern, applicationsController.new(), { auditEvent: 'VIEW_APPLICATION_NEW' })
   get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'VIEW_APPLICATIONS_LIST' })
   get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION_START' })
+  post(paths.applications.submission.pattern, applicationsController.submit(), { auditEvent: 'SUBMIT_APPLICATION' })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { Request } from 'express'
+import { SubmitCas2Application } from '@approved-premises/api'
 import { UpdateCas2Application } from 'server/@types/shared/models/UpdateCas2Application'
 import { DataServices, GroupedApplications, TaskListErrors } from '@approved-premises/ui'
 import ApplicationService from './applicationService'
@@ -7,7 +8,7 @@ import ApplicationClient from '../data/applicationClient'
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
 import { getBody, getPageName, getTaskName } from '../form-pages/utils'
 import { ValidationError } from '../utils/errors'
-import { getApplicationUpdateData } from '../utils/applications/getApplicationData'
+import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
 
 import { applicationFactory, applicationSummaryFactory } from '../testutils/factories'
 
@@ -236,6 +237,22 @@ describe('ApplicationService', () => {
       await service.initializePage(Page, request, dataServices)
 
       expect(Page).toHaveBeenCalledWith(request.body, application, 'previous-page-name')
+    })
+  })
+
+  describe('submit', () => {
+    it('calls the submit method', async () => {
+      const application = applicationFactory.build()
+      const applicationData = createMock<SubmitCas2Application>()
+      const token = 'SOME_TOKEN'
+
+      applicationClient.submit.mockImplementation(() => Promise.resolve())
+      ;(getApplicationSubmissionData as jest.Mock).mockReturnValue(applicationData)
+
+      await service.submit(token, application)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.submit).toHaveBeenCalledWith(application.id, applicationData)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,9 +1,9 @@
 import type { Request } from 'express'
-import { Cas2Application as Application } from '@approved-premises/api'
+import { Cas2Application as Application, Cas2Application } from '@approved-premises/api'
 import type { DataServices, GroupedApplications } from '@approved-premises/ui'
 import { getBody, getPageName, getTaskName } from '../form-pages/utils'
 import type { ApplicationClient, RestClientBuilder } from '../data'
-import { getApplicationUpdateData } from '../utils/applications/getApplicationData'
+import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
 import { ValidationError } from '../utils/errors'
 
@@ -78,5 +78,11 @@ export default class ApplicationService {
       : new Page(body, application, request.session.previousPage)
 
     return page
+  }
+
+  async submit(token: string, application: Cas2Application) {
+    const client = this.applicationClientFactory(token)
+
+    await client.submit(application.id, getApplicationSubmissionData(application))
   }
 }

--- a/server/utils/applications/checkResponsesForPagesInTask.test.ts
+++ b/server/utils/applications/checkResponsesForPagesInTask.test.ts
@@ -1,0 +1,133 @@
+import Apply from '../../form-pages/apply'
+import { applicationFactory } from '../../testutils/factories'
+import { checkResponsesForPagesInTask } from './checkResponsesForPagesInTask'
+
+const FirstApplyPage = jest.fn()
+const SecondApplyPage = jest.fn()
+
+jest.mock('../../form-pages/apply', () => {
+  return {
+    pages: { 'basic-information': {}, 'type-of-ap': {} },
+  }
+})
+
+const applySection1Task1 = {
+  id: 'first-apply-section-task-1',
+  title: 'First Apply section, task 1',
+  actionText: '',
+  pages: {
+    first: FirstApplyPage,
+    second: SecondApplyPage,
+  },
+}
+const applySection1Task2 = {
+  id: 'first-apply-section-task-2',
+  title: 'First Apply section, task 2',
+  actionText: '',
+  pages: {},
+}
+
+const applySection2Task1 = {
+  id: 'second-apply-section-task-1',
+  title: 'Second Apply section, task 1',
+  actionText: '',
+  pages: {},
+}
+
+const applySection2Task2 = {
+  id: 'second-apply-section-task-2',
+  title: 'Second Apply section, task 2',
+  actionText: '',
+  pages: {},
+}
+
+const applySection1 = {
+  name: 'first-apply-section',
+  title: 'First Apply section',
+  tasks: [applySection1Task1, applySection1Task2],
+}
+
+const applySection2 = {
+  name: 'second-apply-section',
+  title: 'Second Apply section',
+  tasks: [applySection2Task1, applySection2Task2],
+}
+
+Apply.sections = [applySection1, applySection2]
+
+Apply.pages['first-apply-section-task-1'] = {
+  first: FirstApplyPage,
+  second: SecondApplyPage,
+}
+
+describe('forPagesInTask', () => {
+  it('iterates through the pages of a task', () => {
+    const firstApplyPageInstance = {
+      next: () => 'second',
+    }
+    const secondApplyPageInstance = {
+      next: () => '',
+    }
+
+    FirstApplyPage.mockReturnValue(firstApplyPageInstance)
+    SecondApplyPage.mockReturnValue(secondApplyPageInstance)
+    const spy = jest.fn()
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: { foo: 'bar' }, second: { bar: 'foo' } },
+      },
+    })
+
+    checkResponsesForPagesInTask(application, applySection1Task1, spy)
+
+    expect(spy).toHaveBeenCalledWith(firstApplyPageInstance, 'first')
+    expect(spy).toHaveBeenCalledWith(secondApplyPageInstance, 'second')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips tasks that are not part of the user journey', () => {
+    const firstApplyPageInstance = {
+      next: () => '',
+    }
+
+    FirstApplyPage.mockReturnValue(firstApplyPageInstance)
+    const spy = jest.fn()
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: { foo: 'bar' }, second: { bar: 'foo' } },
+      },
+    })
+
+    checkResponsesForPagesInTask(application, applySection1Task1, spy)
+
+    expect(spy).toHaveBeenCalledWith(firstApplyPageInstance, 'first')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips pages for which there is no data in the application', () => {
+    const applyPageWithNoData = {
+      next: () => '',
+    }
+    const secondApplyPageInstance = {
+      next: () => '',
+    }
+
+    FirstApplyPage.mockReturnValue(applyPageWithNoData)
+    SecondApplyPage.mockReturnValue(secondApplyPageInstance)
+    const spy = jest.fn()
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: undefined, second: { bar: 'foo' } },
+      },
+    })
+
+    checkResponsesForPagesInTask(application, applySection1Task1, spy)
+
+    expect(spy).not.toHaveBeenCalledWith(applyPageWithNoData)
+    expect(spy).toHaveBeenCalledWith(secondApplyPageInstance, 'second')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/utils/applications/checkResponsesForPagesInTask.ts
+++ b/server/utils/applications/checkResponsesForPagesInTask.ts
@@ -1,0 +1,31 @@
+import { FormArtifact, UiTask } from '../../@types/ui'
+import { getPage } from './getPage'
+import TaskListPage from '../../form-pages/taskListPage'
+
+export const checkResponsesForPagesInTask = (
+  formArtifact: FormArtifact,
+  task: UiTask,
+  callback: (page: TaskListPage, pageName: string) => void,
+): void => {
+  const pageNames = Object.keys(task.pages)
+  let pageName = pageNames?.[0]
+
+  while (pageName && pageName !== 'check-your-answers') {
+    const Page = getPage(task.id, pageName, 'applications')
+    const body = formArtifact?.data?.[task.id]?.[pageName]
+
+    if (body) {
+      // if the user has answered this page, call the callback
+      const page = new Page(body, formArtifact)
+      callback(page, pageName)
+      // skip to the next page
+      pageName = page.next()
+    } else if (pageNames.indexOf(pageName) + 1 < pageNames.length) {
+      // if there are more pages left in the task, skip to the next one
+      pageName = pageNames.at(pageNames.indexOf(pageName) + 1)
+    } else {
+      // break out of while loop
+      pageName = ''
+    }
+  }
+}

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,5 +1,5 @@
 import { applicationFactory } from '../../testutils/factories'
-import { getApplicationUpdateData } from './getApplicationData'
+import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 
 describe('getApplicationUpdateData', () => {
   it('returns the application data', () => {
@@ -7,6 +7,16 @@ describe('getApplicationUpdateData', () => {
     expect(getApplicationUpdateData(mockApplication)).toEqual({
       type: 'CAS2',
       data: mockApplication.data,
+    })
+  })
+})
+
+describe('getApplicationSubmissionData', () => {
+  it('returns the submission data', () => {
+    const mockApplication = applicationFactory.build()
+    expect(getApplicationSubmissionData(mockApplication)).toEqual({
+      type: 'CAS2',
+      translatedDocument: mockApplication.document,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,8 +1,15 @@
-import { Cas2Application as Application, UpdateApplication } from '@approved-premises/api'
+import { Cas2Application as Application, SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
     type: 'CAS2',
     data: application.data,
+  }
+}
+
+export const getApplicationSubmissionData = (application: Application): SubmitCas2Application => {
+  return {
+    translatedDocument: application.document,
+    type: 'CAS2',
   }
 }

--- a/server/utils/applications/getResponses.test.ts
+++ b/server/utils/applications/getResponses.test.ts
@@ -1,0 +1,82 @@
+import Apply from '../../form-pages/apply'
+import { applicationFactory } from '../../testutils/factories'
+import { getResponses } from './getResponses'
+
+const FirstApplyPage = jest.fn()
+const SecondApplyPage = jest.fn()
+
+const applySection1Task1 = {
+  id: 'first-apply-section-task-1',
+  title: 'First Apply section, task 1',
+  actionText: '',
+  pages: {
+    first: FirstApplyPage,
+    second: SecondApplyPage,
+  },
+}
+const applySection1Task2 = {
+  id: 'first-apply-section-task-2',
+  title: 'First Apply section, task 2',
+  actionText: '',
+  pages: {},
+}
+
+const applySection2Task1 = {
+  id: 'second-apply-section-task-1',
+  title: 'Second Apply section, task 1',
+  actionText: '',
+  pages: {},
+}
+
+const applySection2Task2 = {
+  id: 'second-apply-section-task-2',
+  title: 'Second Apply section, task 2',
+  actionText: '',
+  pages: {},
+}
+
+const applySection1 = {
+  name: 'first-apply-section',
+  title: 'First Apply section',
+  tasks: [applySection1Task1, applySection1Task2],
+}
+
+const applySection2 = {
+  name: 'second-apply-section',
+  title: 'Second Apply section',
+  tasks: [applySection2Task1, applySection2Task2],
+}
+
+Apply.sections = [applySection1, applySection2]
+
+Apply.pages['first-apply-section-task-1'] = {
+  first: FirstApplyPage,
+  second: SecondApplyPage,
+}
+
+describe('getResponses', () => {
+  it('returns the responses from all answered questions', () => {
+    FirstApplyPage.mockReturnValue({
+      response: () => ({ foo: 'bar' }),
+      next: () => 'second',
+    })
+
+    SecondApplyPage.mockReturnValue({
+      response: () => ({ bar: 'foo' }),
+      next: () => '',
+    })
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: { foo: 'bar' }, second: { bar: 'foo' } },
+      },
+    })
+
+    expect(getResponses(application)).toEqual({
+      'first-apply-section-task-1': [{ foo: 'bar' }, { bar: 'foo' }],
+      'first-apply-section-task-2': [],
+      'second-apply-section-task-1': [],
+      'second-apply-section-task-2': [],
+    })
+  })
+})

--- a/server/utils/applications/getResponses.ts
+++ b/server/utils/applications/getResponses.ts
@@ -1,0 +1,23 @@
+import Apply from '../../form-pages/apply'
+import { FormArtifact, PageResponse } from '../../@types/ui'
+import { checkResponsesForPagesInTask } from './checkResponsesForPagesInTask'
+import { ApplicationOrAssessmentResponse } from './utils'
+
+export const getResponses = (formArtifact: FormArtifact): ApplicationOrAssessmentResponse => {
+  const responses = {}
+
+  const formSections = Apply.sections
+
+  formSections.forEach(section => {
+    section.tasks.forEach(task => {
+      const responsesForTask: Array<PageResponse> = []
+
+      // add answers from each page in the task to list of responses
+      checkResponsesForPagesInTask(formArtifact, task, page => responsesForTask.push(page.response()))
+
+      responses[task.id] = responsesForTask
+    })
+  })
+
+  return responses
+}

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -1,4 +1,4 @@
-import type { FormPages, JourneyType } from '@approved-premises/ui'
+import type { FormPages, JourneyType, PageResponse } from '@approved-premises/ui'
 import type { Cas2Application as Application } from '@approved-premises/api'
 import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
@@ -25,3 +25,5 @@ export const eligibilityIsDenied = (application: Application): boolean => {
 const eligibilityAnswer = (application: Application): string => {
   return application.data?.['confirm-eligibility']?.['confirm-eligibility']?.isEligible
 }
+
+export type ApplicationOrAssessmentResponse = Record<string, Array<PageResponse>>

--- a/server/views/applications/confirm.njk
+++ b/server/views/applications/confirm.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+                titleText: "Application complete"
+            }) }}
+
+            {{ govukButton({
+                text: "Back to dashboard",
+                href: paths.applications.index()
+                })
+            }}
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/applications/taskList.njk
+++ b/server/views/applications/taskList.njk
@@ -20,32 +20,43 @@
     {{ showErrorSummary(errorSummary) }}
 
     <div class="govuk-grid-column-two-thirds">
-      <ol class="app-task-list">
-        {% include '../partials/taskListItems.njk' %}
+      <form action="{{ paths.applications.submission({id: application.id}) }}" method="post">
+        <ol class="app-task-list">
+          {% include '../partials/taskListItems.njk' %}
 
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">
-              {{ (taskList.sections | length) + 1 }}.
-            </span>
-            Submit your application
-          </h2>
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">
+                {{ (taskList.sections | length) + 1 }}.
+              </span>
+              Submit your application
+            </h2>
 
-          {{
-            govukCheckboxes({
-            idPrefix: "confirmation",
-            name: "confirmation",
-            errorMessage: errorObject,
-            items: [
-            {
-            value: "submit",
-            text: "I confirm the information provided is complete, accurate and up to date."
-            }
-            ]
-            })
-          }}
-        </li>
-      </ol>
+            {{
+              govukCheckboxes({
+              idPrefix: "confirmation",
+              name: "confirmation",
+              errorMessage: errorObject,
+              items: [
+              {
+              value: "submit",
+              text: "I confirm the information provided is complete, accurate and up to date."
+              }
+              ]
+              })
+            }}
+
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+            {{
+              govukButton({
+                text: "Submit application",
+                preventDoubleClick: true
+              })
+            }}
+          </li>
+        </ol>
+      </form>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
API PR here: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/895 

We would like users to be able to mark applications as submitted - this is a first pass at the very minimal functionality to allow users to do this. Does not include validating the application is complete, error handling or correct design for the confirmation page. 

![Screenshot 2023-08-18 at 11 49 05](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/22ddccfb-982c-4c92-bd9b-6a07e32b4bc1)


![Screenshot 2023-08-18 at 11 49 18](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/1ff24fa0-eebe-4951-a19f-c90b166848e1)


