### PR TITLE
(330) Mk3 Health Needs: Substance misuse - tweaks

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
@@ -7,7 +7,7 @@ import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 export default class SubstanceMisusePage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(
-      `Health needs for ${nameOrPlaceholderCopy(application.person)}`,
+      `Substance misuse needs for ${nameOrPlaceholderCopy(application.person)}`,
       application,
       'health-needs',
       'substance-misuse',

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -9,7 +9,7 @@ describe('SubstanceMisuse', () => {
     it('personalises the page title', () => {
       const page = new SubstanceMisuse({}, application)
 
-      expect(page.title).toEqual('Health needs for Roger Smith')
+      expect(page.title).toEqual('Substance misuse needs for Roger Smith')
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -28,11 +28,11 @@ type SubstanceMisuseBody = {
   ],
 })
 export default class SubstanceMisuse implements TaskListPage {
-  documentTitle = 'Health needs for the person'
+  documentTitle = 'Substance misuse needs for the person'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 
-  title = `Health needs for ${nameOrPlaceholderCopy(this.application.person)}`
+  title = `Substance misuse needs for ${nameOrPlaceholderCopy(this.application.person)}`
 
   questions = getQuestions(this.personName)['health-needs']['substance-misuse']
 

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -54,7 +54,7 @@
         {
           fieldName: 'substituteMedicationDetail',
           label: {
-            text: page.questions.substituteMedicationDetail.question,
+            text: page.questions.requiresSubstituteMedication.substituteMedicationDetail.question,
             classes: "govuk-label--s"
           }
         },


### PR DESCRIPTION
See [Trello 330](https://trello.com/c/Qg994Nnx/330-health-subsection-substance-misuse)

Tweaks to Substance misuse page in Health Needs task.

## Screenshots of UI changes

![substance_misuse_tweaks_3](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/4194bbb9-7429-48ff-8ef4-b03bf62fdb23)


