### PR TITLE
add Google analytics to our Content Security Policy

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -24,6 +24,11 @@ export default function setUpWebSecurity(): Router {
           // <link href="http://example.com/" rel="stylesheet" nonce="{{ cspNonce }}">
           // This ensures only scripts we trust are loaded, and not anything injected into the
           // page by an attacker.
+          connectSrc: [
+            "'self'",
+            '*.google-analytics.com',
+            (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
+          ],
           scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           scriptSrcElem: [


### PR DESCRIPTION
This allows any calls to `google-analytics.com` to go through, (as well as our own calls and anything using the `cspNonce`) so that Tag Manager can feed through to GA.
