### PR TITLE
Switch to IRSA for AWS authentication

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -1,6 +1,7 @@
 ---
 generic-service:
   nameOverride: hmpps-community-accommodation-tier-2-ui
+  serviceAccountName: hmpps-community-accommodation-api-service-account
 
   replicaCount: 4
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,8 +20,6 @@ generic-service:
 
   namespace_secrets:
     sqs-hmpps-audit-secret:
-      AUDIT_SQS_ACCESS_KEY_ID: "access_key_id"
-      AUDIT_SQS_SECRET_ACCESS_KEY: "secret_access_key"
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -36,8 +36,6 @@ export interface ApiConfig {
 
 export interface AuditConfig {
   region: string
-  accessKeyId: string
-  secretAccessKey: string
   queueUrl: string
   serviceName: string
   logErrors: boolean
@@ -95,8 +93,6 @@ export default {
     },
     audit: {
       region: get('AUDIT_SQS_REGION', 'eu-west-2'),
-      accessKeyId: get('AUDIT_SQS_ACCESS_KEY_ID', ''),
-      secretAccessKey: get('AUDIT_SQS_SECRET_ACCESS_KEY', ''),
       queueUrl: get('AUDIT_SQS_QUEUE_URL', ''),
       serviceName: get('AUDIT_SERVICE_NAME', 'hmpps-community-accommodation-tier-2-ui'),
       logErrors: get('AUDIT_LOG_ERRORS', 'false') === 'true',

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -12,8 +12,6 @@ describe('AuditService', () => {
 
   const config = {
     region: 'some-region',
-    accessKeyId: 'some-access-key-id',
-    secretAccessKey: 'some-secret-access-key',
     queueUrl: 'some-queue-url',
     serviceName: 'some-service-name' as ServiceName,
     logErrors: false,
@@ -26,10 +24,6 @@ describe('AuditService', () => {
 
       expect(MockSqsClient).toHaveBeenCalledWith({
         region: config.region,
-        credentials: {
-          accessKeyId: config.accessKeyId,
-          secretAccessKey: config.secretAccessKey,
-        },
       })
     })
   })

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -14,10 +14,6 @@ export default class AuditService {
   constructor(config: AuditConfig) {
     this.sqsClient = new SQSClient({
       region: config.region,
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
-      },
     })
 
     this.serviceName = config.serviceName


### PR DESCRIPTION
**Background here:** https://dsdmoj.atlassian.net/wiki/spaces/NOM/pages/4413030459/Migrate+to+using+IRSA 
**Slack thread:** https://mojdt.slack.com/archives/C03K0HB0LBE/p1692367119011029?thread_ts=1691154904.648879&cid=C03K0HB0LBE
 
We need to switch over to using IRSA by 4th September to access AWS
services - in the case of CAS UI's this just means SQS.[1]

If I understand correctly, IRSA effectively means our kubernetes service account 
is given an IAM role which it can then use to authenticate, rather than passing in 
access keys/secrets. The service account name has been added to the cloud platform 
repo already (see below).

This PR removes the credentials we were previously using to access
SQS - from now on the kubernetes service account that this pod runs in
should have an IAM role which it will use to authenticate.

The cloud platform configuration for **dev environment** has been done here: https://github.com/ministryofjustice/cloud-platform-environments/pull/15718/files

Once I've checked this works for CAS2, I will open PRs on the cloud platform for `preprod` and `prod`, and then will work with CAS1 and 3 to remove their auth credentials on the UI and check everything still working.

[1] The CAS API needs access to Domain events SNS, for which the IRSA config was already added and the backend changes made:
Prod https://github.com/ministryofjustice/cloud-platform-environments/pull/14891
PreProd https://github.com/ministryofjustice/cloud-platform-environments/pull/14890 
Dev https://github.com/ministryofjustice/cloud-platform-environments/pull/14880 

API: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/850
