### PR TITLE
"Health needs" task: mental health page

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/mentalHealthPage.ts
@@ -1,7 +1,7 @@
 import { Cas2Application as Application } from '../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../applyPage'
 import paths from '../../../../server/paths/apply'
-import { pageIsActiveInNavigation } from './utils'
+import { pageIsActiveInNavigation, fieldIsOptional } from './utils'
 
 export default class MentalHealthPage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -34,6 +34,7 @@ export default class MentalHealthPage extends ApplyPage {
     this.checkRadioByNameAndValue('hasPrescribedMedication', 'yes')
     this.checkRadioByNameAndValue('isInPossessionOfMeds', 'no')
     this.getTextInputByIdAndEnterDetails('medicationDetail', 'Amitriptyline')
+    fieldIsOptional('medicationIssues')
     this.getTextInputByIdAndEnterDetails('medicationIssues', 'Sometimes fails to take pills')
   }
 }

--- a/integration_tests/pages/apply/risks-and-needs/utils.ts
+++ b/integration_tests/pages/apply/risks-and-needs/utils.ts
@@ -1,3 +1,7 @@
 export const pageIsActiveInNavigation = (linkText: string): void => {
   cy.get('.moj-side-navigation__item--active a').contains(linkText)
 }
+
+export const fieldIsOptional = (labelId: string): void => {
+  cy.get(`label[for="${labelId}"]`).contains('(optional)')
+}

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
@@ -43,6 +43,9 @@ describe('MentalHealth', () => {
         expect(page.questions.hasPrescribedMedication.medicationDetail.question).toBeDefined()
         expect(page.questions.hasPrescribedMedication.medicationIssues.question).toBeDefined()
       })
+      it('has one optional question about issues with medication', () => {
+        expect(page.questions.hasPrescribedMedication.medicationIssues.optional).toBeTruthy()
+      })
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.test.ts
@@ -132,7 +132,7 @@ describe('MentalHealth', () => {
 
       describe('and _medicationDetail_ is UNANSWERED', () => {
         it('includes a validation error for _medicationDetail_', () => {
-          expect(page.errors()).toHaveProperty('medicationDetail', 'List their medication')
+          expect(page.errors()).toHaveProperty('medicationDetail', 'List their mental health medication')
         })
       })
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
@@ -103,7 +103,7 @@ export default class MentalHealth implements TaskListPage {
       }
 
       if (!this.body.medicationDetail) {
-        errors.medicationDetail = 'List their medication'
+        errors.medicationDetail = 'List their mental health medication'
       }
     }
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/mentalHealth.ts
@@ -54,6 +54,7 @@ export default class MentalHealth implements TaskListPage {
       },
       medicationIssues: {
         question: 'Please list any issues they have with taking their medication',
+        optional: true,
       },
     },
   }

--- a/server/views/applications/pages/health-needs/mental-health.njk
+++ b/server/views/applications/pages/health-needs/mental-health.njk
@@ -76,6 +76,7 @@
           fieldName: 'medicationIssues',
           label: {
             text: page.questions.hasPrescribedMedication.medicationIssues.question,
+            optional: page.questions.hasPrescribedMedication.medicationIssues.optional,
             classes: "govuk-label--s"
           }
         },

--- a/server/views/components/formFields/form-page-text-area/macro.njk
+++ b/server/views/components/formFields/form-page-text-area/macro.njk
@@ -1,11 +1,28 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% macro formPageTextArea(params, context) %}
+
+  {% set labelText = params.label.text %}
+  {% if params.label.optional %}
+    {% set labelText = params.label.text + ' (optional)' %}
+  {% endif %}
+
   {{
       govukTextarea(
         mergeObjects(
           params,
-          { id: params.fieldName, name: params.fieldName, errorMessage: context.errors[params.fieldName], value: context[params.fieldName] }
+          {
+            label: mergeObjects(
+              params.label,
+              {
+                text: labelText
+              }
+            ),
+            id: params.fieldName,
+            name: params.fieldName,
+            errorMessage: context.errors[params.fieldName],
+            value: context[params.fieldName]
+          }
         )
       )
   }}


### PR DESCRIPTION
Tweaks to the mental health page

See individual commits:

1) adds a mechanism to add the "(optional)" flag to a text area's label

2) tweak to an error message

![mental_health_tweaked](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/92e3e3ce-3f69-4036-9bde-e37acd7dfeec)
