### PR TITLE
Add preprod values for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,38 +257,36 @@ workflows:
             - helm_lint
             - build_docker
             - request-test-approval
-  #      - request-preprod-approval:
-  #          type: approval
-  #          requires:
-  #            - deploy_dev
-  #      - hmpps/deploy_env:
-  #          name: deploy_preprod
-  #          env: "preprod"
-  #          jira_update: true
-  #          jira_env_type: staging
-  #          context:
-  #            - hmpps-common-vars
-  #            - hmpps-community-accommodation-tier-2-ui-preprod
-  #          requires:
-  #            - request-preprod-approval
-  #          helm_timeout: 5m
-  #      - request-prod-approval:
-  #          type: approval
-  #          requires:
-  #            - deploy_preprod
-  #      - hmpps/deploy_env:
-  #          name: deploy_prod
-  #          env: "prod"
-  #          jira_update: true
-  #          jira_env_type: production
-  #          slack_notification: true
-  #          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-  #          context:
-  #            - hmpps-common-vars
-  #            - hmpps-community-accommodation-tier-2-ui-prod
-  #          requires:
-  #            - request-prod-approval
-  #          helm_timeout: 5m
+      - request-preprod-approval:
+           type: approval
+           requires:
+             - deploy_dev
+             - e2e_environment_test
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - hmpps-community-accommodation-tier-2-ui-preprod
+          requires:
+             - request-preprod-approval
+      # - request-prod-approval:
+      #      type: approval
+      #      requires:
+      #        - deploy_preprod
+      # - hmpps/deploy_env:
+      #      name: deploy_prod
+      #      env: "prod"
+      #      jira_update: true
+      #      jira_env_type: production
+      #      slack_notification: true
+      #      slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+      #      context:
+      #        - hmpps-common-vars
+      #        - hmpps-community-accommodation-tier-2-ui-prod
+      #      requires:
+      #        - request-prod-approval
+      #      helm_timeout: 5m
 
   security:
     triggers:

--- a/helm_deploy/values-preprod.yml
+++ b/helm_deploy/values-preprod.yml
@@ -1,0 +1,26 @@
+---
+# Per environment values which override defaults in approved-premises-ui/values.yaml
+
+generic-service:
+  ingress:
+    hosts:
+      - community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk
+    contextColour: green
+    tlsSecretName: hmpps-community-accommodation-tier-2-preprod-cert
+
+  env:
+    ENVIRONMENT: preprod
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-preprod.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
+    
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+      AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
+      AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
# Context

We would like to begin user testing some features of the service in a production-like environment. 

Cloud Platform PR merged here  https://github.com/ministryofjustice/cloud-platform-environments/pull/17070 
Bootstrap PR here https://github.com/ministryofjustice/dps-project-bootstrap/pull/518 
HMPPS Auth setup here https://dsdmoj.atlassian.net/browse/HAAR-1978 

This PR:
* adds the values needed to deploy to the `preprod` environment.
* adds the CircleCI workflow to manually deploy to preprod. Unlike test and dev, I'm going to require that the e2e tests are passing because we need to have confidence in our pipeline, but open to changing that if we think it's going to hold up things.


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
