### PR TITLE
Silently handle errors for OASyS import

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -120,23 +120,14 @@ describe('OasysImport', () => {
     })
 
     describe('when oasys sections are not returned', () => {
-      it('sets hasOasysRecord to false when a 404 is returned', async () => {
-        ;(dataServices.personService.getOasysRosh as jest.Mock).mockRejectedValue({ status: 404 })
+      it('sets hasOasysRecord to false when an error is returned', async () => {
+        ;(dataServices.personService.getOasysRosh as jest.Mock).mockRejectedValue(new Error())
 
         const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
 
         expect(page.hasOasysRecord).toBe(false)
         expect(page.oasysCompleted).toBe(undefined)
         expect(page.oasysStarted).toBe(undefined)
-      })
-
-      it('throws error when an unexpected error is returned', async () => {
-        const error = new Error()
-        ;(dataServices.personService.getOasysRosh as jest.Mock).mockImplementation(() => {
-          throw error
-        })
-
-        expect(OasysImport.initialize({}, application, 'some-token', dataServices)).rejects.toThrow(error)
       })
     })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
@@ -6,6 +6,7 @@ import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
 import RiskToOthers from '../riskToOthers'
 import { DateFormats } from '../../../../../utils/dateUtils'
 import Summary, { SummaryData } from '../summary'
+import { logOasysError } from '../../../../utils'
 
 type OasysImportBody = Record<string, never>
 
@@ -91,11 +92,8 @@ export default class OasysImport implements TaskListPage {
         risks = await dataServices.personService.getRoshRisks(token, application.person.crn)
         taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys, risks))
       } catch (e) {
-        if (e.status === 404) {
-          oasys = null
-        } else {
-          throw e
-        }
+        logOasysError(e, application.person.crn)
+        oasys = null
       }
       return new OasysImport(body, application, oasys, taskDataJson)
     }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
@@ -97,23 +97,14 @@ describe('OasysImport', () => {
     })
 
     describe('when oasys sections are not returned', () => {
-      it('sets hasOasysRecord to false when a 404 is returned', async () => {
-        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockRejectedValue({ status: 404 })
+      it('sets hasOasysRecord to false when there has been an error', async () => {
+        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockRejectedValue(new Error())
 
         const page = (await OasysImport.initialize({}, application, 'some-token', dataServices)) as OasysImport
 
         expect(page.hasOasysRecord).toBe(false)
         expect(page.oasysCompleted).toBe(undefined)
         expect(page.oasysStarted).toBe(undefined)
-      })
-
-      it('throws error when an unexpected error is returned', async () => {
-        const error = new Error()
-        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockImplementation(() => {
-          throw error
-        })
-
-        expect(OasysImport.initialize({}, application, 'some-token', dataServices)).rejects.toThrow(error)
       })
     })
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
@@ -5,6 +5,7 @@ import TaskListPage from '../../../../taskListPage'
 import { DateFormats } from '../../../../../utils/dateUtils'
 import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
 import Vulnerability from '../vulnerability'
+import { logOasysError } from '../../../../utils'
 
 type GuidanceBody = Record<string, never>
 
@@ -84,11 +85,8 @@ export default class OasysImport implements TaskListPage {
 
         taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys))
       } catch (e) {
-        if (e.status === 404) {
-          oasys = null
-        } else {
-          throw e
-        }
+        logOasysError(e, application.person.crn)
+        oasys = null
       }
       return new OasysImport(body, application, oasys, taskDataJson)
     }

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,6 +1,7 @@
 import type { Request } from 'express'
 import { Cas2Application as Application } from '@approved-premises/api'
 import type { FormArtifact, JourneyType, UiTask } from '@approved-premises/ui'
+import logger from '../../../logger'
 import { TaskListPageInterface } from '../taskListPage'
 import { DateFormats } from '../../utils/dateUtils'
 
@@ -93,6 +94,11 @@ export function getOasysImportDateFromApplication(application: Application, task
     })
   }
   return null
+}
+
+export function logOasysError(e: Error, crn: string) {
+  logger.error(`Error retrieving Oasys for crn ${crn}`)
+  logger.error(e)
 }
 
 export function pageBodyShallowEquals(body1: Record<string, unknown>, body2: Record<string, unknown>) {


### PR DESCRIPTION
If there is an error retrieving OASyS data, we do not want to surface that error to the user. We instead want to indicate that it was not possible to retrieve an oasys report at this time - the user is then given the option to proceed with the form and fill it in manually, or return another time.

This is to quickly fix an issue in development where if the API is not available, then the user is not able to proceed with form. In the future we may want to show a more helpful message based on the type of error received, e.g. 'Person has not been found', 'OASyS API is not available at this time'. We may want to consider what error to show if the user is unauthorized as well.

This is in line with how CAS1 handle errors
regarding OASyS [1], catching all instances of errors and allowing the user to proceed with a blank form.

[1] https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/server/utils/oasysImportUtils.ts#L42

