### PR TITLE
rename title of ACCT page to match design

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/risk-to-self/acctPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-to-self/acctPage.ts
@@ -1,10 +1,16 @@
 import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class AcctPage extends ApplyPage {
   constructor(private readonly application: Application) {
-    super('Assessment, Care in Custody and Teamwork (ACCT)', application, 'risk-to-self', 'acct')
+    super(
+      `${nameOrPlaceholderCopy(application.person, 'The person')}'s ACCT notes`,
+      application,
+      'risk-to-self',
+      'acct',
+    )
   }
 
   static visit(application: Application): void {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
@@ -9,7 +9,7 @@ describe('Acct', () => {
     it('personalises the page title', () => {
       const page = new Acct({}, application)
 
-      expect(page.title).toEqual('Assessment, Care in Custody and Teamwork (ACCT)')
+      expect(page.title).toEqual("Roger Smith's ACCT notes")
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { AcctDataBody } from './custom-forms/acctData'
 import { DateFormats } from '../../../../utils/dateUtils'
 import paths from '../../../../paths/apply'
-import { createQueryString } from '../../../../utils/utils'
+import { createQueryString, nameOrPlaceholderCopy } from '../../../../utils/utils'
 
 type AcctBody = Record<string, never>
 
@@ -16,9 +16,9 @@ type AcctUI = { title: string; referringInstitution: string; acctDetails: string
   bodyProperties: ['acctDetail'],
 })
 export default class Acct implements TaskListPage {
-  title = 'Assessment, Care in Custody and Teamwork (ACCT)'
+  documentTitle = "The person's ACCT notes"
 
-  documentTitle = this.title
+  title = `${nameOrPlaceholderCopy(this.application.person)}'s ACCT notes`
 
   body: AcctBody
 

--- a/server/views/applications/pages/risk-to-self/acct.njk
+++ b/server/views/applications/pages/risk-to-self/acct.njk
@@ -3,10 +3,8 @@
 {% set pageName = "acct" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
-
-  <p class="govuk-body">An ACCT is a tailored plan to support someone in prison 
-    at risk of self harm or suicide.</p>
+  <p class="govuk-body">An Assessment, Care in Custody and Teamwork (ACCT) is a tailored plan to 
+  support someone in prison at risk of self harm or suicide.</p>
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 


### PR DESCRIPTION
Changes title of page to match prototype 
![Screenshot 2023-09-15 at 11 50 16](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/a2dc9387-b7c1-4e81-bd84-ff047baacbd9)
