### PR TITLE
display external user name on application timeline

### DIFF
--- a/integration_tests/pages/assess/submittedApplicationOverviewPage.ts
+++ b/integration_tests/pages/assess/submittedApplicationOverviewPage.ts
@@ -30,6 +30,7 @@ export default class SubmittedApplicationOverviewPage extends Page {
         if (index !== application.statusUpdates.length) {
           cy.wrap($el).within(() => {
             cy.get('.moj-timeline__header').should('contain', sortedTimelineEvents[index].label)
+            cy.get('.moj-timeline__byline').should('contain', sortedTimelineEvents[index].updatedBy.name)
             cy.get('time').should('have.attr', { time: sortedTimelineEvents[index].updatedAt })
             cy.get('time').should('contain', DateFormats.isoDateTimeToUIDateTime(sortedTimelineEvents[index].updatedAt))
           })

--- a/integration_tests/tests/assess/view_application_overview.cy.ts
+++ b/integration_tests/tests/assess/view_application_overview.cy.ts
@@ -23,7 +23,7 @@ context('Assessor views a submitted application overview', () => {
     statusUpdates: [
       statusUpdateFactory.build({
         updatedAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
-        updatedBy: externalUserFactory.build({ username: 'Anne_Assessor' }),
+        updatedBy: externalUserFactory.build({ name: 'Anne Assessor' }),
         name: 'moreInfoRequested',
         label: 'More information requested',
         description:
@@ -31,7 +31,7 @@ context('Assessor views a submitted application overview', () => {
       }),
       statusUpdateFactory.build({
         updatedAt: DateFormats.dateObjToIsoDateTime(faker.date.future()),
-        updatedBy: externalUserFactory.build({ username: 'Anne Other Assessor' }),
+        updatedBy: externalUserFactory.build({ name: 'Anne Other Assessor' }),
         name: 'awaitingDecision',
         label: 'Awaiting decision',
         description: 'All information has been received and the application is awaiting assessment.',

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -80,7 +80,7 @@ describe('utils', () => {
             statusUpdateFactory.build({
               label: 'a status update',
               description: 'the status description',
-              updatedBy: externalUserFactory.build({ username: 'ANacro' }),
+              updatedBy: externalUserFactory.build({ name: 'A Nacro' }),
               updatedAt: '2023-06-22T08:54:50',
             }),
           ],
@@ -90,7 +90,7 @@ describe('utils', () => {
         expect(getApplicationTimelineEvents(application)).toEqual([
           {
             byline: {
-              text: 'ANacro',
+              text: 'A Nacro',
             },
             datetime: {
               date: '22 June 2023 at 08:54am',
@@ -127,23 +127,23 @@ describe('utils', () => {
             statusUpdateFactory.build({
               label: 'a status update',
               description: 'the status description',
-              updatedBy: externalUserFactory.build({ username: 'ANacro' }),
+              updatedBy: externalUserFactory.build(),
               updatedAt: '2023-06-22T08:54:50',
             }),
             statusUpdateFactory.build({
               label: 'a status update',
               description: 'the status description',
-              updatedBy: externalUserFactory.build({ username: 'ANacro' }),
+              updatedBy: externalUserFactory.build(),
               updatedAt: '2023-06-20T08:54:50',
             }),
             statusUpdateFactory.build({
               label: 'a status update',
               description: 'the status description',
-              updatedBy: externalUserFactory.build({ username: 'ANacro' }),
+              updatedBy: externalUserFactory.build(),
               updatedAt: '2023-06-23T08:54:50',
             }),
           ],
-          submittedBy: nomisUserFactory.build({ name: 'Anne Nomis' }),
+          submittedBy: nomisUserFactory.build(),
           submittedAt: '2023-06-21T07:54:50',
         })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -35,8 +35,7 @@ export const getStatusTimelineEvents = (statusUpdates: Array<Cas2StatusUpdate>):
         return {
           label: { text: statusUpdate.label },
           byline: {
-            // TODO: change this to first name/surname when that is available on external users
-            text: statusUpdate.updatedBy.username,
+            text: statusUpdate.updatedBy.name,
           },
           datetime: {
             timestamp: statusUpdate.updatedAt,


### PR DESCRIPTION
The name has been added on the API side, so now
we can display on the timeline and provide a more readable design


# Changes in this PR

![Screenshot 2023-11-24 at 13 20 10](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/525047ea-9dd7-4953-9954-42a5845786ba)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
