### PR TITLE
Add custom CSS to funding checkbox

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -13,6 +13,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/rosh-widget';
 @import './components/summary-card';
 @import './components/tag';
+@import './components/checkboxes';
 
 @import './pages//oasys-import';
 

--- a/assets/scss/components/_checkboxes.scss
+++ b/assets/scss/components/_checkboxes.scss
@@ -1,0 +1,8 @@
+.govuk-checkboxes__divider-custom {
+    color: #0b0c0c;
+    width: 100%;
+    text-align: left;
+    font-weight: bold;
+    margin-top: 15px;
+    margin-bottom: 15px;
+}

--- a/server/form-pages/apply/area-and-funding/funding-information/alternativeID.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/alternativeID.test.ts
@@ -31,7 +31,6 @@ describe('AlternativeIdentification', () => {
       const conditional = 'some html'
 
       const expected = [
-        { divider: 'Work and employment' },
         { checked: false, text: 'Employer letter/contract of employment', value: 'contract' },
         { checked: false, text: 'Trade union membership card', value: 'tradeUnion' },
         { checked: false, text: 'Invoices (self-employed)', value: 'invoice' },

--- a/server/form-pages/apply/area-and-funding/funding-information/alternativeID.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/alternativeID.ts
@@ -33,6 +33,13 @@ export default class AlternativeIdentification implements TaskListPage {
 
   guidanceHtml = `The applicant needs ID if they are applying for Universal Credit for financial support, and Housing Benefit to cover their rent.<br /><br />If they want to receive an advance payment of Universal Credit on the day of release, they will need a bank account and photo ID.`
 
+  subHeadingHtml = `<div class="govuk-checkboxes__divider-custom">Work and employment</div>`
+
+  hintHtml = `<div id="alternativeIDDocuments-hint" class="govuk-hint">
+              ${applicationQuestions.alternativeIDDocuments.hint}
+              </div>
+              ${this.subHeadingHtml}`
+
   constructor(
     body: Partial<AlternativeIdentificationBody>,
     private readonly application: Application,
@@ -118,7 +125,6 @@ export default class AlternativeIdentification implements TaskListPage {
     const other = otherItems.pop()
 
     return [
-      { divider: 'Work and employment' },
       ...convertKeyValuePairToCheckboxItems(workAndEmploymentOptions, this.body.alternativeIDDocuments),
       { divider: 'Citizenship and nationality' },
       ...convertKeyValuePairToCheckboxItems(citizenshipOptions, this.body.alternativeIDDocuments),

--- a/server/views/applications/pages/funding-information/alternative-identification.njk
+++ b/server/views/applications/pages/funding-information/alternative-identification.njk
@@ -24,7 +24,7 @@
         {
           fieldName: "alternativeIDDocuments",
           hint: {
-            text: page.questions.alternativeIDDocuments.hint
+            html: page.hintHtml
           },
           classes: "alternative-id-documents",
           items: page.items(otherID)


### PR DESCRIPTION
When the divider was passed as the first element to the checkbox component, the `for` id given to the next checkbox had a `-2` at the end. This meant that if there was an error summary it was not able to link to the first checkbox.

I couldn't see a way to override the index-based attributes given to the checkbox items, so this is a bit of a hacky way of adding a divider without adding it to the items.

## Screenshots of UI changes

### Before

![Screenshot 2023-11-03 at 11 47 08](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/e085c9ad-02f7-4011-8113-5758a62bc193)


### After

![Screenshot 2023-11-03 at 11 47 20](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/3f1168f0-ebb6-4c40-97c5-5225bb99d4dc)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
