### PR TITLE
Tweak validation error msg when detail missing from 'additional needs' question

### DIFF
--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.test.ts
@@ -88,7 +88,10 @@ describe('LearningDifficulties', () => {
 
       describe('and _needsDetail_ is UNANSWERED', () => {
         it('includes a validation error for _needsDetail_', () => {
-          expect(page.errors()).toHaveProperty('needsDetail', 'Describe the additional support required')
+          expect(page.errors()).toHaveProperty(
+            'needsDetail',
+            'Describe their additional needs relating to learning difficulties or neurodiversity',
+          )
         })
       })
     })

--- a/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/learningDifficulties.ts
@@ -62,7 +62,7 @@ export default class LearningDifficulties implements TaskListPage {
       errors.hasLearningNeeds = `Confirm whether they have additional needs`
     }
     if (this.body.hasLearningNeeds === 'yes' && !this.body.needsDetail) {
-      errors.needsDetail = 'Describe the additional support required'
+      errors.needsDetail = 'Describe their additional needs relating to learning difficulties or neurodiversity'
     }
 
     if (!this.body.isVulnerable) {


### PR DESCRIPTION
See [Trello 375](https://trello.com/c/SmsCqlYJ) - Health section: learning difficulties 

![health_learning_difficulties_validation_msg](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/a446d9a1-8cb2-456c-9798-009cda05a3d7)
