### PR TITLE
Move application submission to new /cas2/submissions endpoint

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,4 +1,4 @@
-import type { Cas2Application as Application, Cas2Application } from '@approved-premises/api'
+import type { Cas2Application as Application } from '@approved-premises/api'
 import { SuperAgentRequest } from 'superagent'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
@@ -59,11 +59,11 @@ export default {
         url: paths.applications.update({ id: applicationId }),
       })
     ).body.requests,
-  stubApplicationSubmit: (args: { application: Cas2Application }): SuperAgentRequest =>
+  stubApplicationSubmit: (): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
-        url: `/cas2/applications/${args.application.id}/submission`,
+        url: `/cas2/submissions`,
       },
       response: {
         status: 200,

--- a/integration_tests/tests/apply/submit.cy.ts
+++ b/integration_tests/tests/apply/submit.cy.ts
@@ -32,7 +32,7 @@ context('Applications dashboard', () => {
   // ----------------------------------------------
   it('shows the dashboard', function test() {
     cy.task('stubApplicationGet', { application: this.application })
-    cy.task('stubApplicationSubmit', { application: this.application })
+    cy.task('stubApplicationSubmit', {})
 
     // I visit the Task List Page
     const page = TaskListPage.visit(this.application)

--- a/script/generate-types
+++ b/script/generate-types
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 
 echo "==> Generating types..."
 
-npx openapi-typescript-codegen -i https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/4981eb92ef938eaab5b7acb2c571c59a6ea48f43/src/main/resources/static/codegen/built-cas2-api-spec.yml -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
+npx openapi-typescript-codegen -i https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/1c3262819d5b9020b0a6c7619480c5691dc63d76/src/main/resources/static/codegen/built-cas2-api-spec.yml -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
 
 echo "==> Renaming the declaration file..."
 

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -75,6 +75,8 @@ export type { Cancellation } from './models/Cancellation';
 export type { CancellationReason } from './models/CancellationReason';
 export type { Cas2Application } from './models/Cas2Application';
 export type { Cas2ApplicationSummary } from './models/Cas2ApplicationSummary';
+export type { Cas2SubmittedApplication } from './models/Cas2SubmittedApplication';
+export type { Cas2SubmittedApplicationSummary } from './models/Cas2SubmittedApplicationSummary';
 export type { Characteristic } from './models/Characteristic';
 export type { CharacteristicPair } from './models/CharacteristicPair';
 export type { ClarificationNote } from './models/ClarificationNote';

--- a/server/@types/shared/models/Cas2SubmittedApplication.ts
+++ b/server/@types/shared/models/Cas2SubmittedApplication.ts
@@ -1,0 +1,21 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { AnyValue } from './AnyValue';
+import type { ApplicationStatus } from './ApplicationStatus';
+import type { Person } from './Person';
+
+export type Cas2SubmittedApplication = {
+    id: string;
+    person: Person;
+    createdAt: string;
+    createdByUserId: string;
+    schemaVersion: string;
+    outdatedSchema: boolean;
+    document?: AnyValue;
+    status: ApplicationStatus;
+    submittedAt?: string;
+};
+

--- a/server/@types/shared/models/Cas2SubmittedApplicationSummary.ts
+++ b/server/@types/shared/models/Cas2SubmittedApplicationSummary.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ApplicationStatus } from './ApplicationStatus';
+import type { Person } from './Person';
+
+export type Cas2SubmittedApplicationSummary = {
+    id: string;
+    createdByUserId: string;
+    status: ApplicationStatus;
+    person: Person;
+    createdAt: string;
+    submittedAt?: string;
+};
+

--- a/server/@types/shared/models/SubmitCas2Application.ts
+++ b/server/@types/shared/models/SubmitCas2Application.ts
@@ -3,7 +3,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { SubmitApplication } from './SubmitApplication';
+import type { AnyValue } from './AnyValue';
 
-export type SubmitCas2Application = SubmitApplication;
+export type SubmitCas2Application = {
+    translatedDocument: AnyValue;
+    /**
+     * Id of the application being submitted
+     */
+    applicationId: string;
+};
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -130,7 +130,7 @@ describeClient('ApplicationClient', provider => {
       const application = applicationFactory.build()
       const data = {
         translatedDocument: application.document,
-        type: 'CAS2',
+        applicationId: application.id,
       } as SubmitCas2Application
 
       provider.addInteraction({
@@ -138,7 +138,7 @@ describeClient('ApplicationClient', provider => {
         uponReceiving: 'A request to submit an application',
         withRequest: {
           method: 'POST',
-          path: paths.applications.submission({ id: application.id }),
+          path: paths.submissions.create.pattern,
           body: data,
           headers: {
             authorization: `Bearer ${token}`,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,7 +1,7 @@
 import {
   Cas2Application as Application,
   Cas2ApplicationSummary,
-  SubmitApplication,
+  SubmitCas2Application,
   UpdateApplication,
 } from '@approved-premises/api'
 import { UpdateCas2Application } from '../@types/shared/models/UpdateCas2Application'
@@ -40,10 +40,10 @@ export default class ApplicationClient {
     })) as Application
   }
 
-  async submit(applicationId: string, submissionData: SubmitApplication): Promise<void> {
+  async submit(applicationId: string, submissionData: SubmitCas2Application): Promise<void> {
     await this.restClient.post({
-      path: paths.applications.submission({ id: applicationId }),
-      data: { ...submissionData, type: 'CAS2' },
+      path: paths.submissions.create.pattern,
+      data: { ...submissionData, applicationId },
     })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -5,6 +5,7 @@ const personPath = peoplePath.path(':crn')
 const oasysPath = personPath.path('oasys')
 const applicationsPath = path('/cas2/applications')
 const singleApplicationPath = applicationsPath.path(':id')
+const submissionsPath = path('/cas2/submissions')
 
 export default {
   people: {
@@ -18,11 +19,13 @@ export default {
       show: personPath.path('risks'),
     },
   },
+  submissions: {
+    create: submissionsPath,
+  },
   applications: {
     new: applicationsPath,
     index: applicationsPath,
     show: singleApplicationPath,
     update: singleApplicationPath,
-    submission: singleApplicationPath.path('submission'),
   },
 }

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,14 +28,14 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/4981eb92ef938eaab5b7acb2c571c59a6ea48f43/src/main/resources/static/codegen/built-cas2-api-spec.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/1c3262819d5b9020b0a6c7619480c5691dc63d76/src/main/resources/static/codegen/built-cas2-api-spec.yml'
 
     const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'cas2-api.yml')
 
     try {
       execSync(`
         if [ ! -f ${openAPIPath} ]; then
-          curl -s "${openAPIUrl}" | sed -E 's@/application@/cas2/application@g' | sed -E 's@/people@/cas2/people@g' > ${openAPIPath}
+          curl -s "${openAPIUrl}" | sed -E 's@/application@/cas2/application@g' | sed -E 's@/submissions@/cas2/submissions@g' | sed -E 's@/people@/cas2/people@g' > ${openAPIPath}
         fi
       `)
 

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -15,7 +15,7 @@ describe('getApplicationSubmissionData', () => {
   it('returns the submission data', () => {
     const mockApplication = applicationFactory.build()
     expect(getApplicationSubmissionData(mockApplication)).toEqual({
-      type: 'CAS2',
+      applicationId: mockApplication.id,
       translatedDocument: mockApplication.document,
     })
   })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -10,6 +10,6 @@ export const getApplicationUpdateData = (application: Application): UpdateApplic
 export const getApplicationSubmissionData = (application: Application): SubmitCas2Application => {
   return {
     translatedDocument: application.document,
-    type: 'CAS2',
+    applicationId: application.id,
   }
 }


### PR DESCRIPTION
# Change application submission endpoint

**This PR should be merged at the same time as the accompanying change at the CAS API https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1085**

There is no change in behaviour from the point of view of users or end-to-end tests.

![post_submissions](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/abb8432c-1a9d-457d-8a05-76f50e9046b8)

## Pre merge checklist

- [x] Does this rely on changes being deployed to the CAS API? **This PR should be merged at the same time as the accompanying change at the CAS API https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1085**

