### PR TITLE
517 switch applications to cas2 api namespace

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -6,7 +6,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/applications`,
+        url: `/cas2/applications`,
       },
       response: {
         status: 201,
@@ -18,7 +18,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/applications`,
+        url: `/cas2/applications`,
       },
       response: {
         status: 200,
@@ -30,7 +30,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/applications/${args.application.id}`,
+        url: `/cas2/applications/${args.application.id}`,
       },
       response: {
         status: 200,
@@ -42,7 +42,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/applications/${args.application.id}`,
+        url: `/cas2/applications/${args.application.id}`,
       },
       response: {
         status: 201,
@@ -65,7 +65,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/applications/${args.application.id}/submission`,
+        url: `/cas2/applications/${args.application.id}/submission`,
       },
       response: {
         status: 200,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -3,7 +3,7 @@ import { path } from 'static-path'
 const peoplePath = path('/people')
 const personPath = peoplePath.path(':crn')
 const oasysPath = personPath.path('oasys')
-const applicationsPath = path('/applications')
+const applicationsPath = path('/cas2/applications')
 const singleApplicationPath = applicationsPath.path(':id')
 
 export default {

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,7 +28,7 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/api.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/ddf95a65a402ac9d3c83ab80ecd2442ed4a20b03/src/main/resources/static/api.yml'
 
     const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'api.yml')
 


### PR DESCRIPTION
# Move "applications" API endpoints into new "/cas2/" namespace

[Trello 517](https://trello.com/c/dtLdFRF6/517-implement-cas2-api-namespace)

**NB: this must be merged at the same time as the corresponding change on the API: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/965**

This PR adjusts the UI to use the newly namespaced "applications" endpoints at the CAS API:

![cas2_namespace](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/df42a794-7e3e-4a45-a399-b43bd3d8564b)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [x] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once this and the [API side](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/965) are merged we should revert commit https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/commit/619f62e902f105694b3ad383b2dc2f8c242ac77a in order to go back to sourcing the PACT test's OpenAPI spec from the CAS API's `main` branch
