### PR TITLE
503 risk to self oasys import date on pages

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -11,6 +11,8 @@ $govuk-page-width: $moj-page-width;
 @import './components/task-list';
 @import './components/copy-text';
 
+@import './pages//oasys-import';
+
 @import 'assets/scss/local';
 
 .govuk-panel--fail {

--- a/assets/scss/pages/_oasys-import.scss
+++ b/assets/scss/pages/_oasys-import.scss
@@ -1,0 +1,3 @@
+.date-of-import {
+  color: govuk-colour('dark-grey');
+}

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -116,13 +116,16 @@
   "risk-to-self": {
     "guidance": {},
     "vulnerability": {
-      "vulnerabilityDetail": "example answer vulnerability"
+      "vulnerabilityDetail": "example answer vulnerability",
+      "dateOfOasysImport": "2023-08-31"
     },
     "current-risk": {
-      "currentRiskDetail": "example answer current risk"
+      "currentRiskDetail": "example answer current risk",
+      "dateOfOasysImport": "2023-08-31"
     },
     "historical-risk": {
-      "historicalRiskDetail": "example answer historical risk "
+      "historicalRiskDetail": "example answer historical risk ",
+      "dateOfOasysImport": "2023-08-31"
     }
   }
 }

--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -1,6 +1,7 @@
 import { Cas2Application as Application } from '@approved-premises/api'
 import Page from '../page'
 import TaskListPage from '../../../server/form-pages/taskListPage'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 import Apply from '../../../server/form-pages/apply'
 
@@ -23,5 +24,11 @@ export default class ApplyPage extends Page {
 
   selectAnswer(name: string, option: string): void {
     this.checkRadioByNameAndValue(name, option)
+  }
+
+  shouldShowOasysImportDate(application: Application, task: string, page: string): void {
+    const date = application.data[task][page].dateOfOasysImport
+
+    cy.get('p').contains(`Imported from OASys on ${DateFormats.isoDateToUIDate(date, { format: 'medium' })}`)
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,4 +1,5 @@
 import errorLookups from '../../server/i18n/en/errors.json'
+import { DateFormats } from '../../server/utils/dateUtils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -50,5 +51,9 @@ export default abstract class Page {
 
   checkCheckboxByLabel(option: string): void {
     cy.get(`input[value="${option}"]`).check()
+  }
+
+  shouldShowOasysImportDate(date: string): void {
+    cy.get('p').contains(`Imported from OASys on ${DateFormats.isoDateToUIDate(date, { format: 'medium' })}`)
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,5 +1,4 @@
 import errorLookups from '../../server/i18n/en/errors.json'
-import { DateFormats } from '../../server/utils/dateUtils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -51,9 +50,5 @@ export default abstract class Page {
 
   checkCheckboxByLabel(option: string): void {
     cy.get(`input[value="${option}"]`).check()
-  }
-
-  shouldShowOasysImportDate(date: string): void {
-    cy.get('p').contains(`Imported from OASys on ${DateFormats.isoDateToUIDate(date, { format: 'medium' })}`)
   }
 }

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents current risk page', function test() {
     const page = Page.verifyOnPage(CurrentRiskPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application.data['risk-to-self']['current-risk'].dateOfOasysImport)
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'current-risk')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
@@ -30,7 +30,6 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['risk-to-self'] = {}
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -58,7 +57,9 @@ context('Visit "Risks and needs" section', () => {
   //  Scenario: view current risk questions
   //    Then I see the "current risk" page
   it('presents current risk page', function test() {
-    Page.verifyOnPage(CurrentRiskPage, this.application)
+    const page = Page.verifyOnPage(CurrentRiskPage, this.application)
+
+    page.shouldShowOasysImportDate(this.application.data['risk-to-self']['current-risk'].dateOfOasysImport)
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents historical risk page', function test() {
     const page = Page.verifyOnPage(HistoricalRiskPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application.data['risk-to-self']['historical-risk'].dateOfOasysImport)
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'historical-risk')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
@@ -30,7 +30,6 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['risk-to-self'] = {}
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -58,7 +57,9 @@ context('Visit "Risks and needs" section', () => {
   //  Scenario: view historical risk questions
   //    Then I see the "historical risk" page
   it('presents historical risk page', function test() {
-    Page.verifyOnPage(HistoricalRiskPage, this.application)
+    const page = Page.verifyOnPage(HistoricalRiskPage, this.application)
+
+    page.shouldShowOasysImportDate(this.application.data['risk-to-self']['historical-risk'].dateOfOasysImport)
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents vulnerability page', function test() {
     const page = Page.verifyOnPage(VulnerabilityPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application.data['risk-to-self'].vulnerability.dateOfOasysImport)
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'vulnerability')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
@@ -30,7 +30,6 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['risk-to-self'] = {}
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -58,7 +57,9 @@ context('Visit "Risks and needs" section', () => {
   //  Scenario: view vulnerability questions
   //    Then I see the "vulnerability" page
   it('presents vulnerability page', function test() {
-    Page.verifyOnPage(VulnerabilityPage, this.application)
+    const page = Page.verifyOnPage(VulnerabilityPage, this.application)
+
+    page.shouldShowOasysImportDate(this.application.data['risk-to-self'].vulnerability.dateOfOasysImport)
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.test.ts
@@ -13,6 +13,14 @@ describe('CurrentRisk', () => {
     })
   })
 
+  describe('import date', () => {
+    it('sets importDate to false where application contains no OASys import date', () => {
+      const page = new CurrentRisk({}, application)
+
+      expect(page.importDate).toEqual(null)
+    })
+  })
+
   describe('Questions', () => {
     const page = new CurrentRisk({}, application)
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -3,6 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
+import { DateFormats } from '../../../../utils/dateUtils'
 
 type CurrentRiskBody = { currentRiskDetail: string }
 
@@ -22,6 +23,10 @@ export default class CurrentRisk implements TaskListPage {
   }
 
   body: CurrentRiskBody
+
+  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self']['current-risk'].dateOfOasysImport, {
+    format: 'medium',
+  })
 
   constructor(
     body: Partial<CurrentRiskBody>,

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -24,9 +24,11 @@ export default class CurrentRisk implements TaskListPage {
 
   body: CurrentRiskBody
 
-  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self']['current-risk'].dateOfOasysImport, {
-    format: 'medium',
-  })
+  importDate = this.application.data?.['risk-to-self']?.['current-risk'].dateOfOasysImport
+    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.['current-risk'].dateOfOasysImport, {
+        format: 'medium',
+      })
+    : null
 
   constructor(
     body: Partial<CurrentRiskBody>,

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -3,7 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { getOasysImportDateFromApplication } from '../../../utils'
 
 type CurrentRiskBody = { currentRiskDetail: string }
 
@@ -24,11 +24,7 @@ export default class CurrentRisk implements TaskListPage {
 
   body: CurrentRiskBody
 
-  importDate = this.application.data?.['risk-to-self']?.['current-risk'].dateOfOasysImport
-    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.['current-risk'].dateOfOasysImport, {
-        format: 'medium',
-      })
-    : null
+  importDate = getOasysImportDateFromApplication(this.application, 'current-risk')
 
   constructor(
     body: Partial<CurrentRiskBody>,

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.test.ts
@@ -13,6 +13,14 @@ describe('HistoricalRisk', () => {
     })
   })
 
+  describe('import date', () => {
+    it('sets importDate to false where application contains no OASys import date', () => {
+      const page = new HistoricalRisk({}, application)
+
+      expect(page.importDate).toEqual(null)
+    })
+  })
+
   describe('Questions', () => {
     const page = new HistoricalRisk({}, application)
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
@@ -22,9 +22,11 @@ export default class HistoricalRisk implements TaskListPage {
     },
   }
 
-  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self']['historical-risk'].dateOfOasysImport, {
-    format: 'medium',
-  })
+  importDate = this.application.data?.['risk-to-self']?.['historical-risk'].dateOfOasysImport
+    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.['historical-risk'].dateOfOasysImport, {
+        format: 'medium',
+      })
+    : null
 
   body: HistoricalRiskBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
@@ -3,7 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { getOasysImportDateFromApplication } from '../../../utils'
 
 type HistoricalRiskBody = { historicalRiskDetail: string }
 
@@ -22,11 +22,7 @@ export default class HistoricalRisk implements TaskListPage {
     },
   }
 
-  importDate = this.application.data?.['risk-to-self']?.['historical-risk'].dateOfOasysImport
-    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.['historical-risk'].dateOfOasysImport, {
-        format: 'medium',
-      })
-    : null
+  importDate = getOasysImportDateFromApplication(this.application, 'historical-risk')
 
   body: HistoricalRiskBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
@@ -3,6 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
+import { DateFormats } from '../../../../utils/dateUtils'
 
 type HistoricalRiskBody = { historicalRiskDetail: string }
 
@@ -20,6 +21,10 @@ export default class HistoricalRisk implements TaskListPage {
       )}'s historical issues and needs related to self harm and suicide`,
     },
   }
+
+  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self']['historical-risk'].dateOfOasysImport, {
+    format: 'medium',
+  })
 
   body: HistoricalRiskBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.test.ts
@@ -18,6 +18,17 @@ describe('RiskToSelfGuidance', () => {
 
   const dataServices = createMock<DataServices>({ personService: createMock<PersonService>({}) })
 
+  const now = new Date()
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(now)
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   describe('title', () => {
     it('personalises the page title', () => {
       const page = new RiskToSelfGuidance({}, application, oasys, '')
@@ -54,9 +65,9 @@ describe('RiskToSelfGuidance', () => {
 
         const taskData = {
           'risk-to-self': {
-            'current-risk': { currentRiskDetail: 'self harm answer' },
-            vulnerability: { vulnerabilityDetail: 'vulnerability answer' },
-            'historical-risk': { historicalRiskDetail: 'historical answer' },
+            'current-risk': { currentRiskDetail: 'self harm answer', dateOfOasysImport: now },
+            vulnerability: { vulnerabilityDetail: 'vulnerability answer', dateOfOasysImport: now },
+            'historical-risk': { historicalRiskDetail: 'historical answer', dateOfOasysImport: now },
           },
         }
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
@@ -15,6 +15,7 @@ export type RiskToSelfTaskData = {
     }
     vulnerability: {
       vulnerabilityDetail: string
+      dateOfOasysImport: Date
     }
     'historical-risk': {
       historicalRiskDetail: string
@@ -92,13 +93,15 @@ export default class RiskToSelfGuidance implements TaskListPage {
 
   private static getTaskData(oasysSections: OASysRiskToSelf): Partial<RiskToSelfTaskData> {
     const taskData = { 'risk-to-self': {} } as Partial<RiskToSelfTaskData>
+    const today = new Date()
+
     oasysSections.riskToSelf.forEach(question => {
       switch (question.questionNumber) {
         case 'R8.1.1':
           taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer }
           break
         case 'R8.3.1':
-          taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer }
+          taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer, dateOfOasysImport: today }
           break
         case 'R8.1.4':
           taskData['risk-to-self']['historical-risk'] = { historicalRiskDetail: question.answer }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/riskToSelfGuidance.ts
@@ -12,6 +12,7 @@ export type RiskToSelfTaskData = {
   'risk-to-self': {
     'current-risk': {
       currentRiskDetail: string
+      dateOfOasysImport: Date
     }
     vulnerability: {
       vulnerabilityDetail: string
@@ -19,6 +20,7 @@ export type RiskToSelfTaskData = {
     }
     'historical-risk': {
       historicalRiskDetail: string
+      dateOfOasysImport: Date
     }
   }
 }
@@ -98,13 +100,16 @@ export default class RiskToSelfGuidance implements TaskListPage {
     oasysSections.riskToSelf.forEach(question => {
       switch (question.questionNumber) {
         case 'R8.1.1':
-          taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer }
+          taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer, dateOfOasysImport: today }
           break
         case 'R8.3.1':
           taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer, dateOfOasysImport: today }
           break
         case 'R8.1.4':
-          taskData['risk-to-self']['historical-risk'] = { historicalRiskDetail: question.answer }
+          taskData['risk-to-self']['historical-risk'] = {
+            historicalRiskDetail: question.answer,
+            dateOfOasysImport: today,
+          }
           break
         default:
           break

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
@@ -13,6 +13,14 @@ describe('Vulnerability', () => {
     })
   })
 
+  describe('import date', () => {
+    it('sets importDate to false where application contains no OASys import date', () => {
+      const page = new Vulnerability({}, application)
+
+      expect(page.importDate).toEqual(null)
+    })
+  })
+
   describe('Questions', () => {
     const page = new Vulnerability({}, application)
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -22,9 +22,11 @@ export default class Vulnerability implements TaskListPage {
     },
   }
 
-  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self'].vulnerability.dateOfOasysImport, {
-    format: 'medium',
-  })
+  importDate = this.application.data?.['risk-to-self']?.vulnerability.dateOfOasysImport
+    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.vulnerability.dateOfOasysImport, {
+        format: 'medium',
+      })
+    : null
 
   body: VulnerabilityBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -3,7 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { getOasysImportDateFromApplication } from '../../../utils'
 
 type VulnerabilityBody = { vulnerabilityDetail: string }
 
@@ -22,11 +22,7 @@ export default class Vulnerability implements TaskListPage {
     },
   }
 
-  importDate = this.application.data?.['risk-to-self']?.vulnerability.dateOfOasysImport
-    ? DateFormats.isoDateToUIDate(this.application.data?.['risk-to-self']?.vulnerability.dateOfOasysImport, {
-        format: 'medium',
-      })
-    : null
+  importDate = getOasysImportDateFromApplication(this.application, 'vulnerability')
 
   body: VulnerabilityBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -3,6 +3,7 @@ import { Cas2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
+import { DateFormats } from '../../../../utils/dateUtils'
 
 type VulnerabilityBody = { vulnerabilityDetail: string }
 
@@ -20,6 +21,10 @@ export default class Vulnerability implements TaskListPage {
       )}'s current circumstances, issues and needs related to vulnerability`,
     },
   }
+
+  importDate = DateFormats.isoDateToUIDate(this.application.data['risk-to-self'].vulnerability.dateOfOasysImport, {
+    format: 'medium',
+  })
 
   body: VulnerabilityBody
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -9,6 +9,10 @@ import { ApprovedPremisesApplication } from '../../@types/shared'
 import { applicationFactory } from '../../testutils/factories'
 import { TaskListPageInterface } from '../taskListPage'
 
+import { DateFormats } from '../../utils/dateUtils'
+
+jest.mock('../../utils/dateUtils')
+
 describe('utils', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -159,6 +163,26 @@ describe('utils', () => {
 
         expect(utils.pageDataFromApplication(page, application)).toEqual({})
       })
+    })
+  })
+
+  describe('getOasysImportDateFromApplication', () => {
+    it('calls date formatting function when as OASys import date exists', () => {
+      const application = applicationFactory.build({
+        data: { 'risk-to-self': { 'historical-risk': { dateOfOasysImport: 'some date' } } },
+      })
+
+      ;(DateFormats.isoDateToUIDate as jest.Mock).mockImplementation(() => null)
+
+      utils.getOasysImportDateFromApplication(application, 'historical-risk')
+
+      expect(DateFormats.isoDateToUIDate).toHaveBeenCalledWith('some date', { format: 'medium' })
+    })
+
+    it('returns null where no import date exists on application', () => {
+      const application = applicationFactory.build({ data: null })
+
+      expect(utils.getOasysImportDateFromApplication(application, 'historical-risk')).toEqual(null)
     })
   })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,6 +1,8 @@
 import type { Request } from 'express'
+import { Cas2Application as Application } from '@approved-premises/api'
 import type { FormArtifact, JourneyType, UiTask } from '@approved-premises/ui'
 import { TaskListPageInterface } from '../taskListPage'
+import { DateFormats } from '../../utils/dateUtils'
 
 export const getTask = <T>(task: T) => {
   const taskPages = {}
@@ -82,4 +84,13 @@ export function pageDataFromApplication(Page: TaskListPageInterface, application
   const taskName = getTaskName(Page)
 
   return application.data?.[taskName]?.[pageName] || {}
+}
+
+export function getOasysImportDateFromApplication(application: Application, pageName: string): string | null {
+  if (application.data?.['risk-to-self']?.[pageName]?.dateOfOasysImport) {
+    return DateFormats.isoDateToUIDate(application.data['risk-to-self'][pageName].dateOfOasysImport, {
+      format: 'medium',
+    })
+  }
+  return null
 }

--- a/server/views/applications/pages/risk-to-self/current-risk.njk
+++ b/server/views/applications/pages/risk-to-self/current-risk.njk
@@ -1,7 +1,14 @@
 {% extends "./_risk-to-self-screen.njk" %}
+{% from "../../../partials/dateOfOasysImport.njk" import dateOfOasysImport %}
+
 {% set pageName = "current-risk" %}
 
 {% block questions %}
+  {% if page.importDate %}
+    {% set date = page.importDate %}
+    {{dateOfOasysImport(date)}}
+  {% endif %}
+
   {{
       formPageTextArea(
         {

--- a/server/views/applications/pages/risk-to-self/historical-risk.njk
+++ b/server/views/applications/pages/risk-to-self/historical-risk.njk
@@ -1,7 +1,14 @@
 {% extends "./_risk-to-self-screen.njk" %}
+{% from "../../../partials/dateOfOasysImport.njk" import dateOfOasysImport %}
+
 {% set pageName = "historical-risk" %}
 
 {% block questions %}
+  {% if page.importDate %}
+    {% set date = page.importDate %}
+    {{dateOfOasysImport(date)}}
+  {% endif %}
+
   {{
       formPageTextArea(
         {

--- a/server/views/applications/pages/risk-to-self/vulnerability.njk
+++ b/server/views/applications/pages/risk-to-self/vulnerability.njk
@@ -1,7 +1,15 @@
 {% extends "./_risk-to-self-screen.njk" %}
+{% from "../../../partials/dateOfOasysImport.njk" import dateOfOasysImport %}
+
 {% set pageName = "vulnerability" %}
 
 {% block questions %}
+
+  {% if page.importDate %}
+    {% set date = page.importDate %}
+    {{dateOfOasysImport(date)}}
+  {% endif %}
+
   {{
       formPageTextArea(
         {

--- a/server/views/partials/dateOfOasysImport.njk
+++ b/server/views/partials/dateOfOasysImport.njk
@@ -1,0 +1,6 @@
+{% macro dateOfOasysImport(date) %}
+
+  <p class="date-of-import">Imported from OASys on <strong>{{date}}</strong>
+  </p>
+
+{% endmacro %}


### PR DESCRIPTION
# Changes in this PR

This PR renders the date that risk to self records were imported into the application from OASys, if records have been imported.

Also temporarily pins the NPM version to unblock our CI pipelines.

## Screenshots of UI changes

### Before

![Screenshot 2023-09-01 at 14 24 07](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/9af72078-1112-4a7c-afa6-cbaab67e1e68)

### After

![Screenshot 2023-09-01 at 14 23 30](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/12410a5d-473c-4b96-9bb7-06670dec38df)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
