### PR TITLE
(577) Introduce first preferred area page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -4,6 +4,12 @@
       "isEligible": "yes"
     }
   },
+  "area-information": {
+    "first-preferred-area": {
+      "preferredArea": "London",
+      "preferenceReason": "They have family there"
+    }
+  },
   "funding-information": {
     "funding-source": {
       "fundingSource": "benefits"

--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -25,6 +25,19 @@
               "answer": "Benefits"
             }
           ]
+        },
+        {
+          "title": "Add exclusion zones and preferred areas",
+          "questionsAndAnswers": [
+            {
+              "question": "Preferred area",
+              "answer": "London"
+            },
+            {
+              "question": "Reason for preference",
+              "answer": "The person has family there"
+            }
+          ]
         }
       ]
     },

--- a/integration_tests/pages/apply/area_and_funding/area_information/FirstPreferredAreaPage.ts
+++ b/integration_tests/pages/apply/area_and_funding/area_information/FirstPreferredAreaPage.ts
@@ -1,0 +1,25 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class FirstPreferredAreaPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `First preferred area for ${nameOrPlaceholderCopy(application.person)}`,
+      application,
+      'area-information',
+      'first-preferred-area',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'area-information',
+        page: 'first-preferred-area',
+      }),
+    )
+  }
+}

--- a/integration_tests/tests/apply/area_and_funding/area_information/first_preferred_area.cy.ts
+++ b/integration_tests/tests/apply/area_and_funding/area_information/first_preferred_area.cy.ts
@@ -1,0 +1,94 @@
+//  Feature: Referrer completes 'First preferred area' page
+//    So that I can complete the 'Area information' task
+//    As a referrer
+//    I want to complete the 'First preferred area' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'First preferred area' page
+//
+//  Scenario: view 'First preferred area' page
+//    Then I see the "First preferred area" page
+//
+//  Scenario: navigate to task list on completion of task
+//    When I complete the "First preferred area" page
+//    And I continue to the next task / page
+//    Then I am returned to the task list
+//    And I see that the area information task is complete
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import FirstPreferredAreaPage from '../../../../pages/apply/area_and_funding/area_information/FirstPreferredAreaPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+
+context('Visit "First preferred area" page', () => {
+  const person = personFactory.build({ name: 'Sue Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['area-information']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'First preferred area' page
+    // --------------------------------
+    FirstPreferredAreaPage.visit(this.application)
+  })
+
+  // Scenario: view 'First preferred area' page
+  // ----------------------------------------------
+
+  it('displays the page', function test() {
+    // Then I see the "First preferred area" page
+    Page.verifyOnPage(FirstPreferredAreaPage, this.application)
+  })
+
+  // Scenario: navigate to task list on completion of task
+  // ----------------------------------------------
+  it('navigates to the next page', function test() {
+    // So that the status of the task will be complete we set application.data
+    // to the full set
+    cy.fixture('applicationData.json').then(applicationData => {
+      const answered = {
+        ...this.application,
+        data: applicationData,
+      }
+      cy.task('stubApplicationGet', { application: answered })
+    })
+
+    //  When I complete the "First preferred area" page
+    const page = Page.verifyOnPage(FirstPreferredAreaPage, this.application)
+    page.getTextInputByIdAndEnterDetails('preferredArea', 'London')
+    page.getTextInputByIdAndEnterDetails('preferenceReason', 'They have family there')
+
+    // When I continue to the next task / page
+    page.clickSubmit()
+
+    // Then I am returned to the task list
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+
+    // And I see that the area information task is complete
+    taskListPage.shouldShowTaskStatus('area-information', 'Completed')
+  })
+})

--- a/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.test.ts
@@ -1,0 +1,44 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import FirstPreferredArea from './firstPreferredArea'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+
+describe('FirstPreferredArea', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Sue Smith' }) })
+  const body = {
+    preferredArea: 'London',
+    preferenceReason: 'They have family in the area',
+  }
+
+  it('sets the question as the page title', () => {
+    const page = new FirstPreferredArea(body, application)
+
+    expect(page.title).toEqual('First preferred area for Sue Smith')
+  })
+
+  it('sets the body', () => {
+    const page = new FirstPreferredArea(body, application)
+
+    expect(page.body).toEqual(body)
+  })
+
+  describe('errors', () => {
+    it('returns an error if preferredArea is not set', () => {
+      const page = new FirstPreferredArea({ ...body, preferredArea: null }, application)
+
+      expect(page.errors()).toEqual({
+        preferredArea: 'Provide a town, city or region for the first preferred area',
+      })
+    })
+
+    it('returns an error if preferenceReason is not set', () => {
+      const page = new FirstPreferredArea({ ...body, preferenceReason: null }, application)
+
+      expect(page.errors()).toEqual({
+        preferenceReason: "Provide the reason for the applicant's first preferred area",
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new FirstPreferredArea(body, application), '')
+  itShouldHavePreviousValue(new FirstPreferredArea(body, application), 'taskList')
+})

--- a/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.ts
@@ -1,0 +1,56 @@
+import { Cas2Application as Application } from '@approved-premises/api'
+import { TaskListErrors } from '@approved-premises/ui'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { getQuestions } from '../../../utils/questions'
+
+type FirstPreferredAreaBody = {
+  preferredArea: string
+  preferenceReason: string
+}
+
+@Page({
+  name: 'first-preferred-area',
+  bodyProperties: ['preferredArea', 'preferenceReason'],
+})
+export default class FirstPreferredArea implements TaskListPage {
+  documentTitle = 'First preferred area for the person'
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `First preferred area for ${nameOrPlaceholderCopy(this.application.person)}`
+
+  questions = getQuestions(this.personName)['area-information']['first-preferred-area']
+
+  body: FirstPreferredAreaBody
+
+  constructor(
+    body: Partial<FirstPreferredAreaBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as FirstPreferredAreaBody
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.preferredArea) {
+      errors.preferredArea = 'Provide a town, city or region for the first preferred area'
+    }
+
+    if (!this.body.preferenceReason) {
+      errors.preferenceReason = "Provide the reason for the applicant's first preferred area"
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/area-and-funding/area-information/index.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+
+import { Task } from '../../../utils/decorators'
+import FirstPreferredArea from './firstPreferredArea'
+
+@Task({
+  name: 'Add exclusion zones and preferred areas',
+  slug: 'area-information',
+  pages: [FirstPreferredArea],
+})
+export default class AreaInformation {}

--- a/server/form-pages/apply/area-and-funding/index.ts
+++ b/server/form-pages/apply/area-and-funding/index.ts
@@ -2,9 +2,10 @@
 
 import { Section } from '../../utils/decorators'
 import FundingInformation from './funding-information'
+import AreaInformation from './area-information'
 
 @Section({
   title: 'Area and funding',
-  tasks: [FundingInformation],
+  tasks: [AreaInformation, FundingInformation],
 })
 export default class AreaAndFunding {}

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -228,6 +228,18 @@ export const getQuestions = (name: string) => {
         },
       },
     },
+    'area-information': {
+      'first-preferred-area': {
+        preferredArea: {
+          question: 'Preferred area',
+          hint: 'Specify a town, city or region',
+        },
+        preferenceReason: {
+          question: 'Reason for preference',
+          hint: 'Include the type of local connection the applicant has with the area',
+        },
+      },
+    },
     'funding-information': {
       'funding-source': {
         fundingSource: {

--- a/server/views/applications/pages/area-information/_area-information-screen.njk
+++ b/server/views/applications/pages/area-information/_area-information-screen.njk
@@ -1,0 +1,31 @@
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="{{ pageName }}">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-4">
+    <div class="govuk-grid-column-one-third">
+      {{ mojSideNavigation({
+          label: 'Preferred areas navigation',
+          items: [{
+            text: 'First preferred area',
+            href: paths.applications.pages.show({ id: applicationId, task: 'area-information', page: 'first-preferred-area' }),
+            active: (pageName === 'first-preferred-area')
+          }]
+        }) }}
+    </div>
+
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-top-4">
+      {{ super() }}
+    </div>
+
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/area-information/_preferred-area.njk
+++ b/server/views/applications/pages/area-information/_preferred-area.njk
@@ -1,0 +1,58 @@
+{% extends "./_area-information-screen.njk" %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "../../../components/formFields/form-page-text-area/macro.njk" import formPageTextArea %}
+
+{% set guidanceHtml %}
+  <p>An applicant has a local connection if:</p>
+
+  <ul>
+    <li>They lived in the area in 6 out of the 12 months before prison.</li>
+    <li>They lived in the area in 3 out of the last 5 years.</li>
+    <li>Their immediate family (parents, children, or siblings) have lived in the area for at least 5 years.</li>
+    <li>They have secured full or part-time work in the area.</li>
+    <li>They have a special reason to live in the area. For example, to receive specialist healthcare.</li>
+  </ul>
+{% endset %}
+
+{% block questions %}
+  <p>Accommodation staff will use this information to help match applicants to the most suitable available rooms.</p>
+  <p>An applicant can request an area because they have a local connection or it is close to their approved probation office.</p>
+
+  {{ govukDetails({
+    summaryText: "What local connection means",
+    html: guidanceHtml
+  }) }}
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  {{
+    formPageInput(
+      {
+        label: {
+          text: page.questions.preferredArea.question,
+          classes: "govuk-label--m"
+        },
+        classes: "govuk-input--width-20",
+        fieldName: "preferredArea",
+        hint: { text: page.questions.preferredArea.hint }
+      },
+      fetchContext()
+    )
+  }}
+
+  {{
+    formPageTextArea(
+      {
+        fieldName: 'preferenceReason',
+        label: {
+          text: page.questions.preferenceReason.question,
+          classes: "govuk-label--m"
+        },
+        hint: { text: page.questions.preferenceReason.hint }
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}

--- a/server/views/applications/pages/area-information/first-preferred-area.njk
+++ b/server/views/applications/pages/area-information/first-preferred-area.njk
@@ -1,0 +1,2 @@
+{% extends "./_preferred-area.njk" %}
+{% set pageName = "first-preferred-area" %}


### PR DESCRIPTION
# Changes in this PR
* Adds the `AreaInformation` task which sits under "Area & funding"
* Adds a new page to the apply journey `FirstPreferredArea`

## Screenshots of UI changes

### Before
![Screenshot 2023-11-21 at 17 06 03](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/ce20ee67-109d-4fc9-9952-71ec4a0e90e1)

### After
![Screenshot 2023-11-21 at 17 05 48](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/ece7c274-15ac-4050-8d2a-f1a6b5748040)

![Screenshot 2023-11-21 at 16 54 04](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/7967c96d-8783-4a08-918c-8931589d8396)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
