### PR TITLE
Allow for no offence history data in CYA

### DIFF
--- a/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
@@ -89,6 +89,11 @@ describe('OffenceHistory', () => {
         'Historical offence 2': 'Arson (09000)\r\nArson\r\n5 June 1940\r\n3 years\r\n\nSummary: second summary detail',
       })
     })
+
+    it('returns empty object when there are no offences', () => {
+      const page = new OffenceHistory({}, application)
+      expect(page.response()).toEqual({})
+    })
   })
 
   describe('getOffenceTagColour', () => {

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.ts
@@ -95,7 +95,7 @@ export default class OffenceHistory implements TaskListPage {
   response() {
     const response = {}
 
-    this.offences.forEach((offence, index) => {
+    this.offences?.forEach((offence, index) => {
       const { titleAndNumber, offenceCategoryText, offenceDate, sentenceLength, summary } = offence
       const offenceString = `${titleAndNumber}\r\n${offenceCategoryText}\r\n${offenceDate}\r\n${sentenceLength}\r\n\nSummary: ${summary}`
       response[`Historical offence ${index + 1}`] = offenceString


### PR DESCRIPTION
Previously, if a person added offences and then removed them, and then returned to Check Your Answers, this threw an error.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
