### PR TITLE
update Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
 
   e2e_environment_test:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.36.2-focal
+      - image: mcr.microsoft.com/playwright:v1.40.0-focal
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:


### PR DESCRIPTION
to match version on e2e repo.
I think it's preventing e2es running on CI https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui/2060/workflows/eabf1b9a-b299-4028-9923-b9b04990c81d/jobs/6974