### PR TITLE
Fixes/tweaks for Behaviour Notes

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.test.ts
@@ -15,7 +15,7 @@ describe('BehaviourNotesData', () => {
     it('has a page title', () => {
       const page = new BehaviourNotesData({}, application)
 
-      expect(page.title).toEqual('Add a behaviour note')
+      expect(page.title).toEqual('Add a behaviour note for Roger Smith')
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.ts
@@ -2,6 +2,7 @@ import type { TaskListErrors } from '@approved-premises/ui'
 import { Cas2Application } from '@approved-premises/api'
 import { Page } from '../../../../utils/decorators'
 import TaskListPage from '../../../../taskListPage'
+import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
 
 export type BehaviourNotesDataBody = {
   behaviourDetail: string
@@ -12,9 +13,9 @@ export type BehaviourNotesDataBody = {
   bodyProperties: ['behaviourDetail'],
 })
 export default class BehaviourNotesData implements TaskListPage {
-  title = 'Add a behaviour note'
+  documentTitle = 'Add a behaviour note'
 
-  documentTitle = this.title
+  title = `Add a behaviour note for ${nameOrPlaceholderCopy(this.application.person)}`
 
   body: BehaviourNotesDataBody
 

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
@@ -58,11 +58,14 @@
         </div>
 
         {% block button %}
-
-          {{ govukButton({
-                text: "Save and add behaviour note"
-            }) }}
-
+          <div class="govuk-button-group">
+            {{ govukButton({
+                  text: "Save and add behaviour note"
+              }) }}
+            <a class="govuk-link" href="{{ paths.applications.pages.show({ id: applicationId, task: 'risk-of-serious-harm', page: 'behaviour-notes' }) }}">
+                Cancel
+            </a>
+          </div>
         {% endblock %}
       </form>
     </div>

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
@@ -40,6 +40,9 @@
                 label: {
                   text: page.questions.behaviourDetail.question,
                   classes: "govuk-label--m"
+                },
+                hint: {
+                  text: page.questions.behaviourDetail.hint
                 }
               },
               fetchContext()

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-three-quarters") }}">
+      {{ showErrorSummary(errorSummary) }}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
         <p>Behaviour notes are positive or negative notes about an applicant's behaviour.</p>
@@ -30,8 +31,6 @@
       </div>
       <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{ showErrorSummary(errorSummary) }}
 
         {{
             formPageTextArea(

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes.njk
@@ -3,8 +3,6 @@
 {% set pageName = "behaviour-notes" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</h1>
-
   <div class="govuk-body">
     <p> Behaviour notes are positive or negative notes about an applicant's behaviour.</p>
 

--- a/server/views/applications/pages/risk-to-self/acct-data.njk
+++ b/server/views/applications/pages/risk-to-self/acct-data.njk
@@ -27,13 +27,12 @@
 
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      {{ showErrorSummary(errorSummary) }}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <p class="govuk-body">An Assessment, Care in Custody and Teamwork (ACCT) 
           is a tailored plan to support someone in prison at risk of self harm or suicide.</p>
       <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{ showErrorSummary(errorSummary) }}
 
         {{ 
           formPageDateInput( {


### PR DESCRIPTION
# Context

This should address all the issues found here https://trello.com/c/c1U9s1L1/414-rosh-behaviour-notes-was-prison-notes#comment-651ebd2e22daf820ce66bb71 


* Error message - the error summary should be at the top of the page (before the title) - _also changed this for ACCT notes_

* Missing personalisation from the title “Add a behaviour note Terry Midhurst”

* Missing hint text for “Describe the behaviour” 

* Missing “Cancel” link 

