### PR TITLE
Correct colour for offence history tags

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -12,6 +12,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/copy-text';
 @import './components/rosh-widget';
 @import './components/summary-card';
+@import './components/tag';
 
 @import './pages//oasys-import';
 

--- a/assets/scss/components/_tag.scss
+++ b/assets/scss/components/_tag.scss
@@ -1,0 +1,4 @@
+.govuk-tag--custom-brown {
+    color: #0b0c0c;
+    background: #eec98c;
+}

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
@@ -58,7 +58,7 @@ describe('OffenceHistory', () => {
           },
           {
             titleAndNumber: 'Arson (09000)',
-            offenceCategoryTag: '<strong class="govuk-tag govuk-tag--orange">Arson</strong>',
+            offenceCategoryTag: '<strong class="govuk-tag govuk-tag--yellow">Arson</strong>',
             offenceCategoryText: 'Arson',
             offenceDate: '5 June 1940',
             sentenceLength: '3 years',
@@ -95,11 +95,11 @@ describe('OffenceHistory', () => {
     const categories = [
       ['stalkingOrHarassment', 'blue'],
       ['weaponsOrFirearms', 'red'],
-      ['arson', 'orange'],
+      ['arson', 'yellow'],
       ['violence', 'pink'],
       ['domesticAbuse', 'purple'],
       ['hateCrime', 'green'],
-      ['drugs', 'yellow'],
+      ['drugs', 'custom-brown'],
       ['other', 'grey'],
       ['undefinedCategory', 'grey'],
     ]

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.ts
@@ -117,7 +117,7 @@ export default class OffenceHistory implements TaskListPage {
       case 'weaponsOrFirearms':
         return 'red'
       case 'arson':
-        return 'orange'
+        return 'yellow'
       case 'violence':
         return 'pink'
       case 'domesticAbuse':
@@ -125,7 +125,7 @@ export default class OffenceHistory implements TaskListPage {
       case 'hateCrime':
         return 'green'
       case 'drugs':
-        return 'yellow'
+        return 'custom-brown'
       default:
         return 'grey'
     }


### PR DESCRIPTION
# Context

https://trello.com/c/kBofxIPG/418-epic-offence-history-add-a-previous-offence

# Changes in this PR

adding a custom brown colour to the tags, as the colours provided by GDS not contrasty enough. Hex codes taken from prototype.

## Screenshots of UI changes

![Screenshot 2023-11-03 at 11 29 02](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/24f65d08-c515-4aa9-90e0-56c6ca660a19)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
