### PR TITLE
Confirm applicant details

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -16,6 +16,18 @@ export default {
         jsonBody: args.application,
       },
     }),
+  stubCreateApplicationServerError: (args: { application: Application }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/cas2/applications`,
+      },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.application,
+      },
+    }),
   stubApplications: (applications: Array<Application>): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/apply/confirmApplicantPage.ts
+++ b/integration_tests/pages/apply/confirmApplicantPage.ts
@@ -1,0 +1,37 @@
+import { FullPerson } from '../../../server/@types/shared/models/FullPerson'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import Page from '../page'
+
+export default class ConfirmApplicantPage extends Page {
+  personName: string
+
+  constructor(name: string) {
+    super(`Confirm ${name}'s details`, name)
+  }
+
+  hasErrorDetails = (): void => {
+    cy.get('.govuk-error-summary').contains('There was an error creating the application, please try again')
+  }
+
+  hasApplicantDetails = (applicant: FullPerson): void => {
+    const expectedApplicantData = [
+      ['Full name', applicant.name],
+      ['Date of birth', DateFormats.isoDateToUIDate(applicant.dateOfBirth, { format: 'short' })],
+      ['Nationality', applicant.nationality],
+      ['Sex', applicant.sex],
+      ['Prison number', applicant.nomsNumber],
+      ['Prison', applicant.prisonName],
+      ['PNC number', applicant.pncNumber],
+      ['NDelius CRN number', applicant.crn],
+      ['Status', applicant.status === 'InCommunity' ? 'In Community' : 'In Custody'],
+    ]
+    cy.get('.govuk-summary-list').within(() => {
+      cy.get('.govuk-summary-list__row').each(($el, index) => {
+        cy.wrap($el).within(() => {
+          cy.get('.govuk-summary-list__key').should('contain', expectedApplicantData[index][0])
+          cy.get('.govuk-summary-list__value').should('contain', expectedApplicantData[index][1])
+        })
+      })
+    })
+  }
+}

--- a/integration_tests/pages/apply/confirmEligibilityPage.ts
+++ b/integration_tests/pages/apply/confirmEligibilityPage.ts
@@ -1,4 +1,5 @@
-import { Cas2Application as Application } from '../../../server/@types/shared/models/Cas2Application'
+import { Cas2Application as Application, Cas2Application } from '../../../server/@types/shared/models/Cas2Application'
+import paths from '../../../server/paths/apply'
 import { nameOrPlaceholderCopy } from '../../../server/utils/utils'
 import ApplyPage from './applyPage'
 
@@ -13,6 +14,16 @@ export default class ConfirmEligibilityPage extends ApplyPage {
       'confirm-eligibility',
     )
     this.personName = nameOrPlaceholderCopy(application.person)
+  }
+
+  static visit = (application: Cas2Application) => {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'confirm-eligibility',
+        page: 'confirm-eligibility',
+      }),
+    )
   }
 
   hasCaption = (): void => {

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -37,7 +37,6 @@
 //    Then I should be able to 'Find by prison number'
 
 import Page from '../../../../pages/page'
-import FindByPrisonNumberPage from '../../../../pages/apply/findByPrisonNumberPage'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import ConfirmEligibilityPage from '../../../../pages/apply/confirmEligibilityPage'
 import IneligiblePage from '../../../../pages/apply/ineligiblePage'
@@ -64,18 +63,15 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
   })
 
   beforeEach(function test() {
-    cy.task('stubCreateApplication', { application: this.application })
-    cy.task('stubApplicationGet', { application: this.application })
-    cy.task('stubApplicationUpdate', { application: this.application })
-
     //  Background:
     //    Given I am logged in
     cy.signIn()
     //    And I have successfully found a person by prison number
-    const page = FindByPrisonNumberPage.visit(this.application.person.name)
-    page.getTextInputByIdAndEnterDetails('prisonNumber', person.nomsNumber)
+    cy.task('stubCreateApplication', { application: this.application })
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
 
-    page.clickSubmit()
+    ConfirmEligibilityPage.visit(this.application)
 
     //   And I'm now faced with the 'Confirm eligibility' task
     Page.verifyOnPage(ConfirmEligibilityPage, this.application)

--- a/integration_tests/tests/apply/confirm_applicant_details.cy.ts
+++ b/integration_tests/tests/apply/confirm_applicant_details.cy.ts
@@ -1,0 +1,83 @@
+//  Feature: Referrer confirms applicant details and creates application
+//    So that I can create an application
+//    As a referrer
+//    I want to see the details of an applicant
+//
+//  Scenario: confirm details
+//      Given I am on the 'confirm applicant details' page
+//      When I confirm these are the correct details
+//      Then I am taken to the eligibility page
+//
+//  Scenario: error when creating an application
+//      Given I am on the 'confirm applicant details' page
+//      When I confirm these are the correct details
+//      And there is a server error
+//      Then I see an error message
+
+import ConfirmApplicantPage from '../../pages/apply/confirmApplicantPage'
+import FindByPrisonNumberPage from '../../pages/apply/findByPrisonNumberPage'
+import ConfirmEligibilityPage from '../../pages/apply/confirmEligibilityPage'
+import { applicationFactory } from '../../../server/testutils/factories/index'
+import Page from '../../pages/page'
+import { fullPersonFactory } from '../../../server/testutils/factories/person'
+
+context('Find by prison number', () => {
+  const person = fullPersonFactory.build({ name: 'Roger Smith', nomsNumber: '123' })
+  const application = applicationFactory.build({ person })
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  beforeEach(() => {
+    // Given I am logged in
+    cy.signIn()
+
+    cy.task('stubCreateApplication', { application })
+    cy.task('stubApplicationGet', { application })
+  })
+
+  //  Scenario: Scenario: confirm details
+  // ----------------------------------------------
+  it('Continues to "Confirm applicant details" section (before task list)', () => {
+    //      Given I am on the 'confirm applicant details' page
+    const prisonNumberPage = FindByPrisonNumberPage.visit(person.name)
+    cy.task('stubFindPerson', { person })
+    prisonNumberPage.getTextInputByIdAndEnterDetails('prisonNumber', person.nomsNumber)
+    prisonNumberPage.clickSubmit()
+
+    const confirmationPage = Page.verifyOnPage(ConfirmApplicantPage, person.name)
+    confirmationPage.hasApplicantDetails(person)
+
+    //  When I confirm these are the correct detaiks
+
+    confirmationPage.clickSubmit()
+
+    //      Then I am taken to the eligibility page
+    Page.verifyOnPage(ConfirmEligibilityPage, application)
+  })
+
+  //  Scenario: error when creating an application
+  //      Given I am on the 'confirm applicant details' page
+  //      When I confirm these are the correct details
+  //      And there is a server error
+  //      Then I see an error message
+  it('Shows an error when an application has not been created successfully', () => {
+    //      Given I am on the 'confirm applicant details' page
+    const prisonNumberPage = FindByPrisonNumberPage.visit(person.name)
+    cy.task('stubFindPerson', { person })
+    prisonNumberPage.getTextInputByIdAndEnterDetails('prisonNumber', person.nomsNumber)
+    prisonNumberPage.clickSubmit()
+
+    const confirmationPage = Page.verifyOnPage(ConfirmApplicantPage, person.name)
+    //      When I confirm these are the correct details
+    cy.task('stubCreateApplicationServerError', { application })
+    confirmationPage.clickSubmit()
+
+    //      And there is a server error
+    //      Then I see an error message
+    confirmationPage.hasErrorDetails()
+  })
+})

--- a/integration_tests/tests/apply/find_by_prison_number.cy.ts
+++ b/integration_tests/tests/apply/find_by_prison_number.cy.ts
@@ -109,8 +109,8 @@ context('Find by prison number', () => {
     page.clickSubmit()
 
     // Then I see an error message
-    cy.get('.govuk-error-summary').should('contain', `You must enter a prison number`)
-    cy.get(`[data-cy-error-prisonNumber]`).should('contain', `You must enter a prison number`)
+    cy.get('.govuk-error-summary').should('contain', `Enter a prison number`)
+    cy.get(`[data-cy-error-prisonNumber]`).should('contain', `Enter a prison number`)
   })
 
   //  Scenario: enter a prison number that can't be found

--- a/integration_tests/tests/apply/find_by_prison_number.cy.ts
+++ b/integration_tests/tests/apply/find_by_prison_number.cy.ts
@@ -8,11 +8,11 @@
 //    And I click the link to start a new application
 //    Then I'm on the Enter prison number page
 //
-//  Scenario: enter a prison number and continue to the 'Before you start' section without seeing the task list
+//  Scenario: enter a prison number and continue to the 'Confirm applicant details' section without seeing the task list
 //    Given I'm on the enter prison number page
 //    When I enter an existing prison number
 //    And I click save and continue
-//    Then I'm on the first task of the 'Before you start' section
+//    Then I'm on the first task of the 'Confirm applicant details' section
 //
 //  Scenario: answer is enforced
 //    Given I'm on the enter prison number page
@@ -29,7 +29,7 @@
 //    When I enter a prison number for a person I'm not authorised to view
 //    Then I see an unathorised error message
 
-import ConfirmEligibilityPage from '../../pages/apply/confirmEligibilityPage'
+import ConfirmApplicantPage from '../../pages/apply/confirmApplicantPage'
 import { personFactory, applicationFactory } from '../../../server/testutils/factories/index'
 import Page from '../../pages/page'
 import FindByPrisonNumberPage from '../../pages/apply/findByPrisonNumberPage'
@@ -66,9 +66,9 @@ context('Find by prison number', () => {
     Page.verifyOnPage(FindByPrisonNumberPage)
   })
 
-  //  Scenario: enter a prison number and continue to 'Before you start' section without seeing the task list
+  //  Scenario: enter a prison number and continue to 'Confirm applicant details' section without seeing the task list
   // ----------------------------------------------
-  it('creates an application and continues to "Before you start" section (before task list)', () => {
+  it('Continues to "Confirm applicant details" section (before task list)', () => {
     // I'm on the enter prison number page
     const page = FindByPrisonNumberPage.visit(person.name)
 
@@ -95,8 +95,8 @@ context('Find by prison number', () => {
     // I click save and continue
     page.clickSubmit()
 
-    // Then I'm on the 'Confirm eligibility' page (in 'Before you start' section)
-    Page.verifyOnPage(ConfirmEligibilityPage, application)
+    // Then I'm on the 'Confirm applicant details' page
+    Page.verifyOnPage(ConfirmApplicantPage, person.name)
   })
 
   //  Scenario: answer is enforced
@@ -127,11 +127,11 @@ context('Find by prison number', () => {
     // I see a not found error message
     cy.get('.govuk-error-summary').should(
       'contain',
-      `No person with a prison number of '${person.nomsNumber}' was found`,
+      `No person found for prison number ${person.nomsNumber}, please try another number.`,
     )
     cy.get(`[data-cy-error-prisonNumber]`).should(
       'contain',
-      `No person with a prison number of '${person.nomsNumber}' was found`,
+      `No person found for prison number ${person.nomsNumber}, please try another number.`,
     )
   })
 
@@ -153,11 +153,11 @@ context('Find by prison number', () => {
     // I see an unathorised error message
     cy.get('.govuk-error-summary').should(
       'contain',
-      `You do not have permission to access the prison number ${person.nomsNumber}`,
+      `You do not have permission to access the prison number ${person.nomsNumber}, please try another number.`,
     )
     cy.get(`[data-cy-error-prisonNumber]`).should(
       'contain',
-      `You do not have permission to access the prison number ${person.nomsNumber}`,
+      `You do not have permission to access the prison number ${person.nomsNumber}, please try another number.`,
     )
   })
 })

--- a/server/@types/shared/models/FullPerson.ts
+++ b/server/@types/shared/models/FullPerson.ts
@@ -9,6 +9,7 @@ export type FullPerson = (Person & {
     name: string;
     dateOfBirth: string;
     nomsNumber?: string;
+    pncNumber?: string;
     ethnicity?: string;
     nationality?: string;
     religionOrBelief?: string;

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -177,3 +177,5 @@ export type UiTimelineEvent = {
   datetime: { timestamp: string; date: string }
   description: { text: string }
 }
+
+export type PersonStatus = 'InCustody' | 'InCommunity'

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -147,11 +147,9 @@ describe('peopleController', () => {
         expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
 
         expect(flashSpy).toHaveBeenCalledWith('errors', {
-          prisonNumber: errorMessage('prisonNumber', 'You must enter a prison number'),
+          prisonNumber: errorMessage('prisonNumber', 'Enter a prison number'),
         })
-        expect(flashSpy).toHaveBeenCalledWith('errorSummary', [
-          errorSummary('prisonNumber', 'You must enter a prison number'),
-        ])
+        expect(flashSpy).toHaveBeenCalledWith('errorSummary', [errorSummary('prisonNumber', 'Enter a prison number')])
       })
     })
   })

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -1,8 +1,9 @@
 import type { Request, RequestHandler, Response } from 'express'
-import paths from '../paths/apply'
+
 import { errorMessage, errorSummary } from '../utils/validation'
 import PersonService from '../services/personService'
 import ApplicationService from '../services/applicationService'
+import { DateFormats } from '../utils/dateUtils'
 
 export default class PeopleController {
   constructor(
@@ -18,22 +19,32 @@ export default class PeopleController {
         try {
           const person = await this.personService.findByPrisonNumber(req.user.token, prisonNumber)
 
-          const application = await this.applicationService.createApplication(req.user.token, person.crn)
-          res.redirect(paths.applications.show({ id: application.id }))
+          return res.render(`people/confirm-applicant-details`, {
+            pageHeading: `Confirm ${person.name}'s details`,
+            person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+          })
         } catch (err) {
           if (err.status === 404) {
-            this.addErrorMessagesToFlash(req, `No person with a prison number of '${prisonNumber}' was found`)
+            this.addErrorMessagesToFlash(
+              req,
+              `No person found for prison number ${prisonNumber}, please try another number.`,
+            )
           } else if (err.status === 403) {
-            this.addErrorMessagesToFlash(req, `You do not have permission to access the prison number ${prisonNumber}`)
+            this.addErrorMessagesToFlash(
+              req,
+              `You do not have permission to access the prison number ${prisonNumber}, please try another number.`,
+            )
           } else {
             throw err
           }
 
-          res.redirect(req.headers.referer)
+          return res.redirect(req.headers.referer)
         }
       } else {
         this.addErrorMessagesToFlash(req, 'You must enter a prison number')
-        res.redirect(req.headers.referer)
+        return res.redirect(req.headers.referer)
       }
     }
   }

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -43,7 +43,7 @@ export default class PeopleController {
           return res.redirect(req.headers.referer)
         }
       } else {
-        this.addErrorMessagesToFlash(req, 'You must enter a prison number')
+        this.addErrorMessagesToFlash(req, 'Enter a prison number')
         return res.redirect(req.headers.referer)
       }
     }

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,4 @@
-import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person, PersonRisks } from '@approved-premises/api'
+import type { FullPerson, OASysRiskOfSeriousHarm, OASysRiskToSelf, PersonRisks } from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -28,7 +28,7 @@ export default class PersonClient {
     return response
   }
 
-  async search(nomsNumber: string): Promise<Person> {
+  async search(nomsNumber: string): Promise<FullPerson> {
     const query = { nomsNumber } as Record<string, string | boolean>
 
     const path = `${paths.people.search({})}?${createQueryString(query)}`
@@ -36,7 +36,7 @@ export default class PersonClient {
       path,
     })
 
-    return response as Person
+    return response as FullPerson
   }
 
   async risks(crn: string): Promise<PersonRisks> {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -18,6 +18,7 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
   get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'VIEW_APPLICATIONS_LIST' })
   get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION_START' })
   post(paths.applications.submission.pattern, applicationsController.submit(), { auditEvent: 'SUBMIT_APPLICATION' })
+  post(paths.applications.create.pattern, applicationsController.create(), { auditEvent: 'CREATE_APPLICATION' })
   put(paths.applications.update.pattern, applicationsController.update(), { auditEvent: 'UPDATE_APPLICATION' })
 
   put(paths.applications.appendToList.pattern, applicationsController.appendToList(), {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -25,7 +25,7 @@ export default function routes(controllers: Controllers, services: Services): Ro
 
   post(paths.applications.people.find.pattern, peopleController.find(), {
     auditEvent: 'FIND_APPLICATION_PERSON',
-    auditBodyParams: ['crn'],
+    auditBodyParams: ['prisonNumber'],
   })
 
   applyRoutes(controllers, router, services)

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,10 +1,10 @@
-import type { OASysRiskOfSeriousHarm, OASysRiskToSelf, Person, RoshRisksEnvelope } from '@approved-premises/api'
+import type { FullPerson, OASysRiskOfSeriousHarm, OASysRiskToSelf, RoshRisksEnvelope } from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
-  async findByPrisonNumber(token: string, nomsNumber: string): Promise<Person> {
+  async findByPrisonNumber(token: string, nomsNumber: string): Promise<FullPerson> {
     const personClient = this.personClientFactory(token)
 
     const person = await personClient.search(nomsNumber)

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -11,6 +11,7 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
   sex: faker.helpers.arrayElement(['Male', 'Female', 'Other', 'Prefer not to say']),
   status: faker.helpers.arrayElement(['InCustody', 'InCommunity']),
   nomsNumber: `NOMS${faker.number.int({ min: 100, max: 999 })}`,
+  pncNumber: `PNC${faker.number.int({ min: 100, max: 999 })}`,
   nationality: faker.location.country(),
   religionOrBelief: faker.helpers.arrayElement(['Christian', 'Muslim', 'Jewish', 'Hindu', 'Buddhist', 'Sikh', 'None']),
   prisonName: `HMP ${faker.location.street()}`,

--- a/server/utils/assessUtils.test.ts
+++ b/server/utils/assessUtils.test.ts
@@ -15,6 +15,11 @@ describe('applicationStatusRadios', () => {
       label: 'Awaiting decision',
       description: 'All information has been received and the application is awaiting assessment.',
     },
+    {
+      id: 'cd4d8432-250b-4ab9-81ec-7eb4b16e5cc2',
+      name: 'example',
+      label: 'Example',
+    },
   ]
 
   it('returns an array of radios', () => {
@@ -34,6 +39,12 @@ describe('applicationStatusRadios', () => {
           text: 'All information has been received and the application is awaiting assessment.',
         },
         checked: true,
+      },
+      {
+        value: 'example',
+        text: 'Example',
+        hint: null,
+        checked: false,
       },
     ]
 
@@ -58,6 +69,12 @@ describe('applicationStatusRadios', () => {
         hint: {
           text: 'All information has been received and the application is awaiting assessment.',
         },
+        checked: false,
+      },
+      {
+        value: 'example',
+        text: 'Example',
+        hint: null,
         checked: false,
       },
     ]

--- a/server/utils/assessUtils.ts
+++ b/server/utils/assessUtils.ts
@@ -8,7 +8,7 @@ export const applicationStatusRadios = (
     return {
       value: status.name,
       text: status.label,
-      hint: status?.description ? { text: status.description } : null,
+      hint: status.description ? { text: status.description } : null,
       checked: previousStatuses.length ? status.name === previousStatuses[0].name : false,
     }
   })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,10 +5,11 @@ import * as pathModule from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
 
+import { PersonStatus } from '@approved-premises/ui'
 import applicationPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import config from '../config'
-import { initialiseName } from './utils'
+import { initialiseName, removeBlankSummaryListItems } from './utils'
 import {
   documentSummaryListRows,
   inProgressApplicationTableRows,
@@ -21,6 +22,7 @@ import { checkYourAnswersSections } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
 import { getApplicationTimelineEvents } from './applications/utils'
 import { applicationStatusRadios } from './assessUtils'
+import { statusTag } from './personUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -90,4 +92,13 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('getApplicationTimelineEvents', getApplicationTimelineEvents)
   njkEnv.addGlobal('applicationStatusRadios', applicationStatusRadios)
+
+  njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
+
+  const markAsSafe = (html: string): string => {
+    const safeFilter = njkEnv.getFilter('safe')
+    return safeFilter(html)
+  }
+
+  njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
 }

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,0 +1,15 @@
+import { statusTag } from './personUtils'
+
+describe('personUtils', () => {
+  describe('statusTag', () => {
+    it('returns an "In Community" tag for an InCommunity status', () => {
+      expect(statusTag('InCommunity')).toEqual(
+        `<strong class="govuk-tag" data-cy-status="InCommunity">In Community</strong>`,
+      )
+    })
+
+    it('returns an "In Custody" tag for an InCustody status', () => {
+      expect(statusTag('InCustody')).toEqual(`<strong class="govuk-tag" data-cy-status="InCustody">In Custody</strong>`)
+    })
+  })
+})

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -1,0 +1,11 @@
+import { PersonStatus } from '@approved-premises/ui'
+
+const statusTag = (status: PersonStatus): string => {
+  if (status === 'InCommunity') {
+    return `<strong class="govuk-tag" data-cy-status="${status}">In Community</strong>`
+  }
+
+  return `<strong class="govuk-tag" data-cy-status="${status}">In Custody</strong>`
+}
+
+export { statusTag }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
-import { convertToTitleCase, initialiseName } from './utils'
+import { SummaryListItem } from '@approved-premises/ui'
+import { convertToTitleCase, initialiseName, removeBlankSummaryListItems } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -26,5 +27,84 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('removeBlankSummaryListItems', () => {
+  it('removes all blank and undefined items', () => {
+    const items = [
+      {
+        key: {
+          text: 'Names',
+        },
+        value: {
+          text: 'Name',
+        },
+      },
+      {
+        key: {
+          text: 'CRN',
+        },
+        value: {
+          text: '',
+        },
+      },
+      {
+        key: {
+          text: 'Date of Birth',
+        },
+        value: {
+          text: undefined,
+        },
+      },
+      {
+        key: {
+          text: 'NOMS Number',
+        },
+        value: {
+          html: '<strong>Some HTML</strong>',
+        },
+      },
+      {
+        key: {
+          text: 'Nationality',
+        },
+        value: {
+          html: undefined,
+        },
+      },
+      {
+        key: {
+          text: 'Religion',
+        },
+        value: {
+          html: '',
+        },
+      },
+      {
+        value: {
+          somethingElse: '',
+        },
+      },
+    ] as Array<SummaryListItem>
+
+    expect(removeBlankSummaryListItems(items)).toEqual([
+      {
+        key: {
+          text: 'Names',
+        },
+        value: {
+          text: 'Name',
+        },
+      },
+      {
+        key: {
+          text: 'NOMS Number',
+        },
+        value: {
+          html: '<strong>Some HTML</strong>',
+        },
+      },
+    ])
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,5 +1,6 @@
 import qs, { IStringifyOptions } from 'qs'
 import { FullPerson, Person } from '@approved-premises/api'
+import { SummaryListItem } from '@approved-premises/ui'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -43,4 +44,21 @@ export const isFullPerson = (person: Person): person is FullPerson => {
  */
 export const nameOrPlaceholderCopy = (person: Person, copyForRestrictedPerson = 'the person'): string => {
   return isFullPerson(person) ? person.name : copyForRestrictedPerson
+}
+
+/**
+ * Removes any items in an array of summary list items that are blank or undefined
+ * @param items an array of summary list items
+ * @returns all items with non-blank values
+ */
+export const removeBlankSummaryListItems = (items: Array<SummaryListItem>): Array<SummaryListItem> => {
+  return items.filter(item => {
+    if ('html' in item.value) {
+      return item.value.html
+    }
+    if ('text' in item.value) {
+      return item.value.text
+    }
+    return false
+  })
 }

--- a/server/views/people/confirm-applicant-details.njk
+++ b/server/views/people/confirm-applicant-details.njk
@@ -1,0 +1,57 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "./partials/personDetails.njk" import personDetails %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Confirm applicant details" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.applications.new()
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.applications.create() }}" method="post">
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="name" value="{{ person.name }}"/>
+        <input type="hidden" name="crn" value="{{ person.crn }}"/>
+        <input type="hidden" name="prisonNumber" value="{{ person.nomsNumber }}"/>
+
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ pageHeading }}</h1>
+
+        <div class="govuk-!-margin-bottom-6">
+          <p class="govuk-caption-m govuk-!-margin-bottom-1">Imported from NDelius <strong>{{ date }}</strong>
+          </p>
+        </div>
+
+        {{ personDetails(person, false) }}
+
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            If any of these details are missing or wrong, please update NDelius before continuing.
+          </strong>
+        </div>
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+                text: "Confirm and continue"
+            }) }}
+
+          <a href="{{ paths.applications.new() }}"> Search for a different applicant </a>
+        </div>
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/people/partials/personDetails.njk
+++ b/server/views/people/partials/personDetails.njk
@@ -1,0 +1,95 @@
+{%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
+
+{% macro personDetails(person, showTitle = true) %}
+  {% set rows = ([
+    {
+      key: {
+        text: "Full name"
+      },
+      value: {
+        text: person.name
+      }
+    }, {
+      key: {
+        text: "Date of birth"
+      },
+      value: {
+        text: formatDate(person.dateOfBirth, {format: 'short'})if person.dateOfBirth else 
+          ''
+      }
+    }, {
+      key: {
+        text: "Nationality"
+      },
+      value: {
+        text: person.nationality
+      }
+    }, {
+      key: {
+        text: "Sex"
+      },
+      value: {
+        text: person.sex
+      }
+    }, {
+      key: {
+        text: "Prison number"
+      },
+      value: {
+        text: person.nomsNumber
+      }
+    }, {
+      key: {
+        text: "Prison"
+      },
+      value: {
+        text: person.prisonName
+      }
+    }, {
+      key: {
+        text: "PNC number"
+      },
+      value: {
+        text: person.pncNumber
+      }
+    }, {
+      key: {
+        text: "NDelius CRN number"
+      },
+      value: {
+        text: person.crn
+      }
+    }, {
+      key: {
+        text: "Status"
+      },
+      value: {
+        html: statusTag(person.status)
+      }
+    }
+  ] | removeBlankSummaryListItems) %}
+
+  {% if showTitle %}
+    {{ govukSummaryList({
+      card: {
+        title: {
+          text: "Person Details",
+          headingLevel: "2",
+          classes: "govuk-heading-m"
+        },
+        attributes: {
+          'data-cy-section': "person-details"
+        }
+      },
+      rows: rows
+    }) }}
+  {% else %}
+    {{ govukSummaryList({
+      attributes: {
+        'data-cy-person-info': true
+      },
+      rows: rows
+    }) }}
+  {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
# Context

https://trello.com/c/QxtY2FOY/314-confirm-applicant 
Confirm applicant details, after searching for them using a prison number

needs this API PR to merge https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1189 

# Changes in this PR

This has involved moving the `create` application function back to the applications controller, rather than creating the application directly in the people controller. 

## Questions:

* I've put in some error handling on the applications controller `create` function:

```
      try {
        const application = await this.applicationService.createApplication(req.user.token, crn)

        res.redirect(paths.applications.show({ id: application.id }))
      } catch (error) {
        req.flash('errors', {
          prisonNumber: {
            text: 'There was an error creating the application, please try again',
            attributes: { 'data-cy-error-prisonNumber': true },
          },
        })
        req.flash('errorSummary', [
          { text: 'There was an error creating the application, please try again', href: '#prisonNumber' },
        ])
        res.redirect(paths.applications.new({}))
      }
```

So that any error from the server will be caught and the user taken back to enter a prison number again. 
There are a few different errors [we could get back from the API](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/c63a95fe13969be0ebd5ff0d69f070b470df958e/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt#L81):
* Offender doesn't exist
* Offender does not have noms Number
* User does not have permission to access
* Just a general error if a service or API went down?

The first three are unlikely to happen between the time that the user has searched for the applicant and clicked 'Confirm', but they could technically happen.
I'm proposing for now we don't need to surface those individual error messages to the user - we'll see them in Sentry if they do start to happen and can deal with them then?
I'm going to ask UCD team their thoughts on what the copy should be.

## Screenshots of UI changes

### Before

no screen

### After

![Screenshot 2023-11-27 at 16 40 07](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/3a4ae5a2-c09a-4d6c-866a-74abcac2da57)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
