### PR TITLE
Fix check for submitted application

### DIFF
--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -41,7 +41,8 @@ export default class ApplicationsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
-      if (application.submittedAt !== undefined) {
+
+      if (application.submittedAt) {
         return res.render('applications/show', { application })
       }
 


### PR DESCRIPTION
On applications that are not submitted the key will be present but the value will be `null`.