### PR TITLE
(330) Health needs: fix missing "Substitute medication" follow-up question on substance misuse page

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
@@ -28,12 +28,19 @@ export default class SubstanceMisusePage extends ApplyPage {
 
   describeIllegalSubstanceUse = (): void => {
     this.checkRadioByNameAndValue('usesIllegalSubstances', 'yes')
+
+    cy.get(`label[for="substanceMisuseHistory"]`).contains('What substances do they take?')
     this.getTextInputByIdAndEnterDetails('substanceMisuseHistory', 'Heroin user')
+
+    cy.get(`label[for="substanceMisuseDetail"]`).contains(
+      'How often do they take these substances, by what method, and how much?',
+    )
     this.getTextInputByIdAndEnterDetails('substanceMisuseDetail', 'Injects daily')
   }
 
   nameDrugAndAlcoholService = (): void => {
     this.checkRadioByNameAndValue('engagedWithDrugAndAlcoholService', 'yes')
+    cy.get(`label[for="drugAndAlcoholServiceDetail"]`).contains('Name the drug and alcohol service')
     this.getTextInputByIdAndEnterDetails('drugAndAlcoholServiceDetail', 'The Drugs Project')
   }
 

--- a/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/health-needs/substanceMisusePage.ts
@@ -39,6 +39,7 @@ export default class SubstanceMisusePage extends ApplyPage {
 
   provideSubstituteMedicationDetails = (): void => {
     this.checkRadioByNameAndValue('requiresSubstituteMedication', 'yes')
+    cy.get(`label[for="substituteMedicationDetail"]`).contains('What substitute medication do they take?')
     this.getTextInputByIdAndEnterDetails('substituteMedicationDetail', 'Methadone')
   }
 }

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -54,7 +54,7 @@
         {
           fieldName: 'substituteMedicationDetail',
           label: {
-            text: page.questions.requiresSubstituteMedication.substituteMedicationDetail.question,
+            text: page.questions.substituteMedicationDetail.question,
             classes: "govuk-label--s"
           }
         },


### PR DESCRIPTION
Fix missing "label" for follow-up substitute medication question on "Substance misuse" page within **Health Needs**
