### PR TITLE
Risk to self errors

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -156,7 +156,6 @@
       "riskToKnownAdult": "Medium",
       "riskToStaff": "Low",
       "lastUpdated": "2023-09-18",
-      "dateOfOasysImport": "2023-09-19",
       "additionalComments": "some comments"
     },
     "risk-to-others": {

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -114,19 +114,17 @@
     }
   },
   "risk-to-self": {
+    "oasys-import": { "oasysImportDate": "2023-09-21T15:47:51.430Z" },
     "vulnerability": {
       "vulnerabilityDetail": "example answer vulnerability",
-      "dateOfOasysImport": "2023-08-31",
       "confirmation": "confirmed"
     },
     "current-risk": {
       "currentRiskDetail": "example answer current risk",
-      "dateOfOasysImport": "2023-08-31",
       "confirmation": "confirmed"
     },
     "historical-risk": {
       "historicalRiskDetail": "example answer historical risk ",
-      "dateOfOasysImport": "2023-08-31",
       "confirmation": "confirmed"
     },
     "acct": {},
@@ -149,7 +147,7 @@
     }
   },
   "risk-of-serious-harm": {
-    "oasys-import": {},
+    "oasys-import": { "oasysImportDate": "2023-09-21T15:47:51.430Z" },
     "summary": {
       "status": "retrieved",
       "overallRisk": "High",
@@ -163,23 +161,20 @@
     },
     "risk-to-others": {
       "whoIsAtRisk": "a person",
-      "natureOfRisk": "a nature",
-      "dateOfOasysImport": "some date"
+      "natureOfRisk": "a nature"
     },
     "risk-factors": {
       "circumstancesLikelyToIncreaseRisk": "a circumstance",
-      "whenIsRiskLikelyToBeGreatest": "a time",
-      "dateOfOasysImport": "some date"
+      "whenIsRiskLikelyToBeGreatest": "a time"
     },
     "reducing-risk": {
-      "factorsLikelyToReduceRisk": "a factor",
-      "dateOfOasysImport": "some date"
+      "factorsLikelyToReduceRisk": "a factor"
     },
     "risk-management-arrangements": {
       "arrangements": ["mappa", "marac", "iom"],
-      "mappaDetails": "mappa details", 
-      "maracDetails": "marac details", 
-      "iomDetails": "iom details" 
+      "mappaDetails": "mappa details",
+      "maracDetails": "marac details",
+      "iomDetails": "iom details"
     },
     "cell-share-information": {
       "hasCellShareComments": "yes",

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,5 +1,6 @@
 import type { Cas2Application as Application, Cas2Application } from '@approved-premises/api'
-import { stubFor } from '../../wiremock'
+import { getMatchingRequests, stubFor } from '../../wiremock'
+import paths from '../../server/paths/api'
 
 export default {
   stubCreateApplication: (args: { application: Application }) =>
@@ -61,6 +62,13 @@ export default {
         transformers: ['response-template'],
       },
     }),
+  verifyApplicationUpdate: async (applicationId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'PUT',
+        url: paths.applications.update({ id: applicationId }),
+      })
+    ).body.requests,
   stubApplicationSubmit: (args: { application: Cas2Application }) =>
     stubFor({
       request: {

--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -28,8 +28,8 @@ export default class ApplyPage extends Page {
     this.checkRadioByNameAndValue(name, option)
   }
 
-  shouldShowOasysImportDate(application: Application, task: string, page: string): void {
-    const date = application.data[task][page].dateOfOasysImport
+  shouldShowOasysImportDate(application: Application, task: string): void {
+    const date = application.data[task]['oasys-import'].oasysImportDate
 
     cy.get('p').contains(`Imported from OASys on ${DateFormats.isoDateToUIDate(date, { format: 'medium' })}`)
   }

--- a/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
@@ -25,9 +25,9 @@ export default class RoshSummaryPage extends ApplyPage {
     )
   }
 
-  shouldShowRiskData = (risks: RoshRisks & { dateOfOasysImport: string }): void => {
+  shouldShowRiskData = (risks: RoshRisks, oasysImportDate: string): void => {
     cy.get('p').contains(
-      `Imported from OASys on ${DateFormats.isoDateToUIDate(risks.dateOfOasysImport, {
+      `Imported from OASys on ${DateFormats.isoDateToUIDate(oasysImportDate, {
         format: 'medium',
       })}, last updated on ${DateFormats.isoDateToUIDate(risks.lastUpdated, {
         format: 'medium',

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
@@ -55,7 +55,35 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    const oasys = oasysRoshFactory.build()
+    const oasys = oasysRoshFactory.build({
+      rosh: [
+        {
+          questionNumber: 'R10.1',
+          label: 'Who is at risk',
+          answer: 'who answer',
+        },
+        {
+          questionNumber: 'R10.2',
+          label: 'What is the nature of the risk',
+          answer: 'what answer',
+        },
+        {
+          questionNumber: 'R10.3',
+          label: 'When is the risk likely to be the greatest',
+          answer: 'when answer',
+        },
+        {
+          questionNumber: 'R10.4',
+          label: 'What circumstances are likely to increase risk',
+          answer: 'circumstances increase answer',
+        },
+        {
+          questionNumber: 'R10.5',
+          label: 'What circumstances are likely to reduce the risk',
+          answer: 'circumstances reduce answer',
+        },
+      ],
+    })
     const risks = risksFactory.build()
 
     cy.task('stubOasysRosh', {
@@ -180,5 +208,20 @@ context('Visit "Risks and needs" section', () => {
 
     //  Then I see the "RoSH summary" page
     Page.verifyOnPage(RoshSummaryPage, this.application)
+
+    cy.task('verifyApplicationUpdate', this.application.id).then(requests => {
+      expect(requests).to.have.length(1)
+
+      const body = JSON.parse(requests[0].body)
+
+      expect(body.data['risk-of-serious-harm']['oasys-import']).to.have.keys('oasysImportDate')
+      expect(body.data['risk-of-serious-harm']).to.have.keys(
+        'summary',
+        'risk-factors',
+        'oasys-import',
+        'reducing-risk',
+        'risk-to-others',
+      )
+    })
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
@@ -98,7 +98,7 @@ context('Visit "RoSH summary" page', () => {
     const page = Page.verifyOnPage(RoshSummaryPage, this.application)
 
     //    Then I see the data presented on the page
-    page.shouldShowRiskData(riskSummary)
+    page.shouldShowRiskData(riskSummary, this.application.data['risk-of-serious-harm']['oasys-import'].oasysImportDate)
   })
 
   //  Scenario: view 'unknown RoSH' card

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/current_risk.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents current risk page', function test() {
     const page = Page.verifyOnPage(CurrentRiskPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'current-risk')
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/historical_risk.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents historical risk page', function test() {
     const page = Page.verifyOnPage(HistoricalRiskPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'historical-risk')
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/oasys_import_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/oasys_import_page.cy.ts
@@ -30,6 +30,8 @@
 //    When I follow the link to the first page in the "Risks and needs" section
 //    Then I see the "OASys import" page
 //    And I see that there is no OASys data
+//    When I choose to continue
+//    Then we are taken to the Vulnerability page
 
 import OasysImportPage from '../../../../pages/apply/risks-and-needs/risk-to-self/oasysImportPage'
 import VulnerabilityPage from '../../../../pages/apply/risks-and-needs/risk-to-self/vulnerabilityPage'
@@ -50,7 +52,25 @@ context('Visit "Risks and needs" section', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
 
-    const oasys = oasysRiskToSelfFactory.build()
+    const oasys = oasysRiskToSelfFactory.build({
+      riskToSelf: [
+        {
+          questionNumber: 'R8.1.1',
+          label: 'Current concerns of self harm and suicide',
+          answer: 'current answer',
+        },
+        {
+          questionNumber: 'R8.3.1',
+          label: 'Current concerns about Vulnerability',
+          answer: 'vulnerability answer',
+        },
+        {
+          questionNumber: 'R8.1.4',
+          label: 'Previous concerns of self harm and suicide',
+          answer: 'previous answer',
+        },
+      ],
+    })
 
     cy.task('stubOasysRiskToSelf', {
       crn: person.crn,
@@ -126,6 +146,15 @@ context('Visit "Risks and needs" section', () => {
 
     //  Then we are taken to the Vulnerability page
     Page.verifyOnPage(VulnerabilityPage, this.application)
+
+    cy.task('verifyApplicationUpdate', this.application.id).then(requests => {
+      expect(requests).to.have.length(1)
+
+      const body = JSON.parse(requests[0].body)
+
+      expect(body.data['risk-to-self']).to.have.keys('oasys-import', 'current-risk', 'historical-risk', 'vulnerability')
+      expect(body.data['risk-to-self']['oasys-import']).to.have.keys('oasysImportDate')
+    })
   })
 
   //  Scenario: return to Task after importing data
@@ -166,5 +195,11 @@ context('Visit "Risks and needs" section', () => {
 
     //  And I see that there is no OASys data
     page.displaysNoOASysNotificationBanner(this.application)
+
+    //  When I choose to continue
+    page.clickContinue()
+
+    //  Then we are taken to the Vulnerability page
+    Page.verifyOnPage(VulnerabilityPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
@@ -20,6 +20,7 @@ import VulnerabilityPage from '../../../../pages/apply/risks-and-needs/risk-to-s
 import CurrentRiskPage from '../../../../pages/apply/risks-and-needs/risk-to-self/currentRiskPage'
 import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import paths from '../../../../../server/paths/api'
 
 context('Visit "Risks and needs" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -75,5 +76,15 @@ context('Visit "Risks and needs" section', () => {
     page.clickSubmit()
 
     Page.verifyOnPage(CurrentRiskPage, this.application)
+
+    cy.task('verifyApplicationUpdate', this.application.id).then(requests => {
+      expect(requests).to.have.length(1)
+
+      expect(requests[0].url).to.equal(paths.applications.update({ id: this.application.id }))
+
+      const body = JSON.parse(requests[0].body)
+
+      expect(body.data['risk-to-self'].vulnerability).to.have.keys('confirmation', 'vulnerabilityDetail')
+    })
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/vulnerability.cy.ts
@@ -59,7 +59,7 @@ context('Visit "Risks and needs" section', () => {
   it('presents vulnerability page', function test() {
     const page = Page.verifyOnPage(VulnerabilityPage, this.application)
 
-    page.shouldShowOasysImportDate(this.application, 'risk-to-self', 'vulnerability')
+    page.shouldShowOasysImportDate(this.application, 'risk-to-self')
   })
 
   //  Scenario: complete page and navigate to next page in health needs task

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -81,18 +81,16 @@ describe('OasysImport', () => {
             },
             'risk-to-others': {
               whoIsAtRisk: 'who is at risk answer',
-              dateOfOasysImport: now,
               natureOfRisk: 'nature of risk answer',
             },
             'risk-factors': {
               whenIsRiskLikelyToBeGreatest: 'risk likely to be greatest answer',
-              dateOfOasysImport: now,
               circumstancesLikelyToIncreaseRisk: 'circumstances likely to increase risk answer',
             },
             'reducing-risk': {
               factorsLikelyToReduceRisk: 'circumstances likely to reduce risk answer',
-              dateOfOasysImport: now,
             },
+            'oasys-import': { oasysImportDate: now },
           },
         }
 
@@ -146,7 +144,8 @@ describe('OasysImport', () => {
       it('returns the Rosh summary page', async () => {
         const roshData = {
           'risk-of-serious-harm': {
-            'risk-factors': { circumstancesLikelyToIncreaseRisk: 'some answer', dateOfOasysImport: now },
+            'oasys-import': { oasysImportDate: now },
+            'risk-factors': { circumstancesLikelyToIncreaseRisk: 'some answer' },
           },
         } as RoshTaskData
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
@@ -11,22 +11,22 @@ type OasysImportBody = Record<string, never>
 
 export type RoshTaskData = {
   'risk-of-serious-harm': {
+    'oasys-import': {
+      oasysImportDate: Date
+    }
     summary: RoshRisksEnvelope & {
       dateOfOasysImport: Date
     }
     'risk-to-others': {
       whoIsAtRisk: string
       natureOfRisk: string
-      dateOfOasysImport: Date
     }
     'risk-factors': {
       circumstancesLikelyToIncreaseRisk: string
       whenIsRiskLikelyToBeGreatest: string
-      dateOfOasysImport: Date
     }
     'reducing-risk': {
       factorsLikelyToReduceRisk: string
-      dateOfOasysImport: Date
     }
   }
 }
@@ -108,11 +108,7 @@ export default class OasysImport implements TaskListPage {
 
   private static isRoshApplicationDataImportedFromOASys(application: Application): boolean {
     const rosh = application.data['risk-of-serious-harm']
-    if (
-      (rosh?.['risk-to-others'] && 'dateOfOasysImport' in rosh['risk-to-others']) ||
-      (rosh?.['risk-factors'] && 'dateOfOasysImport' in rosh['risk-factors']) ||
-      (rosh?.['reducing-risk'] && 'dateOfOasysImport' in rosh['reducing-risk'])
-    ) {
+    if (rosh?.['oasys-import']?.oasysImportDate) {
       return true
     }
     return false
@@ -133,40 +129,37 @@ export default class OasysImport implements TaskListPage {
           taskData['risk-of-serious-harm']['risk-to-others'] = {
             ...taskData['risk-of-serious-harm']['risk-to-others'],
             whoIsAtRisk: question.answer,
-            dateOfOasysImport: today,
           }
           break
         case 'R10.2':
           taskData['risk-of-serious-harm']['risk-to-others'] = {
             ...taskData['risk-of-serious-harm']['risk-to-others'],
             natureOfRisk: question.answer,
-            dateOfOasysImport: today,
           }
           break
         case 'R10.3':
           taskData['risk-of-serious-harm']['risk-factors'] = {
             ...taskData['risk-of-serious-harm']['risk-factors'],
             whenIsRiskLikelyToBeGreatest: question.answer,
-            dateOfOasysImport: today,
           }
           break
         case 'R10.4':
           taskData['risk-of-serious-harm']['risk-factors'] = {
             ...taskData['risk-of-serious-harm']['risk-factors'],
             circumstancesLikelyToIncreaseRisk: question.answer,
-            dateOfOasysImport: today,
           }
           break
         case 'R10.5':
           taskData['risk-of-serious-harm']['reducing-risk'] = {
             factorsLikelyToReduceRisk: question.answer,
-            dateOfOasysImport: today,
           }
           break
         default:
           break
       }
     })
+
+    taskData['risk-of-serious-harm']['oasys-import'] = { oasysImportDate: today }
 
     return taskData
   }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -13,6 +13,14 @@ describe('Summary', () => {
     })
   })
 
+  describe('import date', () => {
+    it('sets importDate to null where application contains no OASys import date', () => {
+      const page = new Summary({}, application)
+
+      expect(page.importDate).toEqual(null)
+    })
+  })
+
   itShouldHaveNextValue(new Summary({}, application), 'risk-to-others')
   itShouldHavePreviousValue(new Summary({}, application), 'oasys-import')
 
@@ -25,7 +33,6 @@ describe('Summary', () => {
       riskToKnownAdult: 'a fourth risk',
       riskToStaff: 'a fifth risk',
       lastUpdated: '2023-09-17',
-      dateOfOasysImport: '2023-09-18',
     }
     it('returns page body if no additional comments have been added', () => {
       const page = new Summary(body, application)

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -4,10 +4,11 @@ import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { DateFormats } from '../../../../utils/dateUtils'
+import { getOasysImportDateFromApplication } from '../../../utils'
 
 type SummaryBody = RoshRisks & {
   status: RiskEnvelopeStatus
-  dateOfOasysImport: string
+  oasysImportDate: string
   additionalComments?: string
 }
 
@@ -21,7 +22,6 @@ type SummaryBody = RoshRisks & {
     'riskToKnownAdult',
     'riskToStaff',
     'lastUpdated',
-    'dateOfOasysImport',
     'additionalComments',
   ],
 })
@@ -36,6 +36,8 @@ export default class Summary implements TaskListPage {
 
   questions = { additionalComments: 'Additional comments (optional)' }
 
+  importDate = getOasysImportDateFromApplication(this.application, 'risk-of-serious-harm')
+
   constructor(
     body: Partial<SummaryBody>,
     private readonly application: Application,
@@ -44,7 +46,6 @@ export default class Summary implements TaskListPage {
     if (this.body.status === 'retrieved') {
       this.risks = {
         ...this.body,
-        dateOfOasysImport: DateFormats.isoDateToUIDate(this.body.dateOfOasysImport, { format: 'medium' }),
         lastUpdated: this.body.lastUpdated
           ? DateFormats.isoDateToUIDate(this.body.lastUpdated, { format: 'medium' })
           : null,

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -33,7 +33,7 @@ export default class CurrentRisk implements TaskListPage {
 
   body: CurrentRiskBody
 
-  importDate = getOasysImportDateFromApplication(this.application, 'current-risk')
+  importDate = getOasysImportDateFromApplication(this.application, 'risk-to-self')
 
   constructor(
     body: Partial<CurrentRiskBody>,

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
@@ -66,9 +66,10 @@ describe('OasysImport', () => {
 
         const taskData = {
           'risk-to-self': {
-            'current-risk': { currentRiskDetail: 'self harm answer', dateOfOasysImport: now },
-            vulnerability: { vulnerabilityDetail: 'vulnerability answer', dateOfOasysImport: now },
-            'historical-risk': { historicalRiskDetail: 'historical answer', dateOfOasysImport: now },
+            'current-risk': { currentRiskDetail: 'self harm answer' },
+            vulnerability: { vulnerabilityDetail: 'vulnerability answer' },
+            'historical-risk': { historicalRiskDetail: 'historical answer' },
+            'oasys-import': { oasysImportDate: now },
           },
         }
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
@@ -10,17 +10,17 @@ type GuidanceBody = Record<string, never>
 
 export type RiskToSelfTaskData = {
   'risk-to-self': {
+    'oasys-import': {
+      oasysImportDate: Date
+    }
     'current-risk': {
       currentRiskDetail: string
-      dateOfOasysImport: Date
     }
     vulnerability: {
       vulnerabilityDetail: string
-      dateOfOasysImport: Date
     }
     'historical-risk': {
       historicalRiskDetail: string
-      dateOfOasysImport: Date
     }
   }
 }
@@ -102,21 +102,22 @@ export default class OasysImport implements TaskListPage {
     oasysSections.riskToSelf.forEach(question => {
       switch (question.questionNumber) {
         case 'R8.1.1':
-          taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer, dateOfOasysImport: today }
+          taskData['risk-to-self']['current-risk'] = { currentRiskDetail: question.answer }
           break
         case 'R8.3.1':
-          taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer, dateOfOasysImport: today }
+          taskData['risk-to-self'].vulnerability = { vulnerabilityDetail: question.answer }
           break
         case 'R8.1.4':
           taskData['risk-to-self']['historical-risk'] = {
             historicalRiskDetail: question.answer,
-            dateOfOasysImport: today,
           }
           break
         default:
           break
       }
     })
+
+    taskData['risk-to-self']['oasys-import'] = { oasysImportDate: today }
 
     return taskData
   }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/historicalRisk.ts
@@ -29,7 +29,7 @@ export default class HistoricalRisk implements TaskListPage {
     },
   }
 
-  importDate = getOasysImportDateFromApplication(this.application, 'historical-risk')
+  importDate = getOasysImportDateFromApplication(this.application, 'risk-to-self')
 
   body: HistoricalRiskBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.test.ts
@@ -14,7 +14,7 @@ describe('Vulnerability', () => {
   })
 
   describe('import date', () => {
-    it('sets importDate to false where application contains no OASys import date', () => {
+    it('sets importDate to null where application contains no OASys import date', () => {
       const page = new Vulnerability({}, application)
 
       expect(page.importDate).toEqual(null)

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/vulnerability.ts
@@ -29,7 +29,7 @@ export default class Vulnerability implements TaskListPage {
     },
   }
 
-  importDate = getOasysImportDateFromApplication(this.application, 'vulnerability')
+  importDate = getOasysImportDateFromApplication(this.application, 'risk-to-self')
 
   body: VulnerabilityBody
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -169,12 +169,12 @@ describe('utils', () => {
   describe('getOasysImportDateFromApplication', () => {
     it('calls date formatting function when as OASys import date exists', () => {
       const application = applicationFactory.build({
-        data: { 'risk-to-self': { 'historical-risk': { dateOfOasysImport: 'some date' } } },
+        data: { 'risk-to-self': { 'oasys-import': { oasysImportDate: 'some date' } } },
       })
 
       ;(DateFormats.isoDateToUIDate as jest.Mock).mockImplementation(() => null)
 
-      utils.getOasysImportDateFromApplication(application, 'historical-risk')
+      utils.getOasysImportDateFromApplication(application, 'risk-to-self')
 
       expect(DateFormats.isoDateToUIDate).toHaveBeenCalledWith('some date', { format: 'medium' })
     })
@@ -182,7 +182,7 @@ describe('utils', () => {
     it('returns null where no import date exists on application', () => {
       const application = applicationFactory.build({ data: null })
 
-      expect(utils.getOasysImportDateFromApplication(application, 'historical-risk')).toEqual(null)
+      expect(utils.getOasysImportDateFromApplication(application, 'risk-to-self')).toEqual(null)
     })
   })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -86,9 +86,9 @@ export function pageDataFromApplication(Page: TaskListPageInterface, application
   return application.data?.[taskName]?.[pageName] || {}
 }
 
-export function getOasysImportDateFromApplication(application: Application, pageName: string): string | null {
-  if (application.data?.['risk-to-self']?.[pageName]?.dateOfOasysImport) {
-    return DateFormats.isoDateToUIDate(application.data['risk-to-self'][pageName].dateOfOasysImport, {
+export function getOasysImportDateFromApplication(application: Application, taskName: string): string | null {
+  if (application.data?.[taskName]?.['oasys-import']?.oasysImportDate) {
+    return DateFormats.isoDateToUIDate(application.data?.[taskName]?.['oasys-import']?.oasysImportDate, {
       format: 'medium',
     })
   }

--- a/server/views/applications/pages/risk-of-serious-harm/summary.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/summary.njk
@@ -22,14 +22,14 @@
 
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-  {% if page.risks and page.risks.dateOfOasysImport %}
+  {% if page.importDate %}
     {% if page.risks.lastUpdated%}
       <p class="govuk-hint">
-        Imported from OASys on <strong>{{page.risks.dateOfOasysImport}}</strong>, last updated on <strong>{{ page.risks.lastUpdated }}</strong>
+        Imported from OASys on <strong>{{page.importDate}}</strong>, last updated on <strong>{{ page.risks.lastUpdated }}</strong>
       </p>
     {% else %}
       <p class="govuk-hint">
-        Imported from OASys on <strong>{{page.risks.dateOfOasysImport}}</strong>, last updated: <strong>not known</strong>
+        Imported from OASys on <strong>{{page.importDate}}</strong>, last updated: <strong>not known</strong>
       </p>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
# Context

I noticed when filling in the Risk To Self task that the OASyS import date was disappearing from questions that I knew should have them, for example...
date is present when I first see question...
![Screenshot 2023-09-22 at 11 52 31](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/4f1bcbb8-5e06-4c31-8af8-9f534076f0fa)

after saving the question and returning, date is gone...

![Screenshot 2023-09-22 at 11 52 37](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/bc2f07b2-1559-4183-b70f-9774d0601bf6)

# Changes in this PR

This PR has two parts:

## 1. changing the way OASyS import date is saved

This issue was happening because the import date was saved against each auto-populated page in
a task as a field `oasysImportDate`:

```
task-name: {
  page-name: {
     oasysData: 'some imported data'
     oasysImportDate: '2023-09-19'
  }
}
```

However, when a user would then press 'save and continue' to submit
their answer, the field was not included in the body of
the form and so overwritten when the data was updated.

```
task-name: {
  page-name: {
    oasysData: 'some updated imported data'
    confirmation: 'confirmed'
  }
}

```

I think it makes sense for the date to 'belong' to an `oasys-import` page
anyway, as it is more like metadata for the section.

So I've refactored import form pages to save it on the task, and the pages to look for the date there:

```
task-name: {
    oasys-import: {
        oasysImportDate: ''2023-09-19'
    }
    page-name: {
        oasysData: 'some updated imported data'
        confirmation: 'confirmed'
    }
}
```
Because we in theory should only show the user the import page once,
this data will not be overwritten.


## 2. tests

This bug flagged to me something that has been bothering me - we don't have coverage over what data is being sent to the API when a form is submitted. In the integration tests, we check that it goes to the right page after submission. On the unit tests, we check the individual functions on the typescript level. 
For regular forms I think we can rely on the form inputs doing their job and sending the body of the form to the backend. But for these 'custom form' pages like the OASyS import we aren't checking that the form sends the correct data from the nunjucks level all the way to the client. 

I've introduced a `verifyApplicationUpdate` that should do this, I'd be interested to know if others think it adds any value.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
