### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.4
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.1
   node: circleci/node@5.1.0
 
@@ -57,7 +57,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - run:
@@ -258,10 +259,10 @@ workflows:
             - build_docker
             - request-test-approval
       - request-preprod-approval:
-           type: approval
-           requires:
-             - deploy_dev
-             - e2e_environment_test
+          type: approval
+          requires:
+            - deploy_dev
+            - e2e_environment_test
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
@@ -269,7 +270,7 @@ workflows:
             - hmpps-common-vars
             - hmpps-community-accommodation-tier-2-ui-preprod
           requires:
-             - request-preprod-approval
+            - request-preprod-approval
       # - request-prod-approval:
       #      type: approval
       #      requires:

--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/Chart.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-community-accommodation-tier-2-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-community-accommodation-tier-2-ui
   serviceAccountName: hmpps-community-accommodation-tier-2-service-account
@@ -7,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-community-accommodation-tier-2-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-community-accommodation-tier-2-ui-cert
 
   livenessProbe:
@@ -58,14 +57,8 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-community-accommodation-tier-2-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
