### PR TITLE
Tweak 2 validation error messages on Health: Learning difficulties page

### DIFF
--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
@@ -117,7 +117,7 @@ describe('LearningDifficulties', () => {
 
       describe('and _needsDetail_ is UNANSWERED', () => {
         it('includes a validation error for _needsDetail_', () => {
-          expect(page.errors()).toHaveProperty('needsDetail', 'Describe their additional needs')
+          expect(page.errors()).toHaveProperty('needsDetail', 'Describe the additional support required')
         })
       })
     })
@@ -137,7 +137,10 @@ describe('LearningDifficulties', () => {
 
       describe('and _interactionDetail_ is UNANSWERED', () => {
         it('includes a validation error for _interactionDetail_', () => {
-          expect(page.errors()).toHaveProperty('interactionDetail', 'Describe their difficulties interacting')
+          expect(page.errors()).toHaveProperty(
+            'interactionDetail',
+            'Describe their difficulties interacting with other people',
+          )
         })
       })
     })

--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
@@ -82,7 +82,7 @@ export default class LearningDifficulties implements TaskListPage {
       errors.hasLearningNeeds = `Confirm whether they have additional needs`
     }
     if (this.body.hasLearningNeeds === 'yes' && !this.body.needsDetail) {
-      errors.needsDetail = 'Describe their additional needs'
+      errors.needsDetail = 'Describe the additional support required'
     }
 
     if (!this.body.isVulnerable) {
@@ -96,7 +96,7 @@ export default class LearningDifficulties implements TaskListPage {
       errors.hasDifficultyInteracting = `Confirm whether they have difficulties interacting`
     }
     if (this.body.hasDifficultyInteracting === 'yes' && !this.body.interactionDetail) {
-      errors.interactionDetail = 'Describe their difficulties interacting'
+      errors.interactionDetail = 'Describe their difficulties interacting with other people'
     }
 
     if (!this.body.requiresAdditionalSupport) {


### PR DESCRIPTION
# Tweak 2 validation error messages on Health: Learning difficulties page

See [Trello 375](https://trello.com/c/SmsCqlYJ/375-health-subsection-learning-difficulties-and-neurodiversity)

# Changes in this PR

This PR tweaks the text of 2 of the validation error messages shown when follow-on questions are not answered.

## Screenshots of UI changes

![health_learning_difficulties_tweaks](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/084a7051-7e3f-4cca-b7c7-081e134f7128)

