### PR TITLE
add `TAG_MANAGER_ID` secret

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,8 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   namespace_secrets:
+    hmpps-community-accommodation-tier-2-ui:
+      TAG_MANAGER_ID: "TAG_MANAGER_ID"
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"


### PR DESCRIPTION
# Context

This adds the google tag manager ID as a secret for the kubernetes pod to read. The secret has already been added via kubectl. When we have a preprod/prod environment we can add to those values, but initially only needed in dev.
