### PR TITLE
allow tasks to be completed in any order

### DIFF
--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -49,42 +49,20 @@ describe('taskListService', () => {
   })
 
   describe('taskStatuses', () => {
-    it('returns cannot_start for any subsequent tasks when no tasks are complete', () => {
-      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
+    it('returns status of task', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('in_progress')
 
       const taskListService = new TaskListService(application)
 
       expect(taskListService.taskStatuses).toEqual({
-        'first-task': 'not_started',
-        'second-task': 'cannot_start',
-        'third-task': 'cannot_start',
-        'fourth-task': 'cannot_start',
-        'fifth-task': 'cannot_start',
-      })
-    })
-
-    it('returns a status when the previous task is complete', () => {
-      ;(getTaskStatus as jest.Mock).mockImplementation(t => {
-        if (t.id === 'first-task') {
-          return 'complete'
-        }
-        if (t.id === 'second-task') {
-          return 'in_progress'
-        }
-        return undefined
-      })
-
-      const taskListService = new TaskListService(application)
-
-      expect(taskListService.taskStatuses).toEqual({
-        'first-task': 'complete',
+        'first-task': 'in_progress',
         'second-task': 'in_progress',
-        'third-task': 'cannot_start',
-        'fourth-task': 'cannot_start',
-        'fifth-task': 'cannot_start',
+        'third-task': 'in_progress',
+        'fourth-task': 'in_progress',
+        'fifth-task': 'in_progress',
       })
 
-      expect(getTaskStatus).toHaveBeenCalledTimes(2)
+      expect(getTaskStatus).toHaveBeenCalledTimes(5)
     })
   })
 
@@ -136,7 +114,7 @@ describe('taskListService', () => {
 
   describe('sections', () => {
     it('returns the section data with the status of each task and the section number', () => {
-      ;(getTaskStatus as jest.Mock).mockReturnValue('cannot_start')
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
 
       const taskListService = new TaskListService(application)
 
@@ -145,17 +123,17 @@ describe('taskListService', () => {
           sectionNumber: 1,
           title: 'First Section',
           tasks: [
-            { id: 'first-task', title: 'First task', status: 'cannot_start' },
-            { id: 'second-task', title: 'Second task', status: 'cannot_start' },
+            { id: 'first-task', title: 'First task', status: 'not_started' },
+            { id: 'second-task', title: 'Second task', status: 'not_started' },
           ],
         },
         {
           sectionNumber: 2,
           title: 'Second Section',
           tasks: [
-            { id: 'third-task', title: 'Third task', status: 'cannot_start' },
-            { id: 'fourth-task', title: 'Fourth task', status: 'cannot_start' },
-            { id: 'fifth-task', title: 'Fifth task', status: 'cannot_start' },
+            { id: 'third-task', title: 'Third task', status: 'not_started' },
+            { id: 'fourth-task', title: 'Fourth task', status: 'not_started' },
+            { id: 'fifth-task', title: 'Fifth task', status: 'not_started' },
           ],
         },
       ])

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -14,14 +14,7 @@ export default class TaskListService {
 
     this.formSections.forEach(section => {
       section.tasks.forEach(task => {
-        const previousTaskKey = Object.keys(this.taskStatuses).at(-1)
-        const previousTaskStatus = this.taskStatuses[previousTaskKey]
-
-        if (!previousTaskStatus || previousTaskStatus === 'complete') {
-          this.taskStatuses[task.id] = getTaskStatus(task, application)
-        } else {
-          this.taskStatuses[task.id] = 'cannot_start'
-        }
+        this.taskStatuses[task.id] = getTaskStatus(task, application)
       })
     })
   }


### PR DESCRIPTION
# Context

https://trello.com/c/uKElr23W/531-tech-task-allow-users-to-start-tasks-out-of-order

Our users would like to be able to dip in and out of the form tasks in any order. 

# Changes in this PR

This commit removes the logic that assigns a `cannot_start` status to tasks. We are keeping the `cannot_start` status and logic in the `taskListUtils` because we will in the future be introducing some rules, e.g. the first task should be completed before the rest.

## Screenshots of UI changes

![Screenshot 2023-09-21 at 14 56 02](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/cc64e176-96ac-4a84-a6c7-473b22aa9059)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
