### PR TITLE
Add rosh risk summary

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -10,6 +10,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/header-bar';
 @import './components/task-list';
 @import './components/copy-text';
+@import './components/rosh-widget';
 
 @import './pages//oasys-import';
 

--- a/assets/scss/components/_rosh-widget.scss
+++ b/assets/scss/components/_rosh-widget.scss
@@ -1,0 +1,89 @@
+$low-score-colour: #485b10;
+$low-score-border-colour: #85994b;
+$medium-score-colour: #a34e00;
+$medium-score-border-colour: #f47738;
+$high-score-colour: #942514;
+$high-score-border-colour: #d4351c;
+$very-high-score-colour: #711a0d;
+$very-high-score-border-colour: #942514;
+
+.rosh-widget {
+  border: 2px solid govuk-colour('black');
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  & h3 {
+    margin-bottom: govuk-spacing(1);
+    font-weight: 400;
+  }
+
+  & :nth-child(2) {
+    margin-bottom: govuk-spacing(2);
+  }
+  & :nth-child(3) {
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
+.rosh-widget--low {
+  border: 2px solid $low-score-border-colour;
+
+  & h3 {
+    color: $low-score-colour;
+  }
+}
+
+.rosh-widget--medium {
+  border: 2px solid $medium-score-border-colour;
+
+  & h3 {
+    color: $medium-score-colour;
+  }
+}
+
+.rosh-widget--high {
+  border: 2px solid $high-score-border-colour;
+
+  & h3 {
+    color: $high-score-colour;
+  }
+}
+
+.rosh-widget--very-high {
+  border: 2px solid $very-high-score-border-colour;
+
+  & h3 {
+    color: $very-high-score-colour;
+  }
+}
+
+.rosh-widget__table {
+  text-align: left;
+  margin: 0;
+
+  & tbody {
+    & th {
+      font-weight: 400;
+    }
+
+    & td {
+      font-weight: bold;
+    }
+  }
+}
+
+.rosh-widget__risk--low {
+  color: $low-score-colour;
+}
+
+.rosh-widget__risk--medium {
+  color: $medium-score-colour;
+}
+
+.rosh-widget__risk--high {
+  color: $high-score-colour;
+}
+
+.rosh-widget__risk--very-high {
+  color: $very-high-score-colour;
+}

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -147,7 +147,17 @@
   },
   "risk-of-serious-harm": {
     "oasys-import": {},
-    "summary": {},
+    "summary": {
+      "status": "retrieved",
+      "overallRisk": "High",
+      "riskToChildren": "High",
+      "riskToPublic": "Very High",
+      "riskToKnownAdult": "Medium",
+      "riskToStaff": "Low",
+      "lastUpdated": "2023-09-18",
+      "dateOfOasysImport": "2023-09-19",
+      "additionalComments": "some comments"
+    },
     "risk-to-others": {
       "whoIsAtRisk": "a person",
       "natureOfRisk": "a nature",

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,4 +1,4 @@
-import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person } from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person, PersonRisks } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 
 export default {
@@ -86,6 +86,30 @@ export default {
       },
       response: {
         status: 403,
+      },
+    }),
+
+  stubPersonRisks: (args: { crn: string; personRisks: PersonRisks }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.crn}/risks`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.personRisks,
+      },
+    }),
+
+  stubPersonRisksNotFound: (args: { crn: string }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.crn}/risks`,
+      },
+      response: {
+        status: 404,
       },
     }),
 }

--- a/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
@@ -2,6 +2,8 @@ import { Cas2Application as Application } from '../../../../../server/@types/sha
 import ApplyPage from '../../applyPage'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 import paths from '../../../../../server/paths/apply'
+import { RoshRisks } from '../../../../../server/@types/shared/models/RoshRisks'
+import { DateFormats } from '../../../../../server/utils/dateUtils'
 
 export default class RoshSummaryPage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -21,5 +23,33 @@ export default class RoshSummaryPage extends ApplyPage {
         page: 'summary',
       }),
     )
+  }
+
+  shouldShowRiskData = (risks: RoshRisks & { dateOfOasysImport: string }): void => {
+    cy.get('p').contains(
+      `Imported from OASys on ${DateFormats.isoDateToUIDate(risks.dateOfOasysImport, {
+        format: 'medium',
+      })}, last updated on ${DateFormats.isoDateToUIDate(risks.lastUpdated, {
+        format: 'medium',
+      })}`,
+    )
+
+    cy.get('h3').contains(`${risks.overallRisk.toLocaleUpperCase()} RoSH`)
+
+    cy.get('.rosh-widget__table').within($row => {
+      cy.wrap($row).get('th').contains('Children').get('td').contains(risks.riskToChildren, { matchCase: false })
+      cy.wrap($row).get('th').contains('Public').get('td').contains(risks.riskToPublic, { matchCase: false })
+      cy.wrap($row).get('th').contains('Known adult').get('td').contains(risks.riskToKnownAdult, { matchCase: false })
+      cy.wrap($row).get('th').contains('Staff').get('td').contains(risks.riskToStaff, { matchCase: false })
+    })
+  }
+
+  shouldShowUnknownRoshCard = (): void => {
+    cy.get('h3').contains('UNKNOWN LEVEL RoSH')
+    cy.get('p').contains('Something went wrong. We are unable to show RoSH information.')
+  }
+
+  clickAddComments = (): void => {
+    cy.get('span').contains('Add comments to this summary').click()
   }
 }

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
@@ -36,7 +36,12 @@
 
 import Page from '../../../../pages/page'
 import TaskListPage from '../../../../pages/apply/taskListPage'
-import { personFactory, applicationFactory, oasysRoshFactory } from '../../../../../server/testutils/factories/index'
+import {
+  personFactory,
+  applicationFactory,
+  oasysRoshFactory,
+  risksFactory,
+} from '../../../../../server/testutils/factories/index'
 import OasysImportPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/oasysImportPage'
 import RoshSummaryPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
@@ -51,6 +56,7 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubAuthUser')
 
     const oasys = oasysRoshFactory.build()
+    const risks = risksFactory.build()
 
     cy.task('stubOasysRosh', {
       crn: person.crn,
@@ -60,6 +66,8 @@ context('Visit "Risks and needs" section', () => {
         dateCompleted: DateFormats.dateObjToIsoDateTime(new Date(2022, 6, 27)),
       },
     })
+
+    cy.task('stubPersonRisks', { crn: person.crn, personRisks: risks })
 
     cy.fixture('applicationData.json').then(applicationData => {
       delete applicationData['risk-of-serious-harm']

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
@@ -11,8 +11,17 @@
 //  Scenario: view 'RoSH summary' page
 //    Then I see the "RoSH summary" page
 //
+//  Scenario: view risk summary data
+//    Given there is risk summary data
+//    Then I see the data presented on the page
+//
+//  Scenario: view 'unknown RoSH' card
+//    Given there is no risk summary data
+//    Then I see the unknown RoSH card
+//
 //  Scenario: navigate to next page in "Risk of serious harm" task
-//    When I continue to the next task / page
+//    When I add an additional comment
+//    And I continue to the next task / page
 //    Then I see the "Risk to others" page
 
 import Page from '../../../../pages/page'
@@ -22,6 +31,7 @@ import RiskToOthersPage from '../../../../pages/apply/risks-and-needs/risk-of-se
 
 context('Visit "RoSH summary" page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
+  let riskSummary
 
   beforeEach(function test() {
     cy.task('reset')
@@ -29,13 +39,33 @@ context('Visit "RoSH summary" page', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      applicationData['risk-of-serious-harm'] = {}
+      riskSummary = applicationData['risk-of-serious-harm'].summary
       const application = applicationFactory.build({
         id: 'abc123',
         person,
         data: applicationData,
       })
       cy.wrap(application).as('application')
+    })
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['risk-of-serious-harm'].summary.additionalComments
+      const application = applicationFactory.build({
+        id: 'abc1234',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('applicationWithoutAdditionalComments')
+    })
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['risk-of-serious-harm'].summary
+      const application = applicationFactory.build({
+        id: 'abc1234',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('applicationWithoutSummary')
     })
   })
 
@@ -62,11 +92,38 @@ context('Visit "RoSH summary" page', () => {
     Page.verifyOnPage(RoshSummaryPage, this.application)
   })
 
+  //  Scenario: view risk summary data
+  // ----------------------------------------------
+  it('presents risk data', function test() {
+    const page = Page.verifyOnPage(RoshSummaryPage, this.application)
+
+    //    Then I see the data presented on the page
+    page.shouldShowRiskData(riskSummary)
+  })
+
+  //  Scenario: view 'unknown RoSH' card
+  // ----------------------------------------------
+  it('presents unknown risk card', function test() {
+    //    Given there is no risk summary data
+    cy.task('stubApplicationGet', { application: this.applicationWithoutSummary })
+    RoshSummaryPage.visit(this.applicationWithoutSummary)
+    const page = Page.verifyOnPage(RoshSummaryPage, this.application)
+
+    //    Then I see the unknown RoSH card
+    page.shouldShowUnknownRoshCard()
+  })
+
   //  Scenario: navigate to next page in "Risk of serious harm" task
   // ----------------------------------------------
   it('navigates to the next page', function test() {
-    //    When I continue to the next task / page
+    cy.task('stubApplicationGet', { application: this.applicationWithoutAdditionalComments })
+
+    //    When I add an additional comment
     const page = Page.verifyOnPage(RoshSummaryPage, this.application)
+    page.clickAddComments()
+    page.getTextInputByIdAndEnterDetails('additionalComments', 'some additional comments')
+
+    //    When I continue to the next task / page
     page.clickSubmit()
 
     //    Then I see the "Risk to others" page

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,6 +1,7 @@
 import { OASysRiskOfSeriousHarm } from '../shared/models/OASysRiskOfSeriousHarm'
 import { OASysRiskToSelf } from '../shared/models/OASysRiskToSelf'
 import { OASysSections } from '../shared/models/OASysSections'
+import { RoshRisksEnvelope } from '../shared/models/RoshRisksEnvelope'
 
 export type JourneyType = 'applications'
 
@@ -51,6 +52,7 @@ export type DataServices = Partial<{
     getOasysSections: (token: string, crn: string) => Promise<OASysSections>
     getOasysRiskToSelf: (token: string, crn: string) => Promise<OASysRiskToSelf>
     getOasysRosh: (token: string, crn: string) => Promise<OASysRiskOfSeriousHarm>
+    getRoshRisks: (token: string, crn: string) => Promise<RoshRisksEnvelope>
   }
   applicationService: {
     findApplication: (token: string, id: string) => Promise<Cas2Application>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,5 +1,11 @@
 import PersonClient from './personClient'
-import { oasysRiskToSelfFactory, oasysSectionsFactory, personFactory, oasysRoshFactory } from '../testutils/factories'
+import {
+  oasysRiskToSelfFactory,
+  oasysSectionsFactory,
+  personFactory,
+  oasysRoshFactory,
+  risksFactory,
+} from '../testutils/factories'
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
@@ -151,6 +157,33 @@ describeClient('PersonClient', provider => {
       const result = await personClient.search('crn')
 
       expect(result).toEqual(person)
+    })
+  })
+
+  describe('risks', () => {
+    it('should return the risks for a person', async () => {
+      const crn = 'crn'
+      const risks = risksFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the risks for a person',
+        withRequest: {
+          method: 'GET',
+          path: `/people/${crn}/risks`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: risks,
+        },
+      })
+
+      const result = await personClient.risks(crn)
+
+      expect(result).toEqual(risks)
     })
   })
 })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,10 @@
-import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
+import type {
+  OASysRiskOfSeriousHarm,
+  OASysRiskToSelf,
+  OASysSections,
+  Person,
+  PersonRisks,
+} from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -47,5 +53,13 @@ export default class PersonClient {
     })
 
     return response as Person
+  }
+
+  async risks(crn: string): Promise<PersonRisks> {
+    const response = await this.restClient.get({
+      path: paths.people.risks.show({ crn }),
+    })
+
+    return response as PersonRisks
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -2,7 +2,7 @@ import { createMock } from '@golevelup/ts-jest'
 import type { DataServices } from '@approved-premises/ui'
 import { DateFormats } from '../../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../../shared-examples'
-import { personFactory, applicationFactory } from '../../../../../testutils/factories/index'
+import { personFactory, applicationFactory, roshRisksEnvelopeFactory } from '../../../../../testutils/factories/index'
 import OasysImport, { RoshTaskData } from './oasysImport'
 import PersonService from '../../../../../services/personService'
 import oasysRoshFactory from '../../../../../testutils/factories/oasysRosh'
@@ -71,8 +71,14 @@ describe('OasysImport', () => {
           },
         ]
 
+        const riskSummary = roshRisksEnvelopeFactory.build()
+
         const taskData = {
           'risk-of-serious-harm': {
+            summary: {
+              ...riskSummary,
+              dateOfOasysImport: now,
+            },
             'risk-to-others': {
               whoIsAtRisk: 'who is at risk answer',
               dateOfOasysImport: now,
@@ -91,6 +97,7 @@ describe('OasysImport', () => {
         }
 
         ;(dataServices.personService.getOasysRosh as jest.Mock).mockResolvedValue(oasys)
+        ;(dataServices.personService.getRoshRisks as jest.Mock).mockResolvedValue(riskSummary)
 
         const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
 
@@ -105,6 +112,7 @@ describe('OasysImport', () => {
           const oasysIncomplete = oasysRoshFactory.build({ dateCompleted: null })
 
           ;(dataServices.personService.getOasysRosh as jest.Mock).mockResolvedValue(oasysIncomplete)
+          ;(dataServices.personService.getRoshRisks as jest.Mock).mockResolvedValue(null)
 
           const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -17,10 +17,30 @@ describe('Summary', () => {
   itShouldHavePreviousValue(new Summary({}, application), 'oasys-import')
 
   describe('response', () => {
-    it('not implemented', () => {
-      const page = new Summary({}, application)
+    const body = {
+      status: 'retrieved' as const,
+      overallRisk: 'a risk',
+      riskToChildren: 'another risk',
+      riskToPublic: 'a third risk',
+      riskToKnownAdult: 'a fourth risk',
+      riskToStaff: 'a fifth risk',
+      lastUpdated: '2023-09-17',
+      dateOfOasysImport: '2023-09-18',
+    }
+    it('returns page body if no additional comments have been added', () => {
+      const page = new Summary(body, application)
 
-      expect(page.response()).toEqual({})
+      expect(page.response()).toEqual(body)
+    })
+
+    it('returns page body and additional comments if a comment is added', () => {
+      const additionalBody = {
+        ...body,
+        additionalComments: 'some comment',
+      }
+      const page = new Summary(additionalBody, application)
+
+      expect(page.response()).toEqual({ ...body, 'Additional comments (optional)': 'some comment' })
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -1,14 +1,29 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Cas2Application as Application } from '@approved-premises/api'
+import { Cas2Application as Application, RiskEnvelopeStatus, RoshRisks } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { DateFormats } from '../../../../utils/dateUtils'
 
-type SummaryBody = Record<string, never>
+type SummaryBody = RoshRisks & {
+  status: RiskEnvelopeStatus
+  dateOfOasysImport: string
+  additionalComments?: string
+}
 
 @Page({
   name: 'summary',
-  bodyProperties: [],
+  bodyProperties: [
+    'status',
+    'overallRisk',
+    'riskToChildren',
+    'riskToPublic',
+    'riskToKnownAdult',
+    'riskToStaff',
+    'lastUpdated',
+    'dateOfOasysImport',
+    'additionalComments',
+  ],
 })
 export default class Summary implements TaskListPage {
   documentTitle = 'Risk of serious harm (RoSH) summary for the person'
@@ -17,11 +32,24 @@ export default class Summary implements TaskListPage {
 
   body: SummaryBody
 
+  risks: Record<string, string> = {}
+
+  questions = { additionalComments: 'Additional comments (optional)' }
+
   constructor(
     body: Partial<SummaryBody>,
     private readonly application: Application,
   ) {
     this.body = body as SummaryBody
+    if (this.body.status === 'retrieved') {
+      this.risks = {
+        ...this.body,
+        dateOfOasysImport: DateFormats.isoDateToUIDate(this.body.dateOfOasysImport, { format: 'medium' }),
+        lastUpdated: this.body.lastUpdated
+          ? DateFormats.isoDateToUIDate(this.body.lastUpdated, { format: 'medium' })
+          : null,
+      }
+    }
   }
 
   previous() {
@@ -39,8 +67,10 @@ export default class Summary implements TaskListPage {
   }
 
   response() {
-    const response = {}
-
-    return response
+    if (this.body.additionalComments) {
+      const { additionalComments, ...response } = this.body
+      return { ...response, [this.questions.additionalComments]: this.body.additionalComments }
+    }
+    return this.body
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -14,6 +14,9 @@ export default {
       rosh: oasysPath.path('rosh'),
     },
     search: peoplePath.path('search'),
+    risks: {
+      show: personPath.path('risks'),
+    },
   },
   applications: {
     new: applicationsPath,

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,4 +1,10 @@
-import { oasysRiskToSelfFactory, oasysRoshFactory, oasysSectionsFactory, personFactory } from '../testutils/factories'
+import {
+  oasysRiskToSelfFactory,
+  oasysRoshFactory,
+  oasysSectionsFactory,
+  personFactory,
+  risksFactory,
+} from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -70,6 +76,20 @@ describe('Person Service', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysRosh).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getRoshRisks', () => {
+    it("on success returns the person's risks given their CRN", async () => {
+      const expectedRisks = risksFactory.build()
+      personClient.risks.mockResolvedValue(expectedRisks)
+
+      const risks = await service.getRoshRisks(token, 'crn')
+
+      expect(risks).toEqual(expectedRisks.roshRisks)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.risks).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,4 +1,10 @@
-import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, OASysSections, Person } from '@approved-premises/api'
+import type {
+  OASysRiskOfSeriousHarm,
+  OASysRiskToSelf,
+  OASysSections,
+  Person,
+  RoshRisksEnvelope,
+} from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
@@ -30,5 +36,13 @@ export default class PersonService {
 
     const rosh = await personClient.oasysRosh(crn)
     return rosh
+  }
+
+  async getRoshRisks(token: string, crn: string): Promise<RoshRisksEnvelope> {
+    const personClient = this.personClientFactory(token)
+
+    const risks = await personClient.risks(crn)
+
+    return risks.roshRisks
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -4,7 +4,7 @@ import oasysRiskToSelfFactory from './oasysRiskToSelf'
 import { fullPersonFactory as personFactory, restrictedPersonFactory } from './person'
 import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
-import risksFactory from './risks'
+import risksFactory, { roshRisksEnvelopeFactory } from './risks'
 import oasysRoshFactory from './oasysRosh'
 
 export {
@@ -18,4 +18,5 @@ export {
   personFactory,
   restrictedPersonFactory,
   risksFactory,
+  roshRisksEnvelopeFactory,
 }

--- a/server/testutils/factories/risks.ts
+++ b/server/testutils/factories/risks.ts
@@ -10,13 +10,13 @@ const riskEnvelopeStatuses: Array<RiskEnvelopeStatus> = ['retrieved', 'not_found
 
 export default Factory.define<PersonRisks>(() => ({
   crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
-  roshRisks: roshRisksFactory.build(),
+  roshRisks: roshRisksEnvelopeFactory.build(),
   mappa: mappaFactory.build(),
   flags: flagsFactory.build(),
   tier: tierEnvelopeFactory.build(),
 }))
 
-const roshRisksFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
+export const roshRisksEnvelopeFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
   status: faker.helpers.arrayElement(riskEnvelopeStatuses),
   value: {
     overallRisk: faker.helpers.arrayElement(riskLevels),

--- a/server/views/applications/pages/risk-of-serious-harm/summary.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/summary.njk
@@ -1,9 +1,44 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../components/roshWidget/macro.njk" import roshWidget %}
+
 {% extends "../layout.njk" %}
+
 {% block questions %}
+  {% set additionalCommentsInput %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'additionalComments',
+          label: {
+            text: page.questions.additionalComments,
+            classes: "govuk-label--s"
+          },
+          classes: 'govuk-!-margin-0'
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-  <p class="govuk-body">
-    RoSH summary page
-  </p>
+  {% if page.risks and page.risks.dateOfOasysImport %}
+    {% if page.risks.lastUpdated%}
+      <p class="govuk-hint">
+        Imported from OASys on <strong>{{page.risks.dateOfOasysImport}}</strong>, last updated on <strong>{{ page.risks.lastUpdated }}</strong>
+      </p>
+    {% else %}
+      <p class="govuk-hint">
+        Imported from OASys on <strong>{{page.risks.dateOfOasysImport}}</strong>, last updated: <strong>not known</strong>
+      </p>
+    {% endif %}
+  {% endif %}
+
+  {{ roshWidget(page.risks) }}
+
+  {{ govukDetails({
+    summaryText: "Add comments to this summary ",
+    html: additionalCommentsInput
+  }) }}
 
 {% endblock %}

--- a/server/views/components/roshWidget/macro.njk
+++ b/server/views/components/roshWidget/macro.njk
@@ -1,0 +1,3 @@
+{% macro roshWidget(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/roshWidget/template.njk
+++ b/server/views/components/roshWidget/template.njk
@@ -1,0 +1,78 @@
+{% macro getOverallRiskLevelClass(level) %}
+  {% if level == 'Very High' %}
+rosh-widget--very-high
+{% elif level == 'High' %}
+rosh-widget--high
+{% elif level == 'Medium' %}
+rosh-widget--medium
+{% elif level == 'Low' %}
+rosh-widget--low
+{% endif %}
+{% endmacro %}
+
+{% macro getRiskLevelText(level) %}
+  {% if level == 'Very High' %}
+Very high
+{% elif level == 'High' %}
+High
+{% elif level == 'Medium' %}
+Medium
+{% elif level == 'Low' %}
+Low
+{% endif %}
+{% endmacro %}
+
+{% macro getRiskLevelClass(level) %}
+  {% if level == 'Very High' %}
+rosh-widget__risk--very-high
+{% elif level == 'High' %}
+rosh-widget__risk--high
+{% elif level == 'Medium' %}
+rosh-widget__risk--medium
+{% elif level == 'Low' %}
+rosh-widget__risk--low
+{% endif %}
+{% endmacro %}
+
+{% if params and params.status == 'retrieved' %}
+  <div class="rosh-widget {{ getOverallRiskLevelClass(params.overallRisk) }}">
+    <h3 class="govuk-heading-m">
+      <strong>{{ getRiskLevelText(params.overallRisk) | upper }}</strong> RoSH</h3>
+    <p class="govuk-body-m">Risk of serious harm</p>
+
+    <table class="govuk-table rosh-widget__table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Risk to</th>
+          <th class="govuk-table__header">Community</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Children</th>
+          <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToChildren) }}">{{ getRiskLevelText(params.riskToChildren) | default("No data") }}</td>
+        </tr>
+        <tr>
+          <th class="govuk-table__header">Public</th>
+          <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToPublic) }}">{{ getRiskLevelText(params.riskToPublic) | default("No data") }}</td>
+        </tr>
+        <tr>
+          <th class="govuk-table__header">Known adult</th>
+          <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToKnownAdult) }}">{{ getRiskLevelText(params.riskToKnownAdult) | default("No data") }}</td>
+        </tr>
+        <tr>
+          <th class="govuk-table__header">Staff</th>
+          <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToStaff) }}">{{ getRiskLevelText(params.riskToStaff) | default("No data") }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+{% else %}
+
+  <div class="rosh-widget {{ roshWidgetClass }}">
+    <h3 class="govuk-heading-m">
+      <strong>UNKNOWN LEVEL</strong> RoSH</h3>
+    <p class="govuk-body-m">Risk of serious harm</p>
+    <p class="govuk-hint govuk-body-m">Something went wrong. We are unable to show RoSH information.</p>
+  </div>
+{% endif %}


### PR DESCRIPTION
# Changes in this PR

Updates the RoSH summary page to render a RoSH summary card, based on data that is retrieved from the RoSH OASys import page.

NB following the prototype, I have allowed users to add additional comments to an 'unknown RoSH' summary, although this feels a bit strange to me.

## Screenshots of UI changes

![Screenshot 2023-09-19 at 09 39 08](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/65f68b6a-6ed8-4a54-a516-a746bcf72482)

![Screenshot 2023-09-19 at 09 40 17](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/e238d808-080c-4a85-bc03-c067683f7d2c)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
