### PR TITLE
fix grammar on person's name

### DIFF
--- a/server/views/applications/pages/risk-of-serious-harm/risk-management-arrangements.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/risk-management-arrangements.njk
@@ -58,7 +58,7 @@
   {% endset -%}
 
   <p class="govuk-body">
-    You should check with {{ page.personName }} Community Probation Practitioner (CPP), 
+    You should check with {{ page.personName }}'s Community Probation Practitioner (CPP), 
     also known as Community Offender Manager (COM), for up-to-date risk management arrangements.
   </p>
   <p class="govuk-body">


### PR DESCRIPTION
Missing an `'s` - this should work if the copy is either 'the person' or the actual person's name
![Screenshot 2023-10-16 at 14 09 44](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/4b0f6407-e867-4147-8d36-184a7902b97f)
