### PR TITLE
Add custom `response` to data pages

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotes.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotes.test.ts
@@ -17,7 +17,7 @@ describe('BehaviourNotes', () => {
   itShouldHavePreviousValue(new BehaviourNotes({}, application), 'cell-share-information')
 
   describe('response', () => {
-    it('not implemented', () => {
+    it('returns behaviour notes', () => {
       const page = new BehaviourNotes({}, application)
 
       page.behaviourNotes = [
@@ -26,6 +26,11 @@ describe('BehaviourNotes', () => {
       ]
 
       expect(page.response()).toEqual({ 'Behaviour note 1': 'detail 1', 'Behaviour note 2': 'detail 2' })
+    })
+
+    it('returns empty object when no notes', () => {
+      const page = new BehaviourNotes({}, application)
+      expect(page.response()).toEqual({})
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotes.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotes.ts
@@ -69,7 +69,7 @@ export default class BehaviourNotes implements TaskListPage {
   response() {
     const response = {}
 
-    this.behaviourNotes.forEach((behaviourNote, index) => {
+    this.behaviourNotes?.forEach((behaviourNote, index) => {
       response[`Behaviour note ${index + 1}`] = behaviourNote.behaviourDetail
     })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.test.ts
@@ -37,4 +37,11 @@ describe('BehaviourNotesData', () => {
       expect(errors.behaviourDetail).toEqual("Describe the applicant's behaviour")
     })
   })
+
+  describe('response', () => {
+    it('returns empty object', () => {
+      const page = new BehaviourNotesData({}, application)
+      expect(page.response()).toEqual({})
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/behaviourNotesData.ts
@@ -50,4 +50,8 @@ export default class BehaviourNotesData implements TaskListPage {
 
     return errors
   }
+
+  response() {
+    return {}
+  }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.test.ts
@@ -97,6 +97,11 @@ describe('Acct', () => {
         'ACCT<br />Created: created date 2<br />Ongoing': 'some different details',
       })
     })
+
+    it('returns empty object when no accts', () => {
+      const page = new Acct({}, application)
+      expect(page.response()).toEqual({})
+    })
   })
 
   describe('errors', () => {

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/acct.ts
@@ -80,7 +80,7 @@ export default class Acct implements TaskListPage {
   response() {
     const response = {}
 
-    this.accts.forEach(acct => {
+    this.accts?.forEach(acct => {
       const key = getAcctMetadata(acct)
       response[key] = acct.acctDetails
     })

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/acctData.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/acctData.test.ts
@@ -79,4 +79,11 @@ describe('AcctData', () => {
       })
     })
   })
+
+  describe('response', () => {
+    it('returns empty object', () => {
+      const page = new AcctData({}, application)
+      expect(page.response()).toEqual({})
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/acctData.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/acctData.ts
@@ -82,4 +82,8 @@ export default class AcctData implements TaskListPage {
 
     return errors
   }
+
+  response() {
+    return {}
+  }
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -383,7 +383,6 @@ export const getQuestions = (name: string) => {
           answers: { confirmed: 'Confirmed' },
         },
       },
-      acct: {},
       'acct-data': {
         createdDate: {
           question: 'When was the ACCT created?',
@@ -489,7 +488,6 @@ export const getQuestions = (name: string) => {
         },
         cellShareInformationDetail: { question: 'Cell sharing information' },
       },
-      'behaviour-notes': {},
       'behaviour-notes-data': {
         behaviourDetail: {
           question: 'Describe the behaviour',

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -142,7 +142,7 @@ export const getSectionsWithAnswers = (): Array<FormSection> => {
 }
 
 export const getPages = (application: Application, task: string) => {
-  const pagesWithoutQuestions = ['summary', 'summary-data', 'oasys-import', 'acct', 'behaviour-notes']
+  const pagesWithoutQuestions = ['summary', 'summary-data']
   const pagesKeys = Object.keys(application.data[task])
 
   return pagesKeys.filter(pageKey => !pagesWithoutQuestions.includes(pageKey))
@@ -173,15 +173,8 @@ export const hasResponseMethod = (page: TaskListPage): boolean => {
 
 export const getPage = (taskName: string, pageName: string): TaskListPageInterface => {
   const pageList = Apply.pages[taskName]
-  let Page
 
-  if (pageName === 'acct-data') {
-    Page = pageList.acct
-  } else if (pageName === 'behaviour-notes-data') {
-    Page = pageList['behaviour-notes']
-  } else {
-    Page = pageList[pageName]
-  }
+  const Page = pageList[pageName]
 
   if (!Page) {
     throw new UnknownPageError(pageName)


### PR DESCRIPTION
# Context

We would like to decouple as much as possible the Check Your Answers utility function from specific page keys.

# Changes in this PR

For pages that we will not render on CYA:
* we do not need to return anything from the `getQuestions` util
* we will return an empty object from the `response` function for the page. This is the purpose of that function, to allow for custom responses rather than specifying in the CYA utilities.

This change removes the need for a hand-rolled list. We still need to include the `summary` pages currently, but will create a future ticket to render that data in it's own way. 

## Screenshots of UI changes

Should be no changes to rendering of Check Your Answers

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
