### PR TITLE
setup Google Tag Manager

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -102,4 +102,7 @@ export default {
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
   },
+  analytics: {
+    tagManagerId: get('TAG_MANAGER_ID', null),
+  },
 }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
@@ -107,6 +107,7 @@ export default class RiskToSelfGuidance implements TaskListPage {
           break
       }
     })
+
     return taskData
   }
 

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -26,6 +26,11 @@ export default function setUpWebSecurity(): Router {
           // page by an attacker.
           scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          scriptSrcElem: [
+            "'self'",
+            'www.googletagmanager.com',
+            (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
+          ],
           fontSrc: ["'self'"],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
         },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,10 +6,10 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 
 import applicationPaths from '../paths/apply'
+import config from '../config'
 import { initialiseName } from './utils'
 import { dashboardTableRows } from './applicationUtils'
 import * as TaskListUtils from './taskListUtils'
-
 import * as OasysImportUtils from './oasysImportUtils'
 
 const production = process.env.NODE_ENV === 'production'
@@ -62,4 +62,12 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('TaskListUtils', TaskListUtils)
 
   njkEnv.addGlobal('dashboardTableRows', dashboardTableRows)
+
+  const {
+    analytics: { tagManagerId },
+  } = config
+  if (tagManagerId) {
+    njkEnv.addGlobal('tagManagerId', tagManagerId.trim())
+    njkEnv.addGlobal('tagManagerUrl', `https://www.googletagmanager.com/ns.html?id=${tagManagerId.trim()}`)
+  }
 }

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -19,6 +19,27 @@
           crossorigin="anonymous"></script>
   <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
+  {% if tagManagerId %}
+    <!-- Google Tag Manager -->
+    <script nonce="{{ cspNonce }}">
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer'
+            ? '&l=' + l
+            : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f
+          .parentNode
+          .insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', "{{ tagManagerId }}");
+    </script>
+    <!-- End Google Tag Manager -->
+  {% endif %}
+
 {% endblock %}
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}
@@ -36,5 +57,15 @@
   <script src="/assets/govuk/all.js"></script>
   <script src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
+
+  {% if tagManagerId %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe nonce="{{ cspNonce }}" src="{{ tagManagerUrl }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
+
   {% block extraScripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
setup Google Tag Manager

We would like to use GTM as an analytics tool. This setup adds the
script provided by GTM to start collecting data, with added
configuration for our content security policy:
* we've added the id to our secrets in dev environment
* we've added `www.googletagmanager.com` to our `scriptSrcElem` helmet
  policy to allow the script to be executed.[2]

With help from step-by-step guide from the 'Create and Vary a License'
docs here:
https://dsdmoj.atlassian.net/wiki/spaces/CVL/pages/3765338186/Analytics+Setup
setUpWebSecurity.ts though ours have diverged to use the Google Tag
Manager specific scripts.

[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem