### PR TITLE
Refactor Risk to Self OASys transformation 

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -114,6 +114,15 @@
     }
   },
   "risk-to-self": {
-    "guidance": {}
+    "guidance": {},
+    "vulnerability": {
+      "vulnerabilityDetail": "example answer vulnerability"
+    },
+    "current-risk": {
+      "currentRiskDetail": "example answer current risk"
+    },
+    "historical-risk": {
+      "historicalRiskDetail": "example answer historical risk "
+    }
   }
 }

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,25 +1,25 @@
-import type { OASysSections, Person } from '@approved-premises/api'
+import type { OASysRiskToSelf, Person } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 
 export default {
-  stubOasysSections: (args: { crn: string; oasysSections: OASysSections }) =>
+  stubOasysRiskToSelf: (args: { crn: string; oasysRiskToSelf: OASysRiskToSelf }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/sections`,
+        url: `/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: args.oasysSections,
+        jsonBody: args.oasysRiskToSelf,
       },
     }),
 
-  stubOasysSectionsNotFound: (args: { crn: string }) =>
+  stubOasysRiskToSelfNotFound: (args: { crn: string }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/sections`,
+        url: `/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 404,

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -132,6 +132,7 @@ export type { NonArrivalReason } from './models/NonArrivalReason';
 export type { OASysAssessmentId } from './models/OASysAssessmentId';
 export type { OASysAssessmentState } from './models/OASysAssessmentState';
 export type { OASysQuestion } from './models/OASysQuestion';
+export type { OASysRiskToSelf } from './models/OASysRiskToSelf';
 export type { OASysSection } from './models/OASysSection';
 export type { OASysSections } from './models/OASysSections';
 export type { OASysSupportingInformationQuestion } from './models/OASysSupportingInformationQuestion';

--- a/server/@types/shared/models/OASysRiskToSelf.ts
+++ b/server/@types/shared/models/OASysRiskToSelf.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ArrayOfOASysRiskToSelfQuestions } from './ArrayOfOASysRiskToSelfQuestions';
+import type { OASysAssessmentId } from './OASysAssessmentId';
+import type { OASysAssessmentState } from './OASysAssessmentState';
+
+export type OASysRiskToSelf = {
+    assessmentId: OASysAssessmentId;
+    assessmentState: OASysAssessmentState;
+    dateStarted: string;
+    dateCompleted?: string;
+    riskToSelf: ArrayOfOASysRiskToSelfQuestions;
+};
+

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,3 +1,4 @@
+import { OASysRiskToSelf } from '../shared/models/OASysRiskToSelf'
 import { OASysSections } from '../shared/models/OASysSections'
 
 export type JourneyType = 'applications'
@@ -47,6 +48,7 @@ export type DataServices = Partial<{
   personService: {
     findByCrn: (token: string, crn: string) => Promise<Person>
     getOasysSections: (token: string, crn: string) => Promise<OASysSections>
+    getOasysRiskToSelf: (token: string, crn: string) => Promise<OASysRiskToSelf>
   }
   applicationService: {
     findApplication: (token: string, id: string) => Promise<Cas2Application>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,5 +1,5 @@
 import PersonClient from './personClient'
-import { oasysSectionsFactory, personFactory } from '../testutils/factories'
+import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
@@ -66,6 +66,34 @@ describeClient('PersonClient', provider => {
       const result = await personClient.oasysSections(crn)
 
       expect(result).toEqual(oasysSections)
+    })
+  })
+
+  describe('oasysRiskToSelf', () => {
+    it('should return the Risk to Self data', async () => {
+      const crn = 'crn'
+      const oasysRiskToSelf = oasysRiskToSelfFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the optional selected sections of OASys for a person',
+        withRequest: {
+          method: 'GET',
+          path: paths.people.oasys.riskToSelf({ crn }),
+          query: {},
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: oasysRiskToSelf,
+        },
+      })
+
+      const result = await personClient.oasysRiskToSelf(crn)
+
+      expect(result).toEqual(oasysRiskToSelf)
     })
   })
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,4 @@
-import type { OASysSections, Person } from '@approved-premises/api'
+import type { OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -18,6 +18,14 @@ export default class PersonClient {
     const path = `${paths.people.oasys.sections({ crn })}${queryString ? `?${queryString}` : ''}`
 
     const response = (await this.restClient.get({ path })) as OASysSections
+
+    return response
+  }
+
+  async oasysRiskToSelf(crn: string): Promise<OASysRiskToSelf> {
+    const path = paths.people.oasys.riskToSelf({ crn })
+
+    const response = (await this.restClient.get({ path })) as OASysRiskToSelf
 
     return response
   }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
@@ -2,10 +2,11 @@
 
 import { Task } from '../../../utils/decorators'
 import RiskToSelfGuidance from './riskToSelfGuidance'
+import Vulnerability from './vulnerability'
 
 @Task({
   name: 'Review risk to self information',
   slug: 'risk-to-self',
-  pages: [RiskToSelfGuidance],
+  pages: [RiskToSelfGuidance, Vulnerability],
 })
 export default class RiskToSelf {}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
@@ -54,9 +54,9 @@ describe('RiskToSelfGuidance', () => {
 
         const taskData = {
           'risk-to-self': {
-            currentRisk: { currentRiskDetail: 'self harm answer' },
+            'current-risk': { currentRiskDetail: 'self harm answer' },
             vulnerability: { vulnerabilityDetail: 'vulnerability answer' },
-            historicalRisk: { historicalRiskDetail: 'historical answer' },
+            'historical-risk': { historicalRiskDetail: 'historical answer' },
           },
         }
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
@@ -1,19 +1,26 @@
 import { createMock } from '@golevelup/ts-jest'
 import type { DataServices } from '@approved-premises/ui'
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { personFactory, applicationFactory, oasysSectionsFactory } from '../../../../testutils/factories/index'
-import RiskToSelfGuidance from './riskToSelfGuidance'
+import { personFactory, applicationFactory, oasysRiskToSelfFactory } from '../../../../testutils/factories/index'
+import RiskToSelfGuidance, { RiskToSelfTaskData } from './riskToSelfGuidance'
 import PersonService from '../../../../services/personService'
+import Vulnerability from './vulnerability'
+
+jest.mock('./vulnerability')
 
 describe('RiskToSelfGuidance', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
-  const oasysSections = oasysSectionsFactory.build()
+  const oasys = oasysRiskToSelfFactory.build({
+    dateCompleted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 29)),
+    dateStarted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 28)),
+  })
 
   const dataServices = createMock<DataServices>({ personService: createMock<PersonService>({}) })
 
   describe('title', () => {
     it('personalises the page title', () => {
-      const page = new RiskToSelfGuidance({}, application, oasysSections, '')
+      const page = new RiskToSelfGuidance({}, application, oasys, '')
 
       expect(page.title).toEqual("Import Roger Smith's risk to self data from OASys")
     })
@@ -22,7 +29,7 @@ describe('RiskToSelfGuidance', () => {
   describe('initialize', () => {
     describe('when oasys sections are returned', () => {
       it('instantiates the class with the task data in the correct format', async () => {
-        oasysSections.riskToSelf = [
+        oasys.riskToSelf = [
           {
             label: 'Current concerns about self-harm or suicide',
             questionNumber: 'R8.1.1',
@@ -38,50 +45,115 @@ describe('RiskToSelfGuidance', () => {
             questionNumber: 'R8.3.1',
             answer: 'vulnerability answer',
           },
+          {
+            label: 'Historical concerns about self-harm or suicide',
+            questionNumber: 'R8.1.4',
+            answer: 'historical answer',
+          },
         ]
 
         const taskData = {
           'risk-to-self': {
             currentRisk: { currentRiskDetail: 'self harm answer' },
             vulnerability: { vulnerabilityDetail: 'vulnerability answer' },
+            historicalRisk: { historicalRiskDetail: 'historical answer' },
           },
         }
 
-        ;(dataServices.personService.getOasysSections as jest.Mock).mockResolvedValue(oasysSections)
+        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockResolvedValue(oasys)
 
-        const page = await RiskToSelfGuidance.initialize({}, application, 'some-token', dataServices)
+        const page = (await RiskToSelfGuidance.initialize(
+          {},
+          application,
+          'some-token',
+          dataServices,
+        )) as RiskToSelfGuidance
 
         expect(page.taskData).toBe(JSON.stringify(taskData))
         expect(page.hasOasysRecord).toBe(true)
+        expect(page.oasysCompleted).toBe('29 August 2023')
+        expect(page.oasysStarted).toBe('28 August 2023')
+      })
+
+      describe('when there is not a completed date', () => {
+        it('does not assign a completed date', async () => {
+          const oasysIncomplete = oasysRiskToSelfFactory.build({ dateCompleted: null })
+
+          ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockResolvedValue(oasysIncomplete)
+
+          const page = (await RiskToSelfGuidance.initialize(
+            {},
+            application,
+            'some-token',
+            dataServices,
+          )) as RiskToSelfGuidance
+
+          expect(page.oasysCompleted).toBe(null)
+        })
       })
     })
 
     describe('when oasys sections are not returned', () => {
       it('sets hasOasysRecord to false when a 404 is returned', async () => {
-        ;(dataServices.personService.getOasysSections as jest.Mock).mockRejectedValue({ status: 404 })
+        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockRejectedValue({ status: 404 })
 
-        const page = await RiskToSelfGuidance.initialize({}, application, 'some-token', dataServices)
+        const page = (await RiskToSelfGuidance.initialize(
+          {},
+          application,
+          'some-token',
+          dataServices,
+        )) as RiskToSelfGuidance
 
         expect(page.hasOasysRecord).toBe(false)
+        expect(page.oasysCompleted).toBe(undefined)
+        expect(page.oasysStarted).toBe(undefined)
       })
 
       it('throws error when an unexpected error is returned', async () => {
         const error = new Error()
-        ;(dataServices.personService.getOasysSections as jest.Mock).mockImplementation(() => {
+        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockImplementation(() => {
           throw error
         })
 
         expect(RiskToSelfGuidance.initialize({}, application, 'some-token', dataServices)).rejects.toThrow(error)
       })
     })
+
+    describe('when questions have already been answered', () => {
+      it('returns the Vulnerability page', async () => {
+        const riskToSelfData = {
+          'risk-to-self': { vulnerability: { vulnerabilityDetail: 'some answer' } },
+        } as RiskToSelfTaskData
+
+        const applicationWithData = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+          data: riskToSelfData,
+        })
+
+        const vulnerabilityPageConstructor = jest.fn()
+
+        ;(Vulnerability as jest.Mock).mockImplementation(() => {
+          return vulnerabilityPageConstructor
+        })
+
+        expect(RiskToSelfGuidance.initialize({}, applicationWithData, 'some-token', dataServices)).resolves.toEqual(
+          vulnerabilityPageConstructor,
+        )
+
+        expect(Vulnerability).toHaveBeenCalledWith(
+          applicationWithData.data['risk-to-self'].vulnerability,
+          applicationWithData,
+        )
+      })
+    })
   })
 
-  itShouldHaveNextValue(new RiskToSelfGuidance({}, application, oasysSections, ''), '')
-  itShouldHavePreviousValue(new RiskToSelfGuidance({}, application, oasysSections, ''), 'taskList')
+  itShouldHaveNextValue(new RiskToSelfGuidance({}, application, oasys, ''), 'vulnerability')
+  itShouldHavePreviousValue(new RiskToSelfGuidance({}, application, oasys, ''), 'taskList')
 
   describe('errors', () => {
     it('returns empty object', () => {
-      const page = new RiskToSelfGuidance({}, application, oasysSections, '')
+      const page = new RiskToSelfGuidance({}, application, oasys, '')
 
       expect(page.errors()).toEqual({})
     })
@@ -89,7 +161,7 @@ describe('RiskToSelfGuidance', () => {
 
   describe('response', () => {
     it('returns empty object', () => {
-      const page = new RiskToSelfGuidance({}, application, oasysSections, '')
+      const page = new RiskToSelfGuidance({}, application, oasys, '')
 
       expect(page.response()).toEqual({})
     })

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { DateFormats } from '../../../../utils/dateUtils'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import Vulnerability from './vulnerability'
 
 type GuidanceBody = Record<string, never>
 
@@ -68,18 +69,21 @@ export default class RiskToSelfGuidance implements TaskListPage {
     let oasysSections
     let taskDataJson
 
-    try {
-      oasysSections = await dataServices.personService.getOasysSections(token, application.person.crn)
+    if (!application.data['risk-to-self'] || Boolean(Object.keys(application.data['risk-to-self']).length < 1)) {
+      try {
+        oasysSections = await dataServices.personService.getOasysSections(token, application.person.crn)
 
-      taskDataJson = JSON.stringify(RiskToSelfGuidance.getTaskData(oasysSections))
-    } catch (e) {
-      if (e.status === 404) {
-        oasysSections = null
-      } else {
-        throw e
+        taskDataJson = JSON.stringify(RiskToSelfGuidance.getTaskData(oasysSections))
+      } catch (e) {
+        if (e.status === 404) {
+          oasysSections = null
+        } else {
+          throw e
+        }
       }
+      return new RiskToSelfGuidance(body, application, oasysSections, taskDataJson)
     }
-    return new RiskToSelfGuidance(body, application, oasysSections, taskDataJson)
+    return new Vulnerability(application.data['risk-to-self'].vulnerability, application)
   }
 
   private static getTaskData(oasysSections: OASysSections): Partial<RiskToSelfTaskData> {
@@ -99,7 +103,7 @@ export default class RiskToSelfGuidance implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'vulnerability'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
@@ -10,13 +10,13 @@ type GuidanceBody = Record<string, never>
 
 export type RiskToSelfTaskData = {
   'risk-to-self': {
-    currentRisk: {
+    'current-risk': {
       currentRiskDetail: string
     }
     vulnerability: {
       vulnerabilityDetail: string
     }
-    historicalRisk: {
+    'historical-risk': {
       historicalRiskDetail: string
     }
   }
@@ -95,13 +95,13 @@ export default class RiskToSelfGuidance implements TaskListPage {
     oasysSections.riskToSelf.forEach(question => {
       switch (question.questionNumber) {
         case 'R8.1.1':
-          taskData['risk-to-self'].currentRisk = { currentRiskDetail: question.answer }
+          taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer }
           break
         case 'R8.3.1':
           taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer }
           break
         case 'R8.1.4':
-          taskData['risk-to-self'].historicalRisk = { historicalRiskDetail: question.answer }
+          taskData['risk-to-self']['historical-risk'] = { historicalRiskDetail: question.answer }
           break
         default:
           break

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
@@ -1,0 +1,50 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import Vulnerability from './vulnerability'
+
+describe('Vulnerability', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new Vulnerability({}, application)
+
+      expect(page.title).toEqual("Roger Smith's vulnerability")
+    })
+  })
+
+  describe('Questions', () => {
+    const page = new Vulnerability({}, application)
+
+    describe('vulnerabilityDetail', () => {
+      it('has a question', () => {
+        expect(page.questions.vulnerabilityDetail.question).toBeDefined()
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new Vulnerability({}, application), '')
+  itShouldHavePreviousValue(new Vulnerability({}, application), 'taskList')
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new Vulnerability(
+        {
+          vulnerabilityDetail: 'is vulnerable',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        "Describe Roger Smith's current circumstances, issues and needs related to vulnerability": 'is vulnerable',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns empty object', () => {
+      const page = new Vulnerability({}, application)
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -1,0 +1,54 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type VulnerabilityBody = { vulnerabilityDetail: string }
+
+@Page({
+  name: 'vulnerability',
+  bodyProperties: ['vulnerabilityDetail'],
+})
+export default class Vulnerability implements TaskListPage {
+  title = `${nameOrPlaceholderCopy(this.application.person)}'s vulnerability`
+
+  questions = {
+    vulnerabilityDetail: {
+      question: `Describe ${nameOrPlaceholderCopy(
+        this.application.person,
+      )}'s current circumstances, issues and needs related to vulnerability`,
+    },
+  }
+
+  body: VulnerabilityBody
+
+  constructor(
+    body: Partial<VulnerabilityBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as VulnerabilityBody
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.vulnerabilityDetail.question]: this.body.vulnerabilityDetail,
+    }
+
+    return response
+  }
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -10,6 +10,7 @@ export default {
   people: {
     oasys: {
       sections: oasysPath.path('sections'),
+      riskToSelf: oasysPath.path('risk-to-self'),
     },
     search: peoplePath.path('search'),
   },

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,4 +1,4 @@
-import { oasysSectionsFactory, personFactory } from '../testutils/factories'
+import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -42,6 +42,20 @@ describe('Person Service', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysSections).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getOasysRiskToSelf', () => {
+    it('returns oasysSections', async () => {
+      const expectedRiskToSelf = oasysRiskToSelfFactory.build()
+      personClient.oasysRiskToSelf.mockResolvedValue(expectedRiskToSelf)
+
+      const oasysSections = await service.getOasysRiskToSelf(token, 'crn')
+
+      expect(oasysSections).toEqual(expectedRiskToSelf)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.oasysRiskToSelf).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,4 +1,4 @@
-import type { OASysSections, Person } from '@approved-premises/api'
+import type { OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
@@ -15,6 +15,13 @@ export default class PersonService {
     const personClient = this.personClientFactory(token)
 
     const oasysSections = await personClient.oasysSections(crn)
+    return oasysSections
+  }
+
+  async getOasysRiskToSelf(token: string, crn: string): Promise<OASysRiskToSelf> {
+    const personClient = this.personClientFactory(token)
+
+    const oasysSections = await personClient.oasysRiskToSelf(crn)
     return oasysSections
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,5 +1,6 @@
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
+import oasysRiskToSelfFactory from './oasysRiskToSelf'
 import { fullPersonFactory as personFactory, restrictedPersonFactory } from './person'
 import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
@@ -9,6 +10,7 @@ export {
   applicationSummaryFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
+  oasysRiskToSelfFactory,
   roshSummaryFactory,
   applicationFactory,
   personFactory,

--- a/server/testutils/factories/oasysRiskToSelf.ts
+++ b/server/testutils/factories/oasysRiskToSelf.ts
@@ -1,0 +1,14 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import { OASysRiskToSelf } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+import { riskToSelfFactory } from './oasysSections'
+
+export default Factory.define<OASysRiskToSelf>(() => ({
+  assessmentId: faker.number.int(),
+  assessmentState: faker.helpers.arrayElement(['Completed', 'Incomplete']),
+  dateStarted: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  dateCompleted: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
+  riskToSelf: riskToSelfFactory.buildList(5),
+}))

--- a/server/views/applications/pages/risk-to-self/guidance.njk
+++ b/server/views/applications/pages/risk-to-self/guidance.njk
@@ -70,9 +70,7 @@
 
         {{ govukButton({
               text: "Continue",
-              href: paths.applications.show({
-                    id: page.application.id   
-                  })
+              href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'vulnerability' })
               }) 
           }}
 

--- a/server/views/applications/pages/risk-to-self/vulnerability.njk
+++ b/server/views/applications/pages/risk-to-self/vulnerability.njk
@@ -1,0 +1,18 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'vulnerabilityDetail',
+          label: {
+            text: page.questions.vulnerabilityDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+
+{% endblock %}


### PR DESCRIPTION
We would like to check if there is OASys information for an applicant on the Risk to Self section.
If there is data, when the user clicks 'save and continue' we populate the relevant answers in the rest of the task.

[We previously used an existing function ](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/173)on the CAS API which gets several sections from the report, and does not include one required part of the Risk to Self section (historical risk of self-harm). 

This PR:
* Uses work from this API PR https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/920 to retrieve only the relevant section of OASys
* adds a skeleton 'Vulnerability' page so that we can see answers populating.

![Screenshot 2023-08-29 at 14 11 48](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/4fd60760-5ba0-4d23-8678-e15858577672)

![Screenshot 2023-08-29 at 14 11 07](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/5ea910b0-e7d8-4f07-84fa-ebb68c459210)
