### PR TITLE
Health needs guidance page - getting in touch section

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -1,5 +1,5 @@
 $govuk-global-styles: true;
-$path: "/assets/images/";
+$path: '/assets/images/';
 
 $moj-page-width: 1170px;
 $govuk-page-width: $moj-page-width;
@@ -9,6 +9,7 @@ $govuk-page-width: $moj-page-width;
 
 @import './components/header-bar';
 @import './components/task-list';
+@import './components/copy-text';
 
 @import 'assets/scss/local';
 

--- a/assets/scss/components/_copy-text.scss
+++ b/assets/scss/components/_copy-text.scss
@@ -1,0 +1,22 @@
+.copy-text {
+  > div {
+    border-left: none;
+    padding-left: 0;
+  }
+
+  &__container {
+    border: 1px solid govuk-colour('dark-grey');
+    padding: 1.25rem;
+  }
+
+  &__button {
+    color: white;
+    background: govuk-colour('blue');
+    box-shadow: 0 2px 0 govuk-colour('dark-blue');
+    margin-bottom: 0;
+
+    &:hover {
+      background: govuk-colour('dark-blue');
+    }
+  }
+}

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -5,5 +5,7 @@ declare namespace Cypress {
      * @example cy.signIn({ failOnStatusCode: boolean })
      */
     signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
+
+    assertValueCopiedToClipboardContains(text: string): Chainable<AUTWindow>
   }
 }

--- a/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
@@ -31,13 +31,35 @@ export default class HealthNeedsGuidancePage extends ApplyPage {
     cy.get('p').contains('My name is {Name}, a {Role} working at the {Location}.')
   }
 
+  copyIntroduceYourselfTemplateToClipboard = (): void => {
+    cy.get('span').contains('Introduce yourself to a team/officer').click()
+    cy.get('#introduce-yourself-button').click()
+    cy.assertValueCopiedToClipboardContains('My name is {Name}, a {Role} working at the {Location}.')
+  }
+
   hasHealthQuestionsTemplate = (): void => {
     cy.get('span').contains("Ask questions about the applicant's health")
     cy.get('li').contains('Do they have any physical health needs? Please describe them and the level of severity.')
   }
 
+  copyHealthQuestionsTemplateToClipboard = (): void => {
+    cy.get('span').contains("Ask questions about the applicant's health").click()
+    cy.get('#health-questions-button').click()
+    cy.assertValueCopiedToClipboardContains(
+      'Do they have any physical health needs? Please describe them and the level of severity.',
+    )
+  }
+
   hasDrugAndAlcoholQuestionsTemplate = (): void => {
     cy.get('span').contains("Ask questions about the applicant's drug and alcohol needs")
     cy.get('p').contains('The applicant has indicated that they are engaged with support for a drug or alcohol need.')
+  }
+
+  copyDrugAndAlcoholTemplateToClipboard = (): void => {
+    cy.get('span').contains("Ask questions about the applicant's drug and alcohol needs").click()
+    cy.get('#drug-alcohol-questions-button').click()
+    cy.assertValueCopiedToClipboardContains(
+      'The applicant has indicated that they are engaged with support for a drug or alcohol need.',
+    )
   }
 }

--- a/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/healthNeedsGuidancePage.ts
@@ -25,4 +25,19 @@ export default class HealthNeedsGuidancePage extends ApplyPage {
     cy.get('p').contains('Typically, this could involve speaking to the following people')
     cy.get('li').contains('Healthcare team')
   }
+
+  hasIntroduceYourselfTemplate = (): void => {
+    cy.get('span').contains('Introduce yourself to a team/officer')
+    cy.get('p').contains('My name is {Name}, a {Role} working at the {Location}.')
+  }
+
+  hasHealthQuestionsTemplate = (): void => {
+    cy.get('span').contains("Ask questions about the applicant's health")
+    cy.get('li').contains('Do they have any physical health needs? Please describe them and the level of severity.')
+  }
+
+  hasDrugAndAlcoholQuestionsTemplate = (): void => {
+    cy.get('span').contains("Ask questions about the applicant's drug and alcohol needs")
+    cy.get('p').contains('The applicant has indicated that they are engaged with support for a drug or alcohol need.')
+  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -23,6 +23,10 @@ export default abstract class Page {
     cy.get('button').click()
   }
 
+  clickContinue(): void {
+    cy.get('a').contains('Continue').click()
+  }
+
   shouldShowErrorMessagesForFields(fields: Array<string>): void {
     fields.forEach(field => {
       const errorMessagesLookup = errorLookups[field].empty

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -2,3 +2,11 @@ Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })
+
+Cypress.Commands.add('assertValueCopiedToClipboardContains', value => {
+  cy.window().then(win => {
+    win.navigator.clipboard.readText().then(text => {
+      expect(text).to.contain(value)
+    })
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -82,6 +82,9 @@ context('Visit "Risks and needs" section', () => {
     const page = Page.verifyOnPage(HealthNeedsGuidancePage, this.application)
     page.hasCaption()
     page.hasGuidance()
+    page.hasIntroduceYourselfTemplate()
+    page.hasHealthQuestionsTemplate()
+    page.hasDrugAndAlcoholQuestionsTemplate()
   })
 
   //  Scenario: continues to next page in "health needs" task

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -85,6 +85,10 @@ context('Visit "Risks and needs" section', () => {
     page.hasIntroduceYourselfTemplate()
     page.hasHealthQuestionsTemplate()
     page.hasDrugAndAlcoholQuestionsTemplate()
+
+    page.copyIntroduceYourselfTemplateToClipboard()
+    page.copyHealthQuestionsTemplateToClipboard()
+    page.copyDrugAndAlcoholTemplateToClipboard()
   })
 
   //  Scenario: continues to next page in "health needs" task
@@ -96,7 +100,7 @@ context('Visit "Risks and needs" section', () => {
 
     // When I continue to the next task/page
     const page = new HealthNeedsGuidancePage(this.application)
-    page.clickSubmit()
+    page.clickContinue()
 
     //  Then I should be on the substance misuse page
     Page.verifyOnPage(SubstanceMisusePage, this.application)

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
@@ -55,7 +55,7 @@ context('Visit "Substance misuse" page', () => {
     // --------------------------------
     HealthNeedsGuidancePage.visit(this.application)
     const guidancePage = new HealthNeedsGuidancePage(this.application)
-    guidancePage.clickSubmit()
+    guidancePage.clickContinue()
   })
 
   //  Scenario: view substance misuse questions

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -14,7 +14,7 @@
 {% include "../../../partials/email-templates/drug-alcohol-questions.njk" %}
 {% endset %}
 
-{% block questions %}
+{% block content %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
 
   <p class="govuk-body">
@@ -49,4 +49,32 @@
   html: drugAlcoholQuestionsTemplate
   }) }}
 
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    function copyToClipboard(divId) {
+      const range = document.createRange()
+      range.selectNodeContents(document.getElementById(divId));
+      const selection = window.getSelection();
+      selection.removeAllRanges()
+      selection.addRange(range)
+      document.execCommand('copy');
+      selection.removeAllRanges()
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      document
+        .getElementById('introduce-yourself-button')
+        .addEventListener('click', () => copyToClipboard('introduce-yourself-template'));
+
+      document
+        .getElementById('health-questions-button')
+        .addEventListener('click', () => copyToClipboard('health-questions-template'));
+
+      document
+        .getElementById('drug-alcohol-questions-button')
+        .addEventListener('click', () => copyToClipboard('drug-alcohol-questions-template'));
+    });
+  </script>
 {% endblock %}

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -1,4 +1,19 @@
 {% extends "../layout.njk" %}
+
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% set introduceYourselfTemplate %}
+{% include "../../../partials/email-templates/introduce-yourself.njk" %}
+{% endset %}
+
+{% set healthQuestionsTemplate %}
+{% include "../../../partials/email-templates/health-questions.njk" %}
+{% endset %}
+
+{% set drugAlcoholQuestionsTemplate %}
+{% include "../../../partials/email-templates/drug-alcohol-questions.njk" %}
+{% endset %}
+
 {% block questions %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
 
@@ -18,4 +33,20 @@
     <li>Adult social care</li>
     <li>Nelson Trust</li>
   </ul>
+
+  {{ govukDetails({
+  summaryText: "Introduce yourself to a team/officer",
+  html: introduceYourselfTemplate
+  }) }}
+
+  {{ govukDetails({
+  summaryText: "Ask questions about the applicant's health",
+  html: healthQuestionsTemplate
+  }) }}
+
+  {{ govukDetails({
+  summaryText: "Ask questions about the applicant's drug and alcohol needs",
+  html: drugAlcoholQuestionsTemplate
+  }) }}
+
 {% endblock %}

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -52,6 +52,15 @@
   classes: 'copy-text'
   }) }}
 
+  {{ govukButton({
+  text: "Continue",
+  href: paths.applications.pages.show({
+        id: page.application.id,
+        task: 'health-needs',
+        page: 'substance-misuse'
+      })
+  }) }}
+
 {% endblock %}
 
 {% block extraScripts %}

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -36,17 +36,20 @@
 
   {{ govukDetails({
   summaryText: "Introduce yourself to a team/officer",
-  html: introduceYourselfTemplate
+  html: introduceYourselfTemplate,
+  classes: 'copy-text'
   }) }}
 
   {{ govukDetails({
   summaryText: "Ask questions about the applicant's health",
-  html: healthQuestionsTemplate
+  html: healthQuestionsTemplate,
+  classes: 'copy-text'
   }) }}
 
   {{ govukDetails({
   summaryText: "Ask questions about the applicant's drug and alcohol needs",
-  html: drugAlcoholQuestionsTemplate
+  html: drugAlcoholQuestionsTemplate,
+  classes: 'copy-text'
   }) }}
 
 {% endblock %}

--- a/server/views/partials/email-templates/drug-alcohol-questions.njk
+++ b/server/views/partials/email-templates/drug-alcohol-questions.njk
@@ -1,8 +1,12 @@
-<p>The applicant has indicated that they are engaged with support for a drug or alcohol need.</p>
+<div id='drug-alcohol-questions-template'>
+  <p>The applicant has indicated that they are engaged with support for a drug or alcohol need.</p>
 
-<ol>
-  <li>What substance(s) did/do they take?</li>
-  <li>How often do they take it, by what method, and how much?</li>
-  <li>Are they engaged with a drug and alcohol service? Please name it.</li>
-  <li>Are they prescribed a substitute medication for their substance? Please name it.</li>
-</ol>
+  <ol>
+    <li>What substance(s) did/do they take?</li>
+    <li>How often do they take it, by what method, and how much?</li>
+    <li>Are they engaged with a drug and alcohol service? Please name it.</li>
+    <li>Are they prescribed a substitute medication for their substance? Please name it.</li>
+  </ol>
+
+  <button id="drug-alcohol-questions-button">Copy text</button>
+</div>

--- a/server/views/partials/email-templates/drug-alcohol-questions.njk
+++ b/server/views/partials/email-templates/drug-alcohol-questions.njk
@@ -1,0 +1,8 @@
+<p>The applicant has indicated that they are engaged with support for a drug or alcohol need.</p>
+
+<ol>
+  <li>What substance(s) did/do they take?</li>
+  <li>How often do they take it, by what method, and how much?</li>
+  <li>Are they engaged with a drug and alcohol service? Please name it.</li>
+  <li>Are they prescribed a substitute medication for their substance? Please name it.</li>
+</ol>

--- a/server/views/partials/email-templates/drug-alcohol-questions.njk
+++ b/server/views/partials/email-templates/drug-alcohol-questions.njk
@@ -1,12 +1,14 @@
-<div id='drug-alcohol-questions-template'>
-  <p>The applicant has indicated that they are engaged with support for a drug or alcohol need.</p>
+<div class='copy-text__container'>
+  <div id='drug-alcohol-questions-template'>
+    <p>The applicant has indicated that they are engaged with support for a drug or alcohol need.</p>
 
-  <ol>
-    <li>What substance(s) did/do they take?</li>
-    <li>How often do they take it, by what method, and how much?</li>
-    <li>Are they engaged with a drug and alcohol service? Please name it.</li>
-    <li>Are they prescribed a substitute medication for their substance? Please name it.</li>
-  </ol>
+    <ol>
+      <li>What substance(s) did/do they take?</li>
+      <li>How often do they take it, by what method, and how much?</li>
+      <li>Are they engaged with a drug and alcohol service? Please name it.</li>
+      <li>Are they prescribed a substitute medication for their substance? Please name it.</li>
+    </ol>
+  </div>
 
-  <button id="drug-alcohol-questions-button">Copy text</button>
+  <button id="drug-alcohol-questions-button" class="govuk-button copy-text__button">Copy text</button>
 </div>

--- a/server/views/partials/email-templates/health-questions.njk
+++ b/server/views/partials/email-templates/health-questions.njk
@@ -1,8 +1,12 @@
-<ol>
-  <li>Do they have any physical health needs? Please describe them and the level of severity.</li>
-  <li>Are they currently receiving any medical treatment for their physical health needs? If so, please describe it.</li>
-  <li>Are they currently taking any medication for their physical health needs? If so, please provide details.</li>
-  <li>Can they climb stairs?</li>
-  <li>Can they live independently?</li>
-  <li>What support is required?</li>
-</ol>
+<div id="health-questions-template">
+  <ol>
+    <li>Do they have any physical health needs? Please describe them and the level of severity.</li>
+    <li>Are they currently receiving any medical treatment for their physical health needs? If so, please describe it.</li>
+    <li>Are they currently taking any medication for their physical health needs? If so, please provide details.</li>
+    <li>Can they climb stairs?</li>
+    <li>Can they live independently?</li>
+    <li>What support is required?</li>
+
+    <button id="health-questions-button">Copy text</button>
+  </ol>
+</div>

--- a/server/views/partials/email-templates/health-questions.njk
+++ b/server/views/partials/email-templates/health-questions.njk
@@ -1,12 +1,14 @@
-<div id="health-questions-template">
-  <ol>
-    <li>Do they have any physical health needs? Please describe them and the level of severity.</li>
-    <li>Are they currently receiving any medical treatment for their physical health needs? If so, please describe it.</li>
-    <li>Are they currently taking any medication for their physical health needs? If so, please provide details.</li>
-    <li>Can they climb stairs?</li>
-    <li>Can they live independently?</li>
-    <li>What support is required?</li>
+<div class='copy-text__container'>
+  <div id="health-questions-template">
+    <ol>
+      <li>Do they have any physical health needs? Please describe them and the level of severity.</li>
+      <li>Are they currently receiving any medical treatment for their physical health needs? If so, please describe it.</li>
+      <li>Are they currently taking any medication for their physical health needs? If so, please provide details.</li>
+      <li>Can they climb stairs?</li>
+      <li>Can they live independently?</li>
+      <li>What support is required?</li>
+    </ol>
+  </div>
 
-    <button id="health-questions-button">Copy text</button>
-  </ol>
+  <button id="health-questions-button" class="govuk-button copy-text__button">Copy text</button>
 </div>

--- a/server/views/partials/email-templates/health-questions.njk
+++ b/server/views/partials/email-templates/health-questions.njk
@@ -1,0 +1,8 @@
+<ol>
+  <li>Do they have any physical health needs? Please describe them and the level of severity.</li>
+  <li>Are they currently receiving any medical treatment for their physical health needs? If so, please describe it.</li>
+  <li>Are they currently taking any medication for their physical health needs? If so, please provide details.</li>
+  <li>Can they climb stairs?</li>
+  <li>Can they live independently?</li>
+  <li>What support is required?</li>
+</ol>

--- a/server/views/partials/email-templates/introduce-yourself.njk
+++ b/server/views/partials/email-templates/introduce-yourself.njk
@@ -1,13 +1,15 @@
-<div id="introduce-yourself-template">
-  <p>Hello,</p>
+<div class='copy-text__container'>
+  <div id="introduce-yourself-template">
+    <p>Hello,</p>
 
-  <p>My name is {Name}, a {Role} working at the {Location}.</p>
+    <p>My name is {Name}, a {Role} working at the {Location}.</p>
 
-  <p>I am currently supporting {Applicant name} with an application for Short-Term Accommodation (CAS-2) and require some healthcare information that you can help me with.</p>
+    <p>I am currently supporting {Applicant name} with an application for Short-Term Accommodation (CAS-2) and require some healthcare information that you can help me with.</p>
 
-  <p>{Applicant} has given their consent for me to reach out to you on {Consent obtained date}. Please let me know if you need to see evidence of this consent before sharing information with me.</p>
+    <p>{Applicant} has given their consent for me to reach out to you on {Consent obtained date}. Please let me know if you need to see evidence of this consent before sharing information with me.</p>
 
-  <p>If possible, it would be much appreciated if you could respond back with the following details:</p>
+    <p>If possible, it would be much appreciated if you could respond back with the following details:</p>
+  </div>
 
-  <button id="introduce-yourself-button">Copy text</button>
+  <button id="introduce-yourself-button" class="govuk-button copy-text__button">Copy text</button>
 </div>

--- a/server/views/partials/email-templates/introduce-yourself.njk
+++ b/server/views/partials/email-templates/introduce-yourself.njk
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>My name is {Name}, a {Role} working at the {Location}.</p>
+
+<p>I am currently supporting {Applicant name} with an application for Short-Term Accommodation (CAS-2) and require some healthcare information that you can help me with.</p>
+
+<p>{Applicant} has given their consent for me to reach out to you on {Consent obtained date}. Please let me know if you need to see evidence of this consent before sharing information with me.</p>
+
+<p>If possible, it would be much appreciated if you could respond back with the following details:</p>

--- a/server/views/partials/email-templates/introduce-yourself.njk
+++ b/server/views/partials/email-templates/introduce-yourself.njk
@@ -1,9 +1,13 @@
-<p>Hello,</p>
+<div id="introduce-yourself-template">
+  <p>Hello,</p>
 
-<p>My name is {Name}, a {Role} working at the {Location}.</p>
+  <p>My name is {Name}, a {Role} working at the {Location}.</p>
 
-<p>I am currently supporting {Applicant name} with an application for Short-Term Accommodation (CAS-2) and require some healthcare information that you can help me with.</p>
+  <p>I am currently supporting {Applicant name} with an application for Short-Term Accommodation (CAS-2) and require some healthcare information that you can help me with.</p>
 
-<p>{Applicant} has given their consent for me to reach out to you on {Consent obtained date}. Please let me know if you need to see evidence of this consent before sharing information with me.</p>
+  <p>{Applicant} has given their consent for me to reach out to you on {Consent obtained date}. Please let me know if you need to see evidence of this consent before sharing information with me.</p>
 
-<p>If possible, it would be much appreciated if you could respond back with the following details:</p>
+  <p>If possible, it would be much appreciated if you could respond back with the following details:</p>
+
+  <button id="introduce-yourself-button">Copy text</button>
+</div>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -12,7 +12,7 @@
   <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
   <![endif]-->
 
-  <script src="/assets/js/jquery.min.js"></script> 
+  <script src="/assets/js/jquery.min.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
           integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
           nonce="{{ cspNonce }}"
@@ -21,14 +21,14 @@
 
 {% endblock %}
 
-{% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
+{% block pageTitle %}{{pageTitle | default(applicationName)}}
+{% endblock %}
 
 {% block header %}
   {% include "./header.njk" %}
 {% endblock %}
 
-{% block bodyStart %}
-{% endblock %}
+{% block bodyStart %}{% endblock %}
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the
@@ -36,4 +36,5 @@
   <script src="/assets/govuk/all.js"></script>
   <script src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
+  {% block extraScripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
This PR allows users to copy email templates from the health needs guidance page.

The functionality has been implemented via an extra script in the guidance template, and tested in our integration test suite.

## Before

<img width="793" alt="Screenshot 2023-08-22 at 11 51 49" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/5a7e8f6f-6b71-4099-b264-53c3d0233cd1">

## After

<img width="812" alt="Screenshot 2023-08-22 at 11 52 10" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/be6d7753-6212-4692-9b71-d156ac216f4e">

<img width="1112" alt="Screenshot 2023-08-22 at 11 52 30" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/2d71679a-d4ef-401d-bf59-7ff41c00d51b">

<img width="1152" alt="Screenshot 2023-08-22 at 11 52 44" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/38fd03e5-4534-468b-9fc0-546d7b646562">

