### PR TITLE
Add error handling for no additional information in 'Risk to Self'

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -143,7 +143,10 @@
         "acctDetails": "ACCT details"
       }
     ],
-    "additional-information": {}
+    "additional-information": {
+      "hasAdditionalInformation": "yes",
+      "additionalInformationDetail": "some information"
+    }
   },
   "risk-of-serious-harm": {
     "oasys-import": {},

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
@@ -37,16 +37,23 @@ describe('AdditionalInformation', () => {
       )
 
       expect(page.response()).toEqual({
-        "Is there anything else to include about Roger Smith's risk to self? (Optional)": 'yes',
+        "Is there anything else to include about Roger Smith's risk to self?": 'yes',
         'Additional information': 'is at risk',
       })
     })
   })
 
   describe('errors', () => {
-    describe('when answer data is valid', () => {
-      it('returns empty object if valid data', () => {
+    describe('when they have not provided any answer', () => {
+      it('returns an error', () => {
         const page = new AdditionalInformation({}, application)
+        expect(page.errors()).toEqual({ hasAdditionalInformation: 'Confirm whether you have additional information' })
+      })
+    })
+
+    describe('when there is no additional data', () => {
+      it('does not return errors', () => {
+        const page = new AdditionalInformation({ hasAdditionalInformation: 'no' }, application)
         expect(page.errors()).toEqual({})
       })
     })

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
@@ -19,7 +19,7 @@ export default class AdditionalInformation implements TaskListPage {
     hasAdditionalInformation: {
       question: `Is there anything else to include about ${nameOrPlaceholderCopy(
         this.application.person,
-      )}'s risk to self? (Optional)`,
+      )}'s risk to self?`,
     },
     additionalInformationDetail: {
       question: 'Additional information',
@@ -46,6 +46,9 @@ export default class AdditionalInformation implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
+    if (!this.body.hasAdditionalInformation) {
+      errors.hasAdditionalInformation = 'Confirm whether you have additional information'
+    }
     if (this.body.hasAdditionalInformation === 'yes' && !this.body.additionalInformationDetail) {
       errors.additionalInformationDetail = 'Provide additional information about their risk to self'
     }


### PR DESCRIPTION
# Context

https://trello.com/c/K4wTSYL3/462-risk-to-self-additional-information

# Changes in this PR

This error case was not handled previously.

## Screenshots of UI changes

![Screenshot 2023-09-19 at 10 12 12](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/9fcb4664-ab88-469a-b706-bef604e1ec79)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
