### PR TITLE
Tweak validation error messages on 'Health: communication needs' page

### DIFF
--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
@@ -99,7 +99,7 @@ describe('CommunicationAndLanguage', () => {
 
       describe('and _communicationDetail_ is UNANSWERED', () => {
         it('includes a validation error for _communicationDetail_', () => {
-          expect(page.errors()).toHaveProperty('communicationDetail', 'Provide details of their additional needs')
+          expect(page.errors()).toHaveProperty('communicationDetail', 'Describe their communication needs')
         })
       })
     })
@@ -109,7 +109,10 @@ describe('CommunicationAndLanguage', () => {
 
       describe('and _interpretationDetail_ is UNANSWERED', () => {
         it('includes a validation error for _interpretationDetail_', () => {
-          expect(page.errors()).toHaveProperty('interpretationDetail', 'Specify the language needing interpretation')
+          expect(page.errors()).toHaveProperty(
+            'interpretationDetail',
+            'Specify the language the interpreter is needed for',
+          )
         })
       })
     })
@@ -119,7 +122,10 @@ describe('CommunicationAndLanguage', () => {
 
       describe('and _supportDetail_ is UNANSWERED', () => {
         it('includes a validation error for _supportDetail_', () => {
-          expect(page.errors()).toHaveProperty('supportDetail', 'Provide details of the support needed')
+          expect(page.errors()).toHaveProperty(
+            'supportDetail',
+            'Describe the support needed to see, hear, speak or understand',
+          )
         })
       })
     })

--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
@@ -72,21 +72,21 @@ export default class CommunicationAndLanguage implements TaskListPage {
       errors.hasCommunicationNeeds = `Confirm whether they have additional communication needs`
     }
     if (this.body.hasCommunicationNeeds === 'yes' && !this.body.communicationDetail) {
-      errors.communicationDetail = 'Provide details of their additional needs'
+      errors.communicationDetail = 'Describe their communication needs'
     }
 
     if (!this.body.requiresInterpreter) {
       errors.requiresInterpreter = `Confirm whether they need an interpreter`
     }
     if (this.body.requiresInterpreter === 'yes' && !this.body.interpretationDetail) {
-      errors.interpretationDetail = 'Specify the language needing interpretation'
+      errors.interpretationDetail = 'Specify the language the interpreter is needed for'
     }
 
     if (!this.body.hasSupportNeeds) {
       errors.hasSupportNeeds = `Confirm they they need support`
     }
     if (this.body.hasSupportNeeds === 'yes' && !this.body.supportDetail) {
-      errors.supportDetail = 'Provide details of the support needed'
+      errors.supportDetail = 'Describe the support needed to see, hear, speak or understand'
     }
 
     return errors


### PR DESCRIPTION
# Tweak validation error messages on 'Health: communication needs' page

This PR tweaks the 3 validation error messages where follow-on questions haven't been answered. See [Trello 373](https://trello.com/c/6V6oEPu8/373-health-subsection-communication-and-language-needs)

# Changes in this PR

## Screenshots of UI changes

![health_communication_error_tweaks](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/aabc1895-ad3e-4ff0-b3cf-67d78224fc0c)


