### PR TITLE
Allow import of RoSH data from OASys

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -147,9 +147,20 @@
   "risk-of-serious-harm": {
     "oasys-import": {},
     "summary": {},
-    "risk-to-others": {},
-    "risk-factors": {},
-    "reducing-risk": {},
+    "risk-to-others": {
+      "whoIsAtRisk": "a person",
+      "natureOfRisk": "a nature",
+      "dateOfOasysImport": "some date"
+    },
+    "risk-factors": {
+      "circumstancesLikelyToIncreaseRisk": "a circumstance",
+      "whenIsRiskLikelyToBeGreatest": "a time",
+      "dateOfOasysImport": "some date"
+    },
+    "reducing-risk": {
+      "factorsLikelyToReduceRisk": "a factor",
+      "dateOfOasysImport": "some date"
+    },
     "risk-management-arrangements": {},
     "cell-share-information": {},
     "behaviour-notes": {},

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,4 +1,4 @@
-import type { OASysRiskToSelf, Person } from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 
 export default {
@@ -20,6 +20,32 @@ export default {
       request: {
         method: 'GET',
         url: `/people/${args.crn}/oasys/risk-to-self`,
+      },
+      response: {
+        status: 404,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { status: 404 },
+      },
+    }),
+
+  stubOasysRosh: (args: { crn: string; oasysRosh: OASysRiskOfSeriousHarm }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.crn}/oasys/rosh`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.oasysRosh,
+      },
+    }),
+
+  stubOasysRoshNotFound: (args: { crn: string }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.crn}/oasys/rosh`,
       },
       response: {
         status: 404,

--- a/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/oasysImportPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/oasysImportPage.ts
@@ -22,4 +22,10 @@ export default class OasysImportPage extends ApplyPage {
       }),
     )
   }
+
+  checkOasysInfo = (application): void => {
+    cy.get('h2').contains(`OASys record available for ${application.person.name}`)
+    cy.get('p').contains('Date created: 26 July 2022')
+    cy.get('p').contains('Date completed: 27 July 2022')
+  }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,3 +1,4 @@
+import { OASysRiskOfSeriousHarm } from '../shared/models/OASysRiskOfSeriousHarm'
 import { OASysRiskToSelf } from '../shared/models/OASysRiskToSelf'
 import { OASysSections } from '../shared/models/OASysSections'
 
@@ -49,6 +50,7 @@ export type DataServices = Partial<{
     findByCrn: (token: string, crn: string) => Promise<Person>
     getOasysSections: (token: string, crn: string) => Promise<OASysSections>
     getOasysRiskToSelf: (token: string, crn: string) => Promise<OASysRiskToSelf>
+    getOasysRosh: (token: string, crn: string) => Promise<OASysRiskOfSeriousHarm>
   }
   applicationService: {
     findApplication: (token: string, id: string) => Promise<Cas2Application>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,5 +1,5 @@
 import PersonClient from './personClient'
-import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
+import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory, oasysRoshFactory } from '../testutils/factories'
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
@@ -94,6 +94,34 @@ describeClient('PersonClient', provider => {
       const result = await personClient.oasysRiskToSelf(crn)
 
       expect(result).toEqual(oasysRiskToSelf)
+    })
+  })
+
+  describe('oasysRosh', () => {
+    it('should return the Rosh data', async () => {
+      const crn = 'crn'
+      const oasysRosh = oasysRoshFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the optional selected sections of OASys for a person',
+        withRequest: {
+          method: 'GET',
+          path: paths.people.oasys.rosh({ crn }),
+          query: {},
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: oasysRosh,
+        },
+      })
+
+      const result = await personClient.oasysRosh(crn)
+
+      expect(result).toEqual(oasysRosh)
     })
   })
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,4 @@
-import type { OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -26,6 +26,14 @@ export default class PersonClient {
     const path = paths.people.oasys.riskToSelf({ crn })
 
     const response = (await this.restClient.get({ path })) as OASysRiskToSelf
+
+    return response
+  }
+
+  async oasysRosh(crn: string): Promise<OASysRiskOfSeriousHarm> {
+    const path = paths.people.oasys.rosh({ crn })
+
+    const response = (await this.restClient.get({ path })) as OASysRiskOfSeriousHarm
 
     return response
   }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -1,34 +1,213 @@
+import { createMock } from '@golevelup/ts-jest'
+import type { DataServices } from '@approved-premises/ui'
+import { DateFormats } from '../../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../../testutils/factories/index'
-import OasysImport from './oasysImport'
+import OasysImport, { RoshTaskData } from './oasysImport'
+import PersonService from '../../../../../services/personService'
+import oasysRoshFactory from '../../../../../testutils/factories/oasysRosh'
+import RiskToOthers from '../riskToOthers'
+import Summary from '../summary'
+
+jest.mock('../riskToOthers')
+jest.mock('../summary')
 
 describe('OasysImport', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+  const oasys = oasysRoshFactory.build({
+    dateCompleted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 29)),
+    dateStarted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 28)),
+  })
+
+  const dataServices = createMock<DataServices>({ personService: createMock<PersonService>({}) })
+
+  const now = new Date()
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(now)
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
 
   describe('title', () => {
     it('personalises the page title', () => {
-      const page = new OasysImport({}, application)
+      const page = new OasysImport({}, application, oasys, '')
 
-      expect(page.title).toEqual(`Import Roger Smith's risk of serious harm (RoSH) data from OASys`)
+      expect(page.title).toEqual("Import Roger Smith's risk of serious harm (RoSH) data from OASys")
     })
   })
 
-  itShouldHaveNextValue(new OasysImport({}, application), 'summary')
-  itShouldHavePreviousValue(new OasysImport({}, application), 'taskList')
+  describe('initialize', () => {
+    describe('when oasys sections are returned', () => {
+      it('instantiates the class with the task data in the correct format', async () => {
+        oasys.rosh = [
+          {
+            label: 'Who is at risk',
+            questionNumber: 'R10.1',
+            answer: 'who is at risk answer',
+          },
+          {
+            label: 'What is the nature of the risk',
+            questionNumber: 'R10.2',
+            answer: 'nature of risk answer',
+          },
+          {
+            label: 'When is the risk likely to be the greatest',
+            questionNumber: 'R10.3',
+            answer: 'risk likely to be greatest answer',
+          },
+          {
+            label: 'What circumstances are likely to increase risk',
+            questionNumber: 'R10.4',
+            answer: 'circumstances likely to increase risk answer',
+          },
+          {
+            label: 'What circumstances are likely to reduce the risk',
+            questionNumber: 'R10.5',
+            answer: 'circumstances likely to reduce risk answer',
+          },
+        ]
 
-  describe('response', () => {
-    it('not implemented', () => {
-      const page = new OasysImport({}, application)
+        const taskData = {
+          'risk-of-serious-harm': {
+            'risk-to-others': {
+              whoIsAtRisk: 'who is at risk answer',
+              dateOfOasysImport: now,
+              natureOfRisk: 'nature of risk answer',
+            },
+            'risk-factors': {
+              whenIsRiskLikelyToBeGreatest: 'risk likely to be greatest answer',
+              dateOfOasysImport: now,
+              circumstancesLikelyToIncreaseRisk: 'circumstances likely to increase risk answer',
+            },
+            'reducing-risk': {
+              factorsLikelyToReduceRisk: 'circumstances likely to reduce risk answer',
+              dateOfOasysImport: now,
+            },
+          },
+        }
 
-      expect(page.response()).toEqual({})
+        ;(dataServices.personService.getOasysRosh as jest.Mock).mockResolvedValue(oasys)
+
+        const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
+
+        expect(page.taskData).toBe(JSON.stringify(taskData))
+        expect(page.hasOasysRecord).toBe(true)
+        expect(page.oasysCompleted).toBe('29 August 2023')
+        expect(page.oasysStarted).toBe('28 August 2023')
+      })
+
+      describe('when there is not a completed date', () => {
+        it('does not assign a completed date', async () => {
+          const oasysIncomplete = oasysRoshFactory.build({ dateCompleted: null })
+
+          ;(dataServices.personService.getOasysRosh as jest.Mock).mockResolvedValue(oasysIncomplete)
+
+          const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
+
+          expect(page.oasysCompleted).toBe(null)
+        })
+      })
+    })
+
+    describe('when oasys sections are not returned', () => {
+      it('sets hasOasysRecord to false when a 404 is returned', async () => {
+        ;(dataServices.personService.getOasysRosh as jest.Mock).mockRejectedValue({ status: 404 })
+
+        const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
+
+        expect(page.hasOasysRecord).toBe(false)
+        expect(page.oasysCompleted).toBe(undefined)
+        expect(page.oasysStarted).toBe(undefined)
+      })
+
+      it('throws error when an unexpected error is returned', async () => {
+        const error = new Error()
+        ;(dataServices.personService.getOasysRosh as jest.Mock).mockImplementation(() => {
+          throw error
+        })
+
+        expect(OasysImport.initialize({}, application, 'some-token', dataServices)).rejects.toThrow(error)
+      })
+    })
+
+    describe('when OASys data has already been imported', () => {
+      it('returns the Rosh summary page', async () => {
+        const roshData = {
+          'risk-of-serious-harm': {
+            'risk-factors': { circumstancesLikelyToIncreaseRisk: 'some answer', dateOfOasysImport: now },
+          },
+        } as RoshTaskData
+
+        const applicationWithData = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+          data: roshData,
+        })
+
+        const roshSummaryPageConstructor = jest.fn()
+
+        ;(Summary as jest.Mock).mockImplementation(() => {
+          return roshSummaryPageConstructor
+        })
+
+        expect(OasysImport.initialize({}, applicationWithData, 'some-token', dataServices)).resolves.toEqual(
+          roshSummaryPageConstructor,
+        )
+
+        expect(Summary).toHaveBeenCalledWith({}, applicationWithData)
+      })
+
+      describe("when there is data but it hasn't been imported from OASys", () => {
+        it('returns the risk to others page', async () => {
+          const roshData = {
+            'risk-of-serious-harm': {
+              'risk-factors': {
+                circumstancesLikelyToIncreaseRisk: 'some answer',
+                whenIsRiskLikelyToBeGreatest: 'some answer',
+              },
+            },
+          } as RoshTaskData
+
+          const applicationWithData = applicationFactory.build({
+            person: personFactory.build({ name: 'Roger Smith' }),
+            data: roshData,
+          })
+
+          const riskToOthersPageConstructor = jest.fn()
+
+          ;(RiskToOthers as jest.Mock).mockImplementation(() => {
+            return riskToOthersPageConstructor
+          })
+
+          expect(OasysImport.initialize({}, applicationWithData, 'some-token', dataServices)).resolves.toEqual(
+            riskToOthersPageConstructor,
+          )
+
+          expect(RiskToOthers).toHaveBeenCalledWith({}, applicationWithData)
+        })
+      })
     })
   })
+
+  itShouldHaveNextValue(new OasysImport({}, application, oasys, ''), 'summary')
+  itShouldHavePreviousValue(new OasysImport({}, application, oasys, ''), 'taskList')
 
   describe('errors', () => {
-    it('not implemented', () => {
-      const page = new OasysImport({}, application)
+    it('returns empty object', () => {
+      const page = new OasysImport({}, application, oasys, '')
 
       expect(page.errors()).toEqual({})
+    })
+  })
+
+  describe('response', () => {
+    it('returns empty object', () => {
+      const page = new OasysImport({}, application, oasys, '')
+
+      expect(page.response()).toEqual({})
     })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
@@ -1,25 +1,162 @@
-import type { TaskListErrors } from '@approved-premises/ui'
-import { Cas2Application as Application } from '@approved-premises/api'
+import type { DataServices, TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application, OASysRiskOfSeriousHarm } from '@approved-premises/api'
 import { Page } from '../../../../utils/decorators'
 import TaskListPage from '../../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
+import RiskToOthers from '../riskToOthers'
+import { DateFormats } from '../../../../../utils/dateUtils'
+import Summary from '../summary'
 
 type OasysImportBody = Record<string, never>
+
+export type RoshTaskData = {
+  'risk-of-serious-harm': {
+    'risk-to-others': {
+      whoIsAtRisk: string
+      natureOfRisk: string
+      dateOfOasysImport: Date
+    }
+    'risk-factors': {
+      circumstancesLikelyToIncreaseRisk: string
+      whenIsRiskLikelyToBeGreatest: string
+      dateOfOasysImport: Date
+    }
+    'reducing-risk': {
+      factorsLikelyToReduceRisk: string
+      dateOfOasysImport: Date
+    }
+  }
+}
 
 @Page({
   name: 'oasys-import',
   bodyProperties: [],
 })
 export default class OasysImport implements TaskListPage {
+  personName = nameOrPlaceholderCopy(this.application.person)
+
   title = `Import ${nameOrPlaceholderCopy(this.application.person)}'s risk of serious harm (RoSH) data from OASys`
 
   body: OasysImportBody
 
+  taskData: string
+
+  hasOasysRecord: boolean
+
+  oasysCompleted: string
+
+  oasysStarted: string
+
+  noOasysBannerText = `No OASys record available to import for ${this.personName}`
+
+  noOasysDescriptiveText = `No information can be imported for the Risk of Serious Harm (RoSH) section because ${this.personName} 
+                            does not have a Layer 3 OASys completed in the last 6 months.`
+
+  taskName = 'risk-of-serious-harm'
+
   constructor(
     body: Partial<OasysImportBody>,
     private readonly application: Application,
+    oasys: OASysRiskOfSeriousHarm,
+    taskData: string,
   ) {
     this.body = body as OasysImportBody
+    this.hasOasysRecord = (oasys && Boolean(Object.keys(oasys).length)) || false
+    if (this.hasOasysRecord) {
+      this.oasysStarted = oasys.dateStarted && DateFormats.isoDateToUIDate(oasys.dateStarted, { format: 'medium' })
+      this.oasysCompleted =
+        oasys.dateCompleted && DateFormats.isoDateToUIDate(oasys.dateCompleted, { format: 'medium' })
+    }
+    this.taskData = taskData
+  }
+
+  static async initialize(
+    body: Partial<OasysImportBody>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    let oasys
+    let taskDataJson
+
+    if (!application.data['risk-of-serious-harm']) {
+      try {
+        oasys = await dataServices.personService.getOasysRosh(token, application.person.crn)
+
+        taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys))
+      } catch (e) {
+        if (e.status === 404) {
+          oasys = null
+        } else {
+          throw e
+        }
+      }
+      return new OasysImport(body, application, oasys, taskDataJson)
+    }
+    if (OasysImport.isRoshApplicationDataImportedFromOASys(application)) {
+      return new Summary(application.data['risk-of-serious-harm'].summary ?? {}, application)
+    }
+    return new RiskToOthers(application.data['risk-of-serious-harm']['risk-to-others'] ?? {}, application)
+  }
+
+  private static isRoshApplicationDataImportedFromOASys(application: Application): boolean {
+    const rosh = application.data['risk-of-serious-harm']
+    if (
+      (rosh?.['risk-to-others'] && 'dateOfOasysImport' in rosh['risk-to-others']) ||
+      (rosh?.['risk-factors'] && 'dateOfOasysImport' in rosh['risk-factors']) ||
+      (rosh?.['reducing-risk'] && 'dateOfOasysImport' in rosh['reducing-risk'])
+    ) {
+      return true
+    }
+    return false
+  }
+
+  private static getTaskData(oasysSections: OASysRiskOfSeriousHarm): Partial<RoshTaskData> {
+    const taskData = { 'risk-of-serious-harm': {} } as Partial<RoshTaskData>
+    const today = new Date()
+
+    oasysSections.rosh.forEach(question => {
+      switch (question.questionNumber) {
+        case 'R10.1':
+          taskData['risk-of-serious-harm']['risk-to-others'] = {
+            ...taskData['risk-of-serious-harm']['risk-to-others'],
+            whoIsAtRisk: question.answer,
+            dateOfOasysImport: today,
+          }
+          break
+        case 'R10.2':
+          taskData['risk-of-serious-harm']['risk-to-others'] = {
+            ...taskData['risk-of-serious-harm']['risk-to-others'],
+            natureOfRisk: question.answer,
+            dateOfOasysImport: today,
+          }
+          break
+        case 'R10.3':
+          taskData['risk-of-serious-harm']['risk-factors'] = {
+            ...taskData['risk-of-serious-harm']['risk-factors'],
+            whenIsRiskLikelyToBeGreatest: question.answer,
+            dateOfOasysImport: today,
+          }
+          break
+        case 'R10.4':
+          taskData['risk-of-serious-harm']['risk-factors'] = {
+            ...taskData['risk-of-serious-harm']['risk-factors'],
+            circumstancesLikelyToIncreaseRisk: question.answer,
+            dateOfOasysImport: today,
+          }
+          break
+        case 'R10.5':
+          taskData['risk-of-serious-harm']['reducing-risk'] = {
+            factorsLikelyToReduceRisk: question.answer,
+            dateOfOasysImport: today,
+          }
+          break
+        default:
+          break
+      }
+    })
+
+    return taskData
   }
 
   previous() {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,6 +11,7 @@ export default {
     oasys: {
       sections: oasysPath.path('sections'),
       riskToSelf: oasysPath.path('risk-to-self'),
+      rosh: oasysPath.path('rosh'),
     },
     search: peoplePath.path('search'),
   },

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,4 +1,4 @@
-import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
+import { oasysRiskToSelfFactory, oasysRoshFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -46,7 +46,7 @@ describe('Person Service', () => {
   })
 
   describe('getOasysRiskToSelf', () => {
-    it('returns oasysSections', async () => {
+    it('returns risk to self data', async () => {
       const expectedRiskToSelf = oasysRiskToSelfFactory.build()
       personClient.oasysRiskToSelf.mockResolvedValue(expectedRiskToSelf)
 
@@ -56,6 +56,20 @@ describe('Person Service', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysRiskToSelf).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getOasysRosh', () => {
+    it('returns Rosh data', async () => {
+      const expectedRosh = oasysRoshFactory.build()
+      personClient.oasysRosh.mockResolvedValue(expectedRosh)
+
+      const oasysSections = await service.getOasysRosh(token, 'crn')
+
+      expect(oasysSections).toEqual(expectedRosh)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.oasysRosh).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,4 +1,4 @@
-import type { OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
@@ -21,7 +21,14 @@ export default class PersonService {
   async getOasysRiskToSelf(token: string, crn: string): Promise<OASysRiskToSelf> {
     const personClient = this.personClientFactory(token)
 
-    const oasysSections = await personClient.oasysRiskToSelf(crn)
-    return oasysSections
+    const riskToSelf = await personClient.oasysRiskToSelf(crn)
+    return riskToSelf
+  }
+
+  async getOasysRosh(token: string, crn: string): Promise<OASysRiskOfSeriousHarm> {
+    const personClient = this.personClientFactory(token)
+
+    const rosh = await personClient.oasysRosh(crn)
+    return rosh
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -5,12 +5,14 @@ import { fullPersonFactory as personFactory, restrictedPersonFactory } from './p
 import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
 import risksFactory from './risks'
+import oasysRoshFactory from './oasysRosh'
 
 export {
   applicationSummaryFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
   oasysRiskToSelfFactory,
+  oasysRoshFactory,
   roshSummaryFactory,
   applicationFactory,
   personFactory,

--- a/server/testutils/factories/oasysRosh.ts
+++ b/server/testutils/factories/oasysRosh.ts
@@ -1,0 +1,14 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import { OASysRiskOfSeriousHarm } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+import { roshSummaryFactory } from './oasysSections'
+
+export default Factory.define<OASysRiskOfSeriousHarm>(() => ({
+  assessmentId: faker.number.int(),
+  assessmentState: faker.helpers.arrayElement(['Completed', 'Incomplete']),
+  dateStarted: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  dateCompleted: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
+  rosh: roshSummaryFactory.buildList(5),
+}))

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -22,8 +22,9 @@ export const roshSummaryFactory = Factory.define<OASysQuestion>(options => ({
   label: faker.helpers.arrayElement([
     'Who is at risk',
     'What is the nature of the risk',
-    'When is the risk likely to be greatest',
+    'When is the risk likely to be the greatest',
     'What circumstances are likely to increase risk',
+    'What circumstances are likely to reduce the risk',
   ]),
   answer: faker.lorem.paragraph(),
 }))

--- a/server/views/applications/pages/risk-of-serious-harm/oasys-import.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/oasys-import.njk
@@ -1,9 +1,82 @@
-{% extends "../layout.njk" %}
-{% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-  <p class="govuk-body">
-    OASys import page
-  </p>
+{% extends "../layout.njk" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
+      {% if page.hasOasysRecord%}
+        <form action="{{ paths.applications.update({ id: applicationId }) }}?_method=PUT" method="post">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+          <input type="hidden" name="pageName" value="{{ page.name }}"/>
+          <input type="hidden" name="taskData" value="{{ page.taskData }}"/>
+          <input type="hidden" name="taskName" value="{{ page.taskName }}"/>
+
+          {{ showErrorSummary(errorSummary) }}
+
+          <p class="govuk-body">
+              There is OASys information you can import to complete this section.
+            </p>
+
+          <p class="govuk-body">
+              You can edit the information. Changes made will not affect the OASys record.
+            </p>
+
+          {{ govukWarningText({
+              text: "You can only import from OASys once. Make sure it is up to date before importing.",
+              iconFallbackText: "Warning"
+            }) }}
+
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+          <div id="oasys-info">
+            <h2 class="govuk-heading-m">OASys record available for {{ page.personName }}</h2>
+            <p>Date created: <strong>{{ page.oasysStarted }}</strong>
+            </p>
+            <p>Date completed: <strong>{{ page.oasysCompleted}}</strong>
+            </p>
+            <p>OASys level: <strong>Layer 3</strong>
+            </p>
+          </div>
+
+          {% block button %}
+            {{ govukButton({
+                text: "Import and continue"
+            }) }}
+
+          {% endblock %}
+
+        </form>
+      {% else %}
+        {{ govukNotificationBanner({
+            text: page.noOasysBannerText
+            }) }}
+
+        <p class="govuk-body">
+          {{ page.noOasysDescriptiveText }}
+        </p>
+
+        <p class="govuk-body">
+            To continue, you can choose to:
+          </p>
+
+        <ul>
+          <li>update OASys before trying again (recommended)</li>
+          <li>complete the section manually</li>
+        </ul>
+
+        {{ govukButton({
+              text: "Continue",
+              href: paths.applications.pages.show({ id: applicationId, task: page.taskName, page: 'risk-to-others' })
+              }) 
+          }}
+
+      {% endif %}
+
+    </div>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
# Changes in this PR

These changes allow users to import risk of serious harm (RoSH) data from OASys if it exists, or else to continue to manual entry if not. The changes generally follow the lead of the risk to self OASys import page, although the logic for routing users on to subsequent pages is slightly more elaborate. If data has already been imported from OASys, the user should skip the OASys import page but be sent to the RoSH summary page. If data has been inputted but manually, the user should be sent straight to the risk to others page.

Comments on casing particularly welcome :)

## Screenshots of UI changes

<img width="588" alt="Screenshot 2023-09-13 at 13 47 00" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/db18ee47-968d-423f-9198-d3ca421e62bb">

<img width="591" alt="Screenshot 2023-09-13 at 13 47 45" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/cc88e59f-3855-45fc-a6a2-65486984e20d">

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
