### PR TITLE
Fix: RoSH risk summary not displaying on second viewing

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -148,7 +148,7 @@
   },
   "risk-of-serious-harm": {
     "oasys-import": { "oasysImportDate": "2023-09-21T15:47:51.430Z" },
-    "summary": {
+    "summary-data": {
       "dateOfOasysImport": "2023-09-21T15:47:51.430Z",
       "status": "retrieved",
       "value": {
@@ -157,9 +157,11 @@
         "riskToPublic": "Very High",
         "riskToKnownAdult": "Medium",
         "riskToStaff": "Low",
-        "lastUpdated": "2023-09-18",
-        "additionalComments": "some comments"
+        "lastUpdated": "2022-11-02"
       }
+    },
+    "summary": {
+      "additionalComments": "some rosh comments"
     },
     "risk-to-others": {
       "whoIsAtRisk": "a person",

--- a/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
@@ -3,7 +3,7 @@ import ApplyPage from '../../applyPage'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 import paths from '../../../../../server/paths/apply'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
-import { RoshRisksEnvelope } from '../../../../../server/@types/shared/models/RoshRisksEnvelope'
+import { SummaryData } from '../../../../../server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary'
 
 export default class RoshSummaryPage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -25,7 +25,7 @@ export default class RoshSummaryPage extends ApplyPage {
     )
   }
 
-  shouldShowRiskData = (risks: RoshRisksEnvelope, oasysImportDate: string): void => {
+  shouldShowRiskData = (risks: SummaryData, oasysImportDate: string): void => {
     cy.get('p').contains(
       `Imported from OASys on ${DateFormats.isoDateToUIDate(oasysImportDate, {
         format: 'medium',

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
@@ -216,7 +216,7 @@ context('Visit "Risks and needs" section', () => {
 
       expect(body.data['risk-of-serious-harm']['oasys-import']).to.have.keys('oasysImportDate')
       expect(body.data['risk-of-serious-harm']).to.have.keys(
-        'summary',
+        'summary-data',
         'risk-factors',
         'oasys-import',
         'reducing-risk',

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
@@ -28,10 +28,11 @@ import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import RoshSummaryPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage'
 import RiskToOthersPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/riskToOthersPage'
+import { SummaryData } from '../../../../../server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary'
 
 context('Visit "RoSH summary" page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
-  let riskSummary
+  let riskSummaryData: SummaryData
 
   beforeEach(function test() {
     cy.task('reset')
@@ -39,7 +40,7 @@ context('Visit "RoSH summary" page', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
-      riskSummary = applicationData['risk-of-serious-harm'].summary
+      riskSummaryData = applicationData['risk-of-serious-harm']['summary-data']
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -59,13 +60,13 @@ context('Visit "RoSH summary" page', () => {
     })
 
     cy.fixture('applicationData.json').then(applicationData => {
-      delete applicationData['risk-of-serious-harm'].summary
+      delete applicationData['risk-of-serious-harm']['summary-data']
       const application = applicationFactory.build({
         id: 'abc1234',
         person,
         data: applicationData,
       })
-      cy.wrap(application).as('applicationWithoutSummary')
+      cy.wrap(application).as('applicationWithoutSummaryData')
     })
   })
 
@@ -98,15 +99,18 @@ context('Visit "RoSH summary" page', () => {
     const page = Page.verifyOnPage(RoshSummaryPage, this.application)
 
     //    Then I see the data presented on the page
-    page.shouldShowRiskData(riskSummary, this.application.data['risk-of-serious-harm']['oasys-import'].oasysImportDate)
+    page.shouldShowRiskData(
+      riskSummaryData,
+      this.application.data['risk-of-serious-harm']['oasys-import'].oasysImportDate,
+    )
   })
 
   //  Scenario: view 'unknown RoSH' card
   // ----------------------------------------------
   it('presents unknown risk card', function test() {
     //    Given there is no risk summary data
-    cy.task('stubApplicationGet', { application: this.applicationWithoutSummary })
-    RoshSummaryPage.visit(this.applicationWithoutSummary)
+    cy.task('stubApplicationGet', { application: this.applicationWithoutSummaryData })
+    RoshSummaryPage.visit(this.applicationWithoutSummaryData)
     const page = Page.verifyOnPage(RoshSummaryPage, this.application)
 
     //    Then I see the unknown RoSH card

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -75,7 +75,7 @@ describe('OasysImport', () => {
 
         const taskData = {
           'risk-of-serious-harm': {
-            summary: {
+            'summary-data': {
               ...riskSummary,
               dateOfOasysImport: now,
             },

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
 import RiskToOthers from '../riskToOthers'
 import { DateFormats } from '../../../../../utils/dateUtils'
-import Summary from '../summary'
+import Summary, { SummaryData } from '../summary'
 
 type OasysImportBody = Record<string, never>
 
@@ -117,10 +117,10 @@ export default class OasysImport implements TaskListPage {
     const taskData = { 'risk-of-serious-harm': {} } as Partial<RoshTaskData>
     const today = new Date()
 
-    taskData['risk-of-serious-harm'].summary = {
+    taskData['risk-of-serious-harm']['summary-data'] = {
       ...risks,
       dateOfOasysImport: today,
-    }
+    } as SummaryData
 
     oasysSections.rosh.forEach(question => {
       switch (question.questionNumber) {


### PR DESCRIPTION
![Screenshot 2023-10-09 at 14 22 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/d763a443-f6e1-46d7-a334-22fde414c3b9)

# Context

Alex picked up in QA that the risk widget in the RoSH task displays correctly on first visit, but then becomes the 'unknown risk' version on second visits.

# Changes in this PR

The RoSH risk ratings are retrieved from the API and saved to our application data by the `oasysImport` page. This data is then retrieved from the application data used to populate the 'risk widget' by the Summary page.

The risk ratings were previously stored under the key for the Summary page, `summary`. When the user first lands on the Summary page we are able to see the widget, but when the user presses 'continue' the form page takes that `summary` key and uses it to overwrite the data that's there with it's own form data (see `save` function in the `applicationService`). Thus deleting the risk widget data.

This commit proposes a solution of saving the risk widget data under its own key on the application data. This means that it will not be overwritten by another form. The downside is that it effectively creates the idea of a `page` in the application data JSON that is not shown to the user. I think that this is mitigated by the pattern we are already using for 'add to list' pages, where we use one page to render data and another page key to store the data (e.g. `acct-data`). This widget is also a slight anomaly because a) it is not user-inputted data, but an exact copy from the API  b) The source of truth for application data should be the JSON itself, not the typescript form pages.

As we've had a few issues with this widget, I've also put an `e2e` test here https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e/pull/30 
But this is a bit of a different test for our e2e's and would be interested in any feedback.


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
