### PR TITLE
470 Risk to Self skeleton

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/acctPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/acctPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+
+export default class AcctPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super('Assessment, Care in Custody and Teamwork (ACCT)', application, 'risk-to-self', 'acct')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-to-self',
+        page: 'acct',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/additionalInformationPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/additionalInformationPage.ts
@@ -1,0 +1,19 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+
+export default class AdditionalInformationPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super('Additional Information', application, 'risk-to-self', 'additional-information')
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-to-self',
+        page: 'additional-information',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/currentRiskPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/currentRiskPage.ts
@@ -1,0 +1,25 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+
+export default class CurrentRiskPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `${nameOrPlaceholderCopy(application.person, 'The person')}'s current risks`,
+      application,
+      'risk-to-self',
+      'current-risk',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-to-self',
+        page: 'current-risk',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/historicalRiskPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/historicalRiskPage.ts
@@ -1,0 +1,25 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+
+export default class HistoricalRiskPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `${nameOrPlaceholderCopy(application.person, 'The person')}'s historical risks`,
+      application,
+      'risk-to-self',
+      'historical-risk',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-to-self',
+        page: 'historical-risk',
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/vulnerabilityPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/vulnerabilityPage.ts
@@ -1,0 +1,25 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+
+export default class VulnerabilityPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `${nameOrPlaceholderCopy(application.person, 'The person')}'s vulnerability`,
+      application,
+      'risk-to-self',
+      'vulnerability',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-to-self',
+        page: 'vulnerability',
+      }),
+    )
+  }
+}

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/acct.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/acct.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Risk to self: ACCT' page
+//    So that I can complete the "Risk to self" task
+//    As a referrer
+//    I want to complete the 'ACCT' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the ACCT page
+//
+//  Scenario: view ACCT questions
+//    Then I see the "ACCT" page
+//
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the ACCT page
+//    And I continue to the next task / page
+//    Then I see the "additional information" page
+
+import AcctPage from '../../../../pages/apply/risks-and-needs/risk-to-self/acctPage'
+import AdditionalInformationPage from '../../../../pages/apply/risks-and-needs/risk-to-self/additionalInformationPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-to-self'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the ACCT page
+    // --------------------------------
+    AcctPage.visit(this.application)
+  })
+
+  //  Scenario: view ACCT questions
+  //    Then I see the "ACCT" page
+  it('presents ACCT page', function test() {
+    Page.verifyOnPage(AcctPage, this.application)
+  })
+
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the ACCT page
+  //    And I continue to the next task / page
+  //    Then I see the "additional information" page
+  it('navigates to the next page (additional information)', function test() {
+    AcctPage.visit(this.application)
+    const page = new AcctPage(this.application)
+
+    page.clickSubmit()
+
+    Page.verifyOnPage(AdditionalInformationPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/additional_information.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/additional_information.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Risk to self: Additional Information' page
+//    So that I can complete the "Risk to self" task
+//    As a referrer
+//    I want to complete the 'Additional Information' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the Additional Information page
+//
+//  Scenario: view Additional Information questions
+//    Then I see the "Additional Information" page
+//
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the Additional Information page
+//    And I continue to the next task / page
+//    Then I see the "task list" page
+
+import AdditionalInformationPage from '../../../../pages/apply/risks-and-needs/risk-to-self/additionalInformationPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-to-self'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the Additional Information page
+    // --------------------------------
+    AdditionalInformationPage.visit(this.application)
+  })
+
+  //  Scenario: view Additional Information questions
+  //    Then I see the "Additional Information" page
+  it('presents Additional Information page', function test() {
+    Page.verifyOnPage(AdditionalInformationPage, this.application)
+  })
+
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the Additional Information page
+  //    And I continue to the next task / page
+  //    Then I see the "task list" page
+  it('navigates to the next page (additional information)', function test() {
+    AdditionalInformationPage.visit(this.application)
+    const page = new AdditionalInformationPage(this.application)
+
+    page.clickSubmit()
+
+    Page.verifyOnPage(TaskListPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Risk to self: current risk' page
+//    So that I can complete the "Risk to self" task
+//    As a referrer
+//    I want to complete the 'current risk' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the current risk page
+//
+//  Scenario: view current risk questions
+//    Then I see the "current risk" page
+//
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the current risk page
+//    And I continue to the next task / page
+//    Then I see the "historical risk" page
+
+import CurrentRiskPage from '../../../../pages/apply/risks-and-needs/risk-to-self/currentRiskPage'
+import HistoricalRiskPage from '../../../../pages/apply/risks-and-needs/risk-to-self/historicalRiskPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-to-self'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the current risk page
+    // --------------------------------
+    CurrentRiskPage.visit(this.application)
+  })
+
+  //  Scenario: view current risk questions
+  //    Then I see the "current risk" page
+  it('presents current risk page', function test() {
+    Page.verifyOnPage(CurrentRiskPage, this.application)
+  })
+
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the current risk page
+  //    And I continue to the next task / page
+  //    Then I see the "historical risk" page
+  it('navigates to the next page (historical risk)', function test() {
+    CurrentRiskPage.visit(this.application)
+    const page = new CurrentRiskPage(this.application)
+
+    page.clickSubmit()
+
+    Page.verifyOnPage(HistoricalRiskPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Risk to self: historical risk' page
+//    So that I can complete the "Risk to self" task
+//    As a referrer
+//    I want to complete the 'historical risk' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the historical risk page
+//
+//  Scenario: view historical risk questions
+//    Then I see the "historical risk" page
+//
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the historical risk page
+//    And I continue to the next task / page
+//    Then I see the "ACCT" page
+
+import HistoricalRiskPage from '../../../../pages/apply/risks-and-needs/risk-to-self/historicalRiskPage'
+import AcctPage from '../../../../pages/apply/risks-and-needs/risk-to-self/acctPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-to-self'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the historical risk page
+    // --------------------------------
+    HistoricalRiskPage.visit(this.application)
+  })
+
+  //  Scenario: view historical risk questions
+  //    Then I see the "historical risk" page
+  it('presents historical risk page', function test() {
+    Page.verifyOnPage(HistoricalRiskPage, this.application)
+  })
+
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the historical risk page
+  //    And I continue to the next task / page
+  //    Then I see the "ACCT" page
+  it('navigates to the next page (ACCT)', function test() {
+    HistoricalRiskPage.visit(this.application)
+    const page = new HistoricalRiskPage(this.application)
+
+    page.clickSubmit()
+
+    Page.verifyOnPage(AcctPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/risk_to_self_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/risk_to_self_guidance_page.cy.ts
@@ -32,6 +32,7 @@
 //    And I see that there is no OASys data
 
 import RiskToSelfGuidancePage from '../../../../pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidancePage'
+import VulnerabilityPage from '../../../../pages/apply/risks-and-needs/risk-to-self/vulnerabilityPage'
 import Page from '../../../../pages/page'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import {
@@ -124,7 +125,7 @@ context('Visit "Risks and needs" section', () => {
     page.clickSubmit()
 
     //  Then we are taken to the Vulnerability page
-    cy.get('h1').contains('vulnerability')
+    Page.verifyOnPage(VulnerabilityPage, this.application)
   })
 
   //  Scenario: return to Task after importing data

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
@@ -1,0 +1,76 @@
+//  Feature: Referrer completes 'Risk to self: vulnerability' page
+//    So that I can complete the "Risk to self" task
+//    As a referrer
+//    I want to complete the 'vulnerability' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the vulnerability page
+//
+//  Scenario: view vulnerability questions
+//    Then I see the "vulnerability" page
+//
+//  Scenario: complete page and navigate to next page in health needs task
+//    When I complete the vulnerability page
+//    And I continue to the next task / page
+//    Then I see the "current risk" page
+
+import VulnerabilityPage from '../../../../pages/apply/risks-and-needs/risk-to-self/vulnerabilityPage'
+import CurrentRiskPage from '../../../../pages/apply/risks-and-needs/risk-to-self/currentRiskPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+
+context('Visit "Risks and needs" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-to-self'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I am on the vulnerability page
+    // --------------------------------
+    VulnerabilityPage.visit(this.application)
+  })
+
+  //  Scenario: view vulnerability questions
+  //    Then I see the "vulnerability" page
+  it('presents vulnerability page', function test() {
+    Page.verifyOnPage(VulnerabilityPage, this.application)
+  })
+
+  //  Scenario: complete page and navigate to next page in health needs task
+  //    When I complete the vulnerability page
+  //    And I continue to the next task / page
+  //    Then I see the "current risk" page
+  it('navigates to the next page (current risk)', function test() {
+    VulnerabilityPage.visit(this.application)
+    const page = new VulnerabilityPage(this.application)
+
+    page.clickSubmit()
+
+    Page.verifyOnPage(CurrentRiskPage, this.application)
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
@@ -1,0 +1,33 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import Acct from './acct'
+
+describe('Acct', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new Acct({}, application)
+
+      expect(page.title).toEqual('Assessment, Care in Custody and Teamwork (ACCT)')
+    })
+  })
+
+  itShouldHaveNextValue(new Acct({}, application), 'additional-information')
+  itShouldHavePreviousValue(new Acct({}, application), 'historical-risk')
+
+  describe('response', () => {
+    it('returns empty object', () => {
+      const page = new Acct({}, application)
+
+      expect(page.response()).toEqual({})
+    })
+  })
+
+  describe('errors', () => {
+    it('returns empty object', () => {
+      const page = new Acct({}, application)
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type AcctBody = Record<string, never>
+
+@Page({
+  name: 'acct',
+  bodyProperties: ['acctDetail'],
+})
+export default class Acct implements TaskListPage {
+  title = 'Assessment, Care in Custody and Teamwork (ACCT)'
+
+  body: AcctBody
+
+  constructor(
+    body: Partial<AcctBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as AcctBody
+  }
+
+  previous() {
+    return 'historical-risk'
+  }
+
+  next() {
+    return 'additional-information'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
@@ -1,0 +1,50 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import AdditionalInformation from './additionalInformation'
+
+describe('AdditionalInformation', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new AdditionalInformation({}, application)
+
+      expect(page.title).toEqual('Additional Information')
+    })
+  })
+
+  describe('Questions', () => {
+    const page = new AdditionalInformation({}, application)
+
+    describe('additionalInformationDetail', () => {
+      it('has a question', () => {
+        expect(page.questions.additionalInformationDetail.question).toBeDefined()
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new AdditionalInformation({}, application), '')
+  itShouldHavePreviousValue(new AdditionalInformation({}, application), 'acct')
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new AdditionalInformation(
+        {
+          additionalInformationDetail: 'is at risk',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        "Is there anything else to include about Roger Smith's risk to self? (Optional)": 'is at risk',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns empty object', () => {
+      const page = new AdditionalInformation({}, application)
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
@@ -1,0 +1,54 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type AdditionalInformationBody = { additionalInformationDetail: string }
+
+@Page({
+  name: 'additional-information',
+  bodyProperties: ['additionalInformationDetail'],
+})
+export default class AdditionalInformation implements TaskListPage {
+  title = 'Additional Information'
+
+  questions = {
+    additionalInformationDetail: {
+      question: `Is there anything else to include about ${nameOrPlaceholderCopy(
+        this.application.person,
+      )}'s risk to self? (Optional)`,
+    },
+  }
+
+  body: AdditionalInformationBody
+
+  constructor(
+    body: Partial<AdditionalInformationBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as AdditionalInformationBody
+  }
+
+  previous() {
+    return 'acct'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.additionalInformationDetail.question]: this.body.additionalInformationDetail,
+    }
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
@@ -1,0 +1,50 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import CurrentRisk from './currentRisk'
+
+describe('CurrentRisk', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new CurrentRisk({}, application)
+
+      expect(page.title).toEqual("Roger Smith's current risks")
+    })
+  })
+
+  describe('Questions', () => {
+    const page = new CurrentRisk({}, application)
+
+    describe('currentRiskDetail', () => {
+      it('has a question', () => {
+        expect(page.questions.currentRiskDetail.question).toBeDefined()
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new CurrentRisk({}, application), 'historicalRisk')
+  itShouldHavePreviousValue(new CurrentRisk({}, application), 'vulnerability')
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new CurrentRisk(
+        {
+          currentRiskDetail: 'is at risk',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        "Describe Roger Smith's current issues and needs related to self harm and suicide": 'is at risk',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns empty object', () => {
+      const page = new CurrentRisk({}, application)
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
@@ -23,7 +23,7 @@ describe('CurrentRisk', () => {
     })
   })
 
-  itShouldHaveNextValue(new CurrentRisk({}, application), 'historicalRisk')
+  itShouldHaveNextValue(new CurrentRisk({}, application), 'historical-risk')
   itShouldHavePreviousValue(new CurrentRisk({}, application), 'vulnerability')
 
   describe('response', () => {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -7,7 +7,7 @@ import TaskListPage from '../../../taskListPage'
 type CurrentRiskBody = { currentRiskDetail: string }
 
 @Page({
-  name: 'currentRisk',
+  name: 'current-risk',
   bodyProperties: ['currentRiskDetail'],
 })
 export default class CurrentRisk implements TaskListPage {
@@ -35,7 +35,7 @@ export default class CurrentRisk implements TaskListPage {
   }
 
   next() {
-    return 'historicalRisk'
+    return 'historical-risk'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -1,0 +1,54 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type CurrentRiskBody = { currentRiskDetail: string }
+
+@Page({
+  name: 'currentRisk',
+  bodyProperties: ['currentRiskDetail'],
+})
+export default class CurrentRisk implements TaskListPage {
+  title = `${nameOrPlaceholderCopy(this.application.person)}'s current risks`
+
+  questions = {
+    currentRiskDetail: {
+      question: `Describe ${nameOrPlaceholderCopy(
+        this.application.person,
+      )}'s current issues and needs related to self harm and suicide`,
+    },
+  }
+
+  body: CurrentRiskBody
+
+  constructor(
+    body: Partial<CurrentRiskBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as CurrentRiskBody
+  }
+
+  previous() {
+    return 'vulnerability'
+  }
+
+  next() {
+    return 'historicalRisk'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.currentRiskDetail.question]: this.body.currentRiskDetail,
+    }
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.test.ts
@@ -1,0 +1,50 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import HistoricalRisk from './historicalRisk'
+
+describe('HistoricalRisk', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new HistoricalRisk({}, application)
+
+      expect(page.title).toEqual("Roger Smith's historical risks")
+    })
+  })
+
+  describe('Questions', () => {
+    const page = new HistoricalRisk({}, application)
+
+    describe('historicalRiskDetail', () => {
+      it('has a question', () => {
+        expect(page.questions.historicalRiskDetail.question).toBeDefined()
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new HistoricalRisk({}, application), 'acct')
+  itShouldHavePreviousValue(new HistoricalRisk({}, application), 'current-risk')
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new HistoricalRisk(
+        {
+          historicalRiskDetail: 'is at risk',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        "Describe Roger Smith's historical issues and needs related to self harm and suicide": 'is at risk',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns empty object', () => {
+      const page = new HistoricalRisk({}, application)
+      expect(page.errors()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
@@ -1,0 +1,54 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+
+type HistoricalRiskBody = { historicalRiskDetail: string }
+
+@Page({
+  name: 'historical-risk',
+  bodyProperties: ['historicalRiskDetail'],
+})
+export default class HistoricalRisk implements TaskListPage {
+  title = `${nameOrPlaceholderCopy(this.application.person)}'s historical risks`
+
+  questions = {
+    historicalRiskDetail: {
+      question: `Describe ${nameOrPlaceholderCopy(
+        this.application.person,
+      )}'s historical issues and needs related to self harm and suicide`,
+    },
+  }
+
+  body: HistoricalRiskBody
+
+  constructor(
+    body: Partial<HistoricalRiskBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as HistoricalRiskBody
+  }
+
+  previous() {
+    return 'current-risk'
+  }
+
+  next() {
+    return 'acct'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+
+  response() {
+    const response = {
+      [this.questions.historicalRiskDetail.question]: this.body.historicalRiskDetail,
+    }
+
+    return response
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
@@ -1,12 +1,13 @@
 /* istanbul ignore file */
 
 import { Task } from '../../../utils/decorators'
+import CurrentRisk from './currentRisk'
 import RiskToSelfGuidance from './riskToSelfGuidance'
 import Vulnerability from './vulnerability'
 
 @Task({
   name: 'Review risk to self information',
   slug: 'risk-to-self',
-  pages: [RiskToSelfGuidance, Vulnerability],
+  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk],
 })
 export default class RiskToSelf {}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
@@ -2,12 +2,13 @@
 
 import { Task } from '../../../utils/decorators'
 import CurrentRisk from './currentRisk'
+import HistoricalRisk from './historicalRisk'
 import RiskToSelfGuidance from './riskToSelfGuidance'
 import Vulnerability from './vulnerability'
 
 @Task({
   name: 'Review risk to self information',
   slug: 'risk-to-self',
-  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk],
+  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk, HistoricalRisk],
 })
 export default class RiskToSelf {}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import { Task } from '../../../utils/decorators'
+import Acct from './acct'
 import CurrentRisk from './currentRisk'
 import HistoricalRisk from './historicalRisk'
 import RiskToSelfGuidance from './riskToSelfGuidance'
@@ -9,6 +10,6 @@ import Vulnerability from './vulnerability'
 @Task({
   name: 'Review risk to self information',
   slug: 'risk-to-self',
-  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk, HistoricalRisk],
+  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk, HistoricalRisk, Acct],
 })
 export default class RiskToSelf {}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/index.ts
@@ -2,6 +2,7 @@
 
 import { Task } from '../../../utils/decorators'
 import Acct from './acct'
+import AdditionalInformation from './additionalInformation'
 import CurrentRisk from './currentRisk'
 import HistoricalRisk from './historicalRisk'
 import RiskToSelfGuidance from './riskToSelfGuidance'
@@ -10,6 +11,6 @@ import Vulnerability from './vulnerability'
 @Task({
   name: 'Review risk to self information',
   slug: 'risk-to-self',
-  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk, HistoricalRisk, Acct],
+  pages: [RiskToSelfGuidance, Vulnerability, CurrentRisk, HistoricalRisk, Acct, AdditionalInformation],
 })
 export default class RiskToSelf {}

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
@@ -23,7 +23,7 @@ describe('Vulnerability', () => {
     })
   })
 
-  itShouldHaveNextValue(new Vulnerability({}, application), '')
+  itShouldHaveNextValue(new Vulnerability({}, application), 'current-risk')
   itShouldHavePreviousValue(new Vulnerability({}, application), 'taskList')
 
   describe('response', () => {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -35,7 +35,7 @@ export default class Vulnerability implements TaskListPage {
   }
 
   next() {
-    return ''
+    return 'current-risk'
   }
 
   errors() {

--- a/server/views/applications/pages/risk-to-self/_risk-to-self-screen.njk
+++ b/server/views/applications/pages/risk-to-self/_risk-to-self-screen.njk
@@ -1,0 +1,46 @@
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="{{ pageName }}">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-4">
+    <div class="govuk-grid-column-one-third">
+      {{ mojSideNavigation({
+          items: [{
+            text: 'Vulnerability',
+            href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'vulnerability' }),
+            active: (pageName === 'vulnerability')
+          }, {
+            text: 'Current risk',
+            href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'current-risk' }),
+            active: (pageName === 'current-risk')
+          }, {
+            text: 'Historical risk',
+            href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'historical-risk' }),
+            active: (pageName === 'historical-risk')
+          }, {
+            text: 'ACCT',
+            href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'acct' }),
+            active: (pageName === 'acct')
+          }, {
+            text: 'Additional information',
+            href: paths.applications.pages.show({ id: applicationId, task: 'risk-to-self', page: 'additional-information' }),
+            active: (pageName === 'additional-information')
+          }]
+        }) }}
+    </div>
+
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-top-4">
+      {{ super() }}
+    </div>
+
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/risk-to-self/acct.njk
+++ b/server/views/applications/pages/risk-to-self/acct.njk
@@ -1,0 +1,6 @@
+{% extends "./_risk-to-self-screen.njk" %}
+{% set pageName = "acct" %}
+
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+{% endblock %}

--- a/server/views/applications/pages/risk-to-self/additional-information.njk
+++ b/server/views/applications/pages/risk-to-self/additional-information.njk
@@ -1,0 +1,17 @@
+{% extends "./_risk-to-self-screen.njk" %}
+{% set pageName = "additional-information" %}
+
+{% block questions %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'additionalInformationDetail',
+          label: {
+            text: page.questions.additionalInformationDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+  }}
+{% endblock %}

--- a/server/views/applications/pages/risk-to-self/current-risk.njk
+++ b/server/views/applications/pages/risk-to-self/current-risk.njk
@@ -1,0 +1,17 @@
+{% extends "./_risk-to-self-screen.njk" %}
+{% set pageName = "current-risk" %}
+
+{% block questions %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'currentRiskDetail',
+          label: {
+            text: page.questions.currentRiskDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+  }}
+{% endblock %}

--- a/server/views/applications/pages/risk-to-self/historical-risk.njk
+++ b/server/views/applications/pages/risk-to-self/historical-risk.njk
@@ -1,0 +1,17 @@
+{% extends "./_risk-to-self-screen.njk" %}
+{% set pageName = "historical-risk" %}
+
+{% block questions %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'historicalRiskDetail',
+          label: {
+            text: page.questions.historicalRiskDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+  }}
+{% endblock %}

--- a/server/views/applications/pages/risk-to-self/vulnerability.njk
+++ b/server/views/applications/pages/risk-to-self/vulnerability.njk
@@ -1,7 +1,7 @@
-{% extends "../layout.njk" %}
-{% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+{% extends "./_risk-to-self-screen.njk" %}
+{% set pageName = "vulnerability" %}
 
+{% block questions %}
   {{
       formPageTextArea(
         {
@@ -13,6 +13,5 @@
         },
         fetchContext()
       )
-    }}
-
+  }}
 {% endblock %}


### PR DESCRIPTION
This can be merged after the work to refactor the guidance page https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/176 

We would like to have a bare bones 'scaffolding' for the Risk to Self page, so that we can work on pages in parallel.

This PR adds basic pages (some with text areas so we can see data autopopulating) and basic tests

![Screenshot 2023-08-29 at 16 40 26](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/1ef397f0-690c-4a9b-ab4c-c08f15478b65)

![Screenshot 2023-08-29 at 16 40 31](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/ec4e4809-c2a1-4537-a2b2-363740f53f5a)

![Screenshot 2023-08-29 at 16 40 39](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/fa23ed94-c196-4b2e-b6bd-198853944fc1)


etc.