### PR TITLE
559: switch UI paths to use CAS2 people endpoints

### DIFF
--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -6,7 +6,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/risk-to-self`,
+        url: `/cas2/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 200,
@@ -19,7 +19,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/risk-to-self`,
+        url: `/cas2/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 404,
@@ -32,7 +32,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/rosh`,
+        url: `/cas2/people/${args.crn}/oasys/rosh`,
       },
       response: {
         status: 200,
@@ -45,7 +45,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/oasys/rosh`,
+        url: `/cas2/people/${args.crn}/oasys/rosh`,
       },
       response: {
         status: 404,
@@ -58,7 +58,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/search?crn=${args.person.crn}`,
+        url: `/cas2/people/search?crn=${args.person.crn}`,
       },
       response: {
         status: 201,
@@ -71,7 +71,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/search?crn=${args.person.crn}`,
+        url: `/cas2/people/search?crn=${args.person.crn}`,
       },
       response: {
         status: 404,
@@ -82,7 +82,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/search?crn=${args.person.crn}`,
+        url: `/cas2/people/search?crn=${args.person.crn}`,
       },
       response: {
         status: 403,
@@ -93,7 +93,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/risks`,
+        url: `/cas2/people/${args.crn}/risks`,
       },
       response: {
         status: 200,
@@ -106,7 +106,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/people/${args.crn}/risks`,
+        url: `/cas2/people/${args.crn}/risks`,
       },
       response: {
         status: 404,

--- a/script/generate-types
+++ b/script/generate-types
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 
 echo "==> Generating types..."
 
-npx openapi-typescript-codegen -i https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/api.yml -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
+npx openapi-typescript-codegen -i https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/4981eb92ef938eaab5b7acb2c571c59a6ea48f43/src/main/resources/static/codegen/built-cas2-api-spec.yml -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
 
 echo "==> Renaming the declaration file..."
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,6 +1,5 @@
 import { OASysRiskOfSeriousHarm } from '../shared/models/OASysRiskOfSeriousHarm'
 import { OASysRiskToSelf } from '../shared/models/OASysRiskToSelf'
-import { OASysSections } from '../shared/models/OASysSections'
 import { RoshRisksEnvelope } from '../shared/models/RoshRisksEnvelope'
 
 export type JourneyType = 'applications'
@@ -49,7 +48,6 @@ export type FormArtifact = Cas2Application
 export type DataServices = Partial<{
   personService: {
     findByCrn: (token: string, crn: string) => Promise<Person>
-    getOasysSections: (token: string, crn: string) => Promise<OASysSections>
     getOasysRiskToSelf: (token: string, crn: string) => Promise<OASysRiskToSelf>
     getOasysRosh: (token: string, crn: string) => Promise<OASysRiskOfSeriousHarm>
     getRoshRisks: (token: string, crn: string) => Promise<RoshRisksEnvelope>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,11 +1,5 @@
 import PersonClient from './personClient'
-import {
-  oasysRiskToSelfFactory,
-  oasysSectionsFactory,
-  personFactory,
-  oasysRoshFactory,
-  risksFactory,
-} from '../testutils/factories'
+import { oasysRiskToSelfFactory, personFactory, oasysRoshFactory, risksFactory } from '../testutils/factories'
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
@@ -17,62 +11,6 @@ describeClient('PersonClient', provider => {
 
   beforeEach(() => {
     personClient = new PersonClient(token)
-  })
-
-  describe('oasysSections', () => {
-    it('should return the sections of OASys when there is optional selected sections', async () => {
-      const crn = 'crn'
-      const optionalSections = [1, 2, 3]
-      const oasysSections = oasysSectionsFactory.build()
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to get the optional selected sections of OASys for a person',
-        withRequest: {
-          method: 'GET',
-          path: paths.people.oasys.sections({ crn }),
-          query: {
-            'selected-sections': ['1', '2', '3'],
-          },
-          headers: {
-            authorization: `Bearer ${token}`,
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: oasysSections,
-        },
-      })
-
-      const result = await personClient.oasysSections(crn, optionalSections)
-
-      expect(result).toEqual(oasysSections)
-    })
-
-    it('should return the sections of OASys with no optional selected sections', async () => {
-      const crn = 'crn'
-      const oasysSections = oasysSectionsFactory.build()
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to get sections of OASys for a person',
-        withRequest: {
-          method: 'GET',
-          path: paths.people.oasys.sections({ crn }),
-          headers: {
-            authorization: `Bearer ${token}`,
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: oasysSections,
-        },
-      })
-
-      const result = await personClient.oasysSections(crn)
-
-      expect(result).toEqual(oasysSections)
-    })
   })
 
   describe('oasysRiskToSelf', () => {

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -78,7 +78,7 @@ describeClient('PersonClient', provider => {
         uponReceiving: 'A request to search for a person',
         withRequest: {
           method: 'GET',
-          path: `/people/search`,
+          path: `/cas2/people/search`,
           query: {
             crn: 'crn',
           },
@@ -108,7 +108,7 @@ describeClient('PersonClient', provider => {
         uponReceiving: 'A request to get the risks for a person',
         withRequest: {
           method: 'GET',
-          path: `/people/${crn}/risks`,
+          path: `/cas2/people/${crn}/risks`,
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,10 +1,4 @@
-import type {
-  OASysRiskOfSeriousHarm,
-  OASysRiskToSelf,
-  OASysSections,
-  Person,
-  PersonRisks,
-} from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person, PersonRisks } from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -16,16 +10,6 @@ export default class PersonClient {
 
   constructor(token: string) {
     this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
-  }
-
-  async oasysSections(crn: string, selectedSections?: Array<number>): Promise<OASysSections> {
-    const queryString: string = createQueryString({ 'selected-sections': selectedSections })
-
-    const path = `${paths.people.oasys.sections({ crn })}${queryString ? `?${queryString}` : ''}`
-
-    const response = (await this.restClient.get({ path })) as OASysSections
-
-    return response
   }
 
   async oasysRiskToSelf(crn: string): Promise<OASysRiskToSelf> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,6 +1,6 @@
 import { path } from 'static-path'
 
-const peoplePath = path('/people')
+const peoplePath = path('/cas2/people')
 const personPath = peoplePath.path(':crn')
 const oasysPath = personPath.path('oasys')
 const applicationsPath = path('/cas2/applications')

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,10 +1,4 @@
-import {
-  oasysRiskToSelfFactory,
-  oasysRoshFactory,
-  oasysSectionsFactory,
-  personFactory,
-  risksFactory,
-} from '../testutils/factories'
+import { oasysRiskToSelfFactory, oasysRoshFactory, personFactory, risksFactory } from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -34,20 +28,6 @@ describe('Person Service', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.search).toHaveBeenCalledWith('crn')
-    })
-  })
-
-  describe('getOasysSections', () => {
-    it('returns oasysSections', async () => {
-      const expectedOasysSections = oasysSectionsFactory.build()
-      personClient.oasysSections.mockResolvedValue(expectedOasysSections)
-
-      const oasysSections = await service.getOasysSections(token, 'crn')
-
-      expect(oasysSections).toEqual(expectedOasysSections)
-
-      expect(personClientFactory).toHaveBeenCalledWith(token)
-      expect(personClient.oasysSections).toHaveBeenCalledWith('crn')
     })
   })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,10 +1,4 @@
-import type {
-  OASysRiskOfSeriousHarm,
-  OASysRiskToSelf,
-  OASysSections,
-  Person,
-  RoshRisksEnvelope,
-} from '@approved-premises/api'
+import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person, RoshRisksEnvelope } from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
@@ -15,13 +9,6 @@ export default class PersonService {
 
     const person = await personClient.search(crn)
     return person
-  }
-
-  async getOasysSections(token: string, crn: string): Promise<OASysSections> {
-    const personClient = this.personClientFactory(token)
-
-    const oasysSections = await personClient.oasysSections(crn)
-    return oasysSections
   }
 
   async getOasysRiskToSelf(token: string, crn: string): Promise<OASysRiskToSelf> {

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,16 +28,17 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/ddf95a65a402ac9d3c83ab80ecd2442ed4a20b03/src/main/resources/static/api.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/4981eb92ef938eaab5b7acb2c571c59a6ea48f43/src/main/resources/static/codegen/built-cas2-api-spec.yml'
 
-    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'api.yml')
+    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'cas2-api.yml')
 
     try {
       execSync(`
-          if [ ! -f ${openAPIPath} ]; then
-            curl -s "${openAPIUrl}" > ${openAPIPath}
-          fi
-        `)
+        if [ ! -f ${openAPIPath} ]; then
+          curl -s "${openAPIUrl}" | sed -E 's@/application@/cas2/application@g' | sed -E 's@/people@/cas2/people@g' > ${openAPIPath}
+        fi
+      `)
+
       execSync(`npx swagger-mock-validator ${openAPIPath} ${pactPath}`)
       return {
         message: () => `Swagger mock validator for ${pactPath} did not fail`,


### PR DESCRIPTION
This PR should be merged at the same time as the API [PR 991: use CAS2 with NOMIS credentials](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/991)

It includes changes to make the UI compatible with i) newly namespaced endpoints and ii) the separate new-style 'built' CAS2 OpenAPI spec:

- puts API calls to the 'people' endpoints into the new `/cas2/` namespace
- removes unused and no longer supported `PersonService.getOasysSections()` function
- changes the path to the CAS2 OpenAPI spec in the Typescript type generator
- changes the path to the CAS2 OpenAPI spec for PACT testing and reformats the specification to work around limitation in the PACT testing library



# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [x] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
