### PR TITLE
Add hint text for identification checkboxes

### DIFF
--- a/server/form-pages/apply/area-and-funding/funding-information/identification.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/identification.test.ts
@@ -69,6 +69,7 @@ describe('Identification', () => {
           },
           checked: false,
           text: 'UK photo driving licence',
+          hint: { text: 'Can be provisional' },
           value: 'drivingLicence',
         },
         {
@@ -77,6 +78,7 @@ describe('Identification', () => {
           },
           checked: false,
           text: 'Recent wage slip',
+          hint: { text: 'With payee name and NI number' },
           value: 'wageSlip',
         },
         {

--- a/server/form-pages/apply/area-and-funding/funding-information/identification.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/identification.ts
@@ -68,6 +68,11 @@ export default class Identification implements TaskListPage {
 
     items.forEach(item => {
       item.attributes = { 'data-selector': 'documents' }
+      if (item.value === 'wageSlip') {
+        item.hint = { text: 'With payee name and NI number' }
+      } else if (item.value === 'drivingLicence') {
+        item.hint = { text: 'Can be provisional' }
+      }
     })
 
     return [...items, { divider: 'or' }, { ...none }]


### PR DESCRIPTION
# Changes in this PR

Add hint text from prototype to driver's licence and wage slip checkbox. Because of the way we iterate through the checkbox values I've hardcoded them in the `items` function. Open to other suggestions!

## Screenshots of UI changes

### Before


![Screenshot 2023-11-07 at 16 54 08](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/d8b08d4f-e175-4e09-baa1-c965e13114c5)

### After

![Screenshot 2023-11-07 at 16 53 55](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/ae7748b4-968f-4497-8e38-fc922a67f8f4)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
