### PR TITLE
Verbal consent form

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -4,6 +4,15 @@
       "isEligible": "yes"
     }
   },
+  "confirm-consent": {
+    "confirm-consent": {
+      "hasGivenConsent": "yes",
+      "consentDate": "2023-01-01",
+      "consentDate-year": "2023",
+      "consentDate-month": "1",
+      "consentDate-day": "1"
+    }
+  },
   "area-information": {
     "first-preferred-area": {
       "preferredArea": "London",

--- a/integration_tests/pages/apply/before_you_start/confirm_consent/confirmConsentPage.ts
+++ b/integration_tests/pages/apply/before_you_start/confirm_consent/confirmConsentPage.ts
@@ -1,0 +1,40 @@
+import {
+  Cas2Application as Application,
+  Cas2Application,
+} from '../../../../../server/@types/shared/models/Cas2Application'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import ApplyPage from '../../applyPage'
+
+export default class ConfirmConsentPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Confirm ${nameOrPlaceholderCopy(application.person)}'s consent to apply for Short-Term Accommodation (CAS-2)`,
+      application,
+      'confirm-consent',
+      'confirm-consent',
+    )
+  }
+
+  static visit = (application: Cas2Application) => {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'confirm-consent',
+        page: 'confirm-consent',
+      }),
+    )
+  }
+
+  completeFormWithConsent(): void {
+    this.checkRadioByNameAndValue('hasGivenConsent', 'yes')
+    this.getTextInputByIdAndEnterDetails('consentDate-day', '1')
+    this.getTextInputByIdAndEnterDetails('consentDate-month', '1')
+    this.getTextInputByIdAndEnterDetails('consentDate-year', '2023')
+  }
+
+  completeFormWithoutConsent(): void {
+    this.checkRadioByNameAndValue('hasGivenConsent', 'no')
+    this.getTextInputByIdAndEnterDetails('consentRefusalDetail', 'some reasons')
+  }
+}

--- a/integration_tests/pages/apply/before_you_start/confirm_consent/consentRefusedPage.ts
+++ b/integration_tests/pages/apply/before_you_start/confirm_consent/consentRefusedPage.ts
@@ -1,0 +1,36 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import { FullPerson } from '../../../../../server/@types/shared/models/FullPerson'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import Page from '../../../page'
+
+export default class ConsentRefusedPage extends Page {
+  constructor(private readonly application: Application) {
+    const person = application.person as FullPerson
+    super(`${nameOrPlaceholderCopy(application.person, 'The person')} has not given their consent`, person.name)
+  }
+
+  hasGuidance(): void {
+    cy.contains('has not given their consent so you cannot apply for Short-Term Accommodation (CAS-2) on their behalf')
+  }
+
+  hasLinkToChangeAnswer(): void {
+    cy.contains('Change consent answer').should(
+      'have.attr',
+      'href',
+      paths.applications.pages.show({
+        id: this.application.id,
+        task: 'confirm-consent',
+        page: 'confirm-consent',
+      }),
+    )
+  }
+
+  chooseToChangeAnswer(): void {
+    cy.get('a').contains('Change consent answer').click()
+  }
+
+  startANewApplication(): void {
+    cy.get('a').contains('Search for a different applicant').click()
+  }
+}

--- a/integration_tests/pages/apply/confirmEligibilityPage.ts
+++ b/integration_tests/pages/apply/confirmEligibilityPage.ts
@@ -8,7 +8,7 @@ export default class ConfirmEligibilityPage extends ApplyPage {
 
   constructor(private readonly application: Application) {
     super(
-      `Is ${nameOrPlaceholderCopy(application.person)} eligible for Short-Term Accommodation (CAS-2)`,
+      `Check ${nameOrPlaceholderCopy(application.person)} is eligible for Short-Term Accommodation (CAS-2)`,
       application,
       'confirm-eligibility',
       'confirm-eligibility',
@@ -36,10 +36,8 @@ export default class ConfirmEligibilityPage extends ApplyPage {
   }
 
   hasGuidance = (): void => {
-    cy.get('.govuk-inset-text').within(() => {
-      cy.get('p').contains('The applicant must:')
-      cy.get('li').contains('be 18 years old or older')
-    })
+    cy.get('p').contains('The applicant must:')
+    cy.get('li').contains('be 18 years old or older')
   }
 
   doesNotHaveTaskListLink = (): void => {

--- a/integration_tests/tests/apply/before_you_apply/confirm-consent/confirm_consent.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm-consent/confirm_consent.cy.ts
@@ -1,0 +1,209 @@
+//  Feature: Referrer completes 'Confirm consent' task
+//    So that I can complete the 'Confirm consent' task
+//    As a referrer
+//    I want to answer questions within that task
+//
+//  Background:
+//    Given I am logged in
+//    And I have confirmed the user is eligible for CAS-2
+//    And I'm now faced with the 'Confirm consent' task
+//
+//  Scenario: Confirms that the person has given consent
+//    When I confirm that the person has given consent
+//    And I continue to the next task
+//    Then I see that the 'Confirm consent' task is complete
+//
+//  Scenario: Confirms that the person has NOT given consent
+//    When I confirm that the person has NOT given consent
+//    And I continue to the next task
+//    Then I see that I have marked that this person has not given consent
+//    And I am on the 'consent refused' page
+//    And I am provided with a way of changing the consent answer
+//
+//  Scenario: Changes consent answer: from NO to YES
+//    Given I have confirmed that the person has not given consent
+//    And I am on the 'person ineligible' page
+//    When I choose to change my consent answer
+//    I confirm that the person has given consent
+//    And I continue to the next task
+//    Then I see that the 'Confirm consent' task is complete
+//
+//  Scenario: Abandons application and starts new one
+//    Given I have confirmed that the person has not given consent
+//    And I am on the 'consent refused' page
+//    When I opt to start a new application
+//    Then I should be able to 'Find by prison number'
+
+import Page from '../../../../pages/page'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import ConfirmConsentPage from '../../../../pages/apply/before_you_start/confirm_consent/confirmConsentPage'
+import ConsentRefusedPage from '../../../../pages/apply/before_you_start/confirm_consent/consentRefusedPage'
+import FindByPrisonNumberPage from '../../../../pages/apply/findByPrisonNumberPage'
+
+context('Complete "Confirm consent" task in "Before you start" section', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['confirm-consent'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+
+    cy.task('stubFindPerson', { person })
+  })
+
+  beforeEach(function test() {
+    cy.wrap({
+      ...this.application,
+      data: {
+        ...this.application.data,
+        'confirm-consent': {
+          'confirm-consent': {
+            hasGivenConsent: 'yes',
+            consentDate: '2023-01-01',
+            'consentDate-year': '2023',
+            'consentDate-month': '1',
+            'consentDate-day': '1',
+          },
+        },
+      },
+    }).as('applicationWithConsent')
+
+    cy.wrap({
+      ...this.application,
+      data: {
+        ...this.application.data,
+        'confirm-consent': {
+          'confirm-consent': {
+            hasGivenConsent: 'no',
+            consentRefusalDetail: 'some reasons',
+          },
+        },
+      },
+    }).as('applicationWithConsentRefused')
+
+    //  Background:
+    //    Given I am logged in
+    cy.signIn()
+    //    And I have confirmed the user is eligible for CAS-2
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    ConfirmConsentPage.visit(this.application)
+
+    //   And I'm now faced with the 'Confirm consent' task
+    Page.verifyOnPage(ConfirmConsentPage, this.application)
+  })
+
+  //  Scenario: Confirms that the person has given consent
+  //    When I confirm that the person has given consent
+  //    And I continue to the next task
+  //    Then I see that the 'Confirm consent' task is complete
+  it('allows consent to be confirmed', function test() {
+    const page = Page.verifyOnPage(ConfirmConsentPage, this.application)
+
+    // When I select the 'Yes' option and click save and continue
+    page.completeFormWithConsent()
+
+    // after submission of the valid form the API will return the answered question
+    // -- note that it this case the value must be yes or no to indicate that the
+    //    'Confirm consent' task is complete
+    cy.task('stubApplicationGet', { application: this.applicationWithConsent })
+
+    page.clickSubmit()
+
+    // Then I return to the task list
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+
+    // And I see that the task is now complete
+    taskListPage.shouldShowTaskStatus('confirm-consent', 'Completed')
+  })
+
+  //  Scenario: Confirms that the person has NOT given consent
+  //    When I confirm that the person has NOT given consent
+  //    And I continue to the next task
+  //    Then I see that I have marked that this person has not given consent
+  //    And I am on the 'consent refused' page
+  //    And I am provided with a way of changing the consent answer
+  it('allows NO CONSENT to be confirmed', function test() {
+    const page = Page.verifyOnPage(ConfirmConsentPage, this.application)
+
+    // When I select the 'NO' option and click save and continue
+    page.completeFormWithoutConsent()
+
+    // after submission of the valid form the API will return the answered question
+    // -- note that it this case the value must be yes or no to indicate that the
+    //    'Confirm consent' task is complete
+    cy.task('stubApplicationGet', { application: this.applicationWithConsentRefused })
+
+    page.clickSubmit()
+
+    // Then I see that I have marked that this person has not given consent
+    // And I am on the 'consent refused' page
+    const consentRefusedPage = Page.verifyOnPage(ConsentRefusedPage, this.application)
+    consentRefusedPage.hasGuidance()
+    // And I am provided with a way of changing the eligibility answer)
+    consentRefusedPage.hasLinkToChangeAnswer()
+  })
+
+  //  Scenario: Changes consent answer: from NO to YES
+  //    Given I have confirmed that the person has not given consent
+  //    And I am on the 'person ineligible' page
+  //    When I choose to change my consent answer
+  //    I confirm that the person has given consent
+  //    And I continue to the next task
+  //    Then I see that the 'Confirm consent' task is complete
+  it('allows consent answer to be changed from NO to YES', function test() {
+    //  Given I have confirmed that the person has not given consent
+    cy.task('stubApplicationGet', { application: this.applicationWithConsentRefused })
+
+    // And I am on the 'consent refused' page
+    cy.visit('applications/abc123')
+    const page = Page.verifyOnPage(ConsentRefusedPage, this.application)
+
+    //  When I choose to change my consent answer
+    page.chooseToChangeAnswer()
+
+    //  I confirm that the person has given consent
+    const confirmConsentPage = new ConfirmConsentPage(this.application)
+    confirmConsentPage.completeFormWithConsent()
+
+    //  And I continue to the next task
+    cy.task('stubApplicationGet', { application: this.applicationWithConsent })
+    confirmConsentPage.clickSubmit()
+
+    // Then I see that the 'Confirm consent' task is complete
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.shouldShowTaskStatus('confirm-consent', 'Completed')
+  })
+
+  //  Scenario: Abandons application and starts new one
+  //    Given I have confirmed that the person has not given consent
+  //    And I am on the 'consent refused' page
+  //    When I opt to start a new application
+  //    Then I should be able to 'Find by prison number'
+  it('allows application to be abandoned and a new one started', function test() {
+    //  Given I have confirmed that the person has not given consent
+    cy.task('stubApplicationGet', { application: this.applicationWithConsentRefused })
+
+    // And I am on the 'consent refused' page
+    cy.visit('applications/abc123')
+    const page = Page.verifyOnPage(ConsentRefusedPage, this.application)
+
+    // When I opt to start a new application
+    page.startANewApplication()
+
+    // Then I should be able to 'Find by prison number'
+    Page.verifyOnPage(FindByPrisonNumberPage)
+  })
+})

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -11,7 +11,7 @@
 //  Scenario: Confirms that the person is eligible for CAS-2
 //    When I confirm that the person is eligible
 //    And I continue to the next task
-//    Then I see that the 'Confirm eligibility' task is complete
+//    Then I am on the 'Confirm consent' page
 //
 //  Scenario: Confirms that the person is NOT eligible for CAS-2
 //    When I confirm that the person is NOT eligible
@@ -37,10 +37,10 @@
 //    Then I should be able to 'Find by prison number'
 
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
 import ConfirmEligibilityPage from '../../../../pages/apply/confirmEligibilityPage'
 import IneligiblePage from '../../../../pages/apply/ineligiblePage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import ConfirmConsentPage from '../../../../pages/apply/before_you_start/confirm_consent/confirmConsentPage'
 import FindByPrisonNumberPage from '../../../../pages/apply/findByPrisonNumberPage'
 
 context('Complete "Confirm eligibility" task in "Before you start" section', () => {
@@ -81,7 +81,7 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
   //  Scenario: Confirms that the person is eligible for CAS-2
   //    When I confirm that the person is eligible
   //    And I continue to the next task
-  //    Then I see that the 'Confirm eligibility' task is complete
+  //    Then I am on the 'Confirm consent' page
   it('allows eligibility to be confirmed', function test() {
     const confirmEligibilityPage = new ConfirmEligibilityPage(this.application)
     confirmEligibilityPage.hasCaption()
@@ -107,11 +107,8 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
 
     confirmEligibilityPage.clickSubmit()
 
-    // Then I return to the task list
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-
-    // And I see that the task is now complete
-    taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Completed')
+    // Then I am on the 'Confirm consent' page
+    Page.verifyOnPage(ConfirmConsentPage, this.application)
   })
 
   //  Scenario: Confirms that the person is NOT eligible for CAS-2
@@ -156,7 +153,7 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
   //    When I choose to change my eligibility answer
   //    I confirm that the person is eligible
   //    And I continue to the next task
-  //    Then I see that the 'Confirm eligibility' task is complete
+  //    Then I am on the 'confirm consent' task
   it('allows eligibility answer to be changed from NO to YES', function test() {
     //  Given I have confirmed that the person is not eligible
     const answered = {
@@ -191,9 +188,8 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
     cy.task('stubApplicationGet', { application: updated })
     confirmEligibilityPage.clickSubmit()
 
-    // Then I see that the 'Confirm eligibility' task is complete
-    const taskListPage = Page.verifyOnPage(TaskListPage)
-    taskListPage.shouldShowTaskStatus('confirm-eligibility', 'Completed')
+    // Then I am on the 'confirm consent' task
+    Page.verifyOnPage(ConfirmConsentPage, updated)
   })
 
   //  Scenario: Abandons ineligible application and starts new one

--- a/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/confirm_eligibility/confirm_eligibility_task.cy.ts
@@ -41,6 +41,7 @@ import TaskListPage from '../../../../pages/apply/taskListPage'
 import ConfirmEligibilityPage from '../../../../pages/apply/confirmEligibilityPage'
 import IneligiblePage from '../../../../pages/apply/ineligiblePage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import FindByPrisonNumberPage from '../../../../pages/apply/findByPrisonNumberPage'
 
 context('Complete "Confirm eligibility" task in "Before you start" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -218,5 +219,8 @@ context('Complete "Confirm eligibility" task in "Before you start" section', () 
 
     // When I opt to start a new application
     ineligiblePage.startANewApplication()
+
+    // Then I should be able to 'Find by prison number'
+    Page.verifyOnPage(FindByPrisonNumberPage)
   })
 })

--- a/integration_tests/tests/apply/view_task_list.cy.ts
+++ b/integration_tests/tests/apply/view_task_list.cy.ts
@@ -23,6 +23,15 @@ context('Visit task list', () => {
       'confirm-eligibility': {
         'confirm-eligibility': { isEligible: 'yes' },
       },
+      'confirm-consent': {
+        'confirm-consent': {
+          hasGivenConsent: 'yes',
+          consentDate: '2023-01-01',
+          'consentDate-year': '2023',
+          'consentDate-month': '1',
+          'consentDate-day': '1',
+        },
+      },
     },
     person: fullPersonFactory.build(),
   })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -45,7 +45,12 @@ describe('applicationsController', () => {
       applicationService,
     })
 
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({
+      user: { token },
+      headers: {
+        referer: 'some-referrer/',
+      },
+    })
     response = createMock<Response>({})
   })
 
@@ -82,16 +87,25 @@ describe('applicationsController', () => {
         })
       })
     })
-    describe('when "Confirm eligibility" task ("Before you start" section) is complete', () => {
-      describe('and the person is confirmed eligible', () => {
-        it('renders the task list view', async () => {
-          const application = applicationFactory.build({
-            data: {
-              'confirm-eligibility': {
-                'confirm-eligibility': { isEligible: 'yes' },
+    describe('when "Confirm eligibility" and "confirm consent" tasks are complete', () => {
+      describe('and the person is confirmed eligible and has given consent', () => {
+        const application = applicationFactory.build({
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'yes' },
+            },
+            'confirm-consent': {
+              'confirm-consent': {
+                hasGivenConsent: 'yes',
+                consentDate: '2022-02-22',
+                'consentDate-year': '2022',
+                'consentDate-month': '2',
+                'consentDate-day': '22',
               },
             },
-          })
+          },
+        })
+        it('renders the task list view', async () => {
           const stubTaskList = jest.fn()
           applicationService.findApplication.mockResolvedValue(application)
           ;(TaskListService as jest.Mock).mockImplementation(() => {
@@ -113,13 +127,6 @@ describe('applicationsController', () => {
         })
 
         it('renders the task list view with errors', async () => {
-          const application = applicationFactory.build({
-            data: {
-              'confirm-eligibility': {
-                'confirm-eligibility': { isEligible: 'yes' },
-              },
-            },
-          })
           const stubTaskList = jest.fn()
           applicationService.findApplication.mockResolvedValue(application)
           ;(TaskListService as jest.Mock).mockImplementation(() => {
@@ -194,332 +201,397 @@ describe('applicationsController', () => {
         )
       })
     })
-  })
 
-  describe('create', () => {
-    it('redirects to the new applications page on success', async () => {
-      request.body = {
-        crn: 'crn123',
-        prisonNumber: 'prisonNumber123',
-      }
+    describe('when the person is confirmed ELIGIBLE but consent has been DENIED', () => {
+      it('renders the _consent refused_ page', async () => {
+        const application = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'yes' },
+            },
+            'confirm-consent': {
+              'confirm-consent': {
+                hasGivenConsent: 'no',
+                consentRefusalDetail: 'some reason',
+              },
+            },
+          },
+        })
 
-      applicationService.createApplication.mockResolvedValue({} as Application)
-
-      const requestHandler = applicationsController.create()
-      await requestHandler(request, response, next)
-
-      expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
-    })
-
-    it('handles a not found error if person not found', async () => {
-      request.body = {
-        crn: 'crn123',
-        prisonNumber: 'prisonNumber123',
-      }
-
-      const requestHandler = applicationsController.create()
-
-      const err = createHttpError(404)
-
-      applicationService.createApplication.mockImplementation(() => {
-        throw err
-      })
-
-      await requestHandler(request, response, next)
-
-      expect(errorSummaryMock).toHaveBeenCalledWith(
-        'prisonNumber',
-        'No person found for prison number prisonNumber123, please try another number.',
-      )
-
-      expect(errorMessage).toHaveBeenCalledWith(
-        'prisonNumber',
-        'No person found for prison number prisonNumber123, please try another number.',
-      )
-
-      expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
-    })
-
-    it('handles a forbidden error if person forbidden', async () => {
-      request.body = {
-        crn: 'crn123',
-        prisonNumber: 'prisonNumber123',
-      }
-
-      const requestHandler = applicationsController.create()
-
-      const err = createHttpError(403)
-
-      applicationService.createApplication.mockImplementation(() => {
-        throw err
-      })
-
-      await requestHandler(request, response, next)
-
-      expect(errorSummaryMock).toHaveBeenCalledWith(
-        'prisonNumber',
-        'You do not have permission to access the prison number prisonNumber123, please try another number.',
-      )
-
-      expect(errorMessage).toHaveBeenCalledWith(
-        'prisonNumber',
-        'You do not have permission to access the prison number prisonNumber123, please try another number.',
-      )
-
-      expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
-    })
-
-    it('throws a generic error if createApplication returns server error', async () => {
-      const requestHandler = applicationsController.create()
-
-      const err = new Error()
-
-      applicationService.createApplication.mockImplementation(() => {
-        throw err
-      })
-
-      await requestHandler(request, response, next)
-
-      expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
-    })
-  })
-
-  describe('new', () => {
-    it('renders the enter CRN template', async () => {
-      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
-        return { errors: {}, errorSummary: [], userInput: {} }
-      })
-
-      const requestHandler = applicationsController.new()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('applications/new', {
-        errors: {},
-        errorSummary: [],
-        pageHeading: "Enter the person's prison number",
-      })
-    })
-
-    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
-      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
-      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
-
-      const requestHandler = applicationsController.new()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('applications/new', {
-        pageHeading: "Enter the person's prison number",
-        errors: errorsAndUserInput.errors,
-        errorSummary: errorsAndUserInput.errorSummary,
-        ...errorsAndUserInput.userInput,
-      })
-    })
-  })
-
-  describe('submit', () => {
-    describe('when the confirmation checkbox is checked', () => {
-      it('renders the application submission confirmation page', async () => {
-        const application = applicationFactory.build()
-
-        ;(buildDocument as jest.Mock).mockReturnValue({})
-
-        request.params.id = 'some-id'
-        request.body = { confirmation: 'submit' }
+        const panelText = `Roger Smith has not given their consent`
+        const changeAnswerPath = paths.applications.pages.show({
+          id: application.id,
+          task: 'confirm-consent',
+          page: 'confirm-consent',
+        })
+        const newApplicationPath = paths.applications.new({})
 
         applicationService.findApplication.mockResolvedValue(application)
 
-        const requestHandler = applicationsController.submit()
+        const requestHandler = applicationsController.show()
         await requestHandler(request, response, next)
 
-        expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
-        expect(applicationService.submit).toHaveBeenCalledWith(request.user.token, application)
-        expect(response.render).toHaveBeenCalledWith('applications/confirm', {
-          pageHeading: 'Application confirmation',
+        expect(response.render).toHaveBeenCalledWith('applications/consent-refused', {
+          application,
+          panelText,
+          changeAnswerPath,
+          newApplicationPath,
+          backLink: 'some-referrer/',
         })
       })
     })
 
-    describe('when the confirmation checkbox is not checked', () => {
-      it('renders the application submission confirmation page', async () => {
-        const application = applicationFactory.build()
-
-        ;(buildDocument as jest.Mock).mockReturnValue({})
-
-        request.params.id = 'some-id'
-        request.body = undefined
+    describe('when the person is confirmed ELIGIBLE but the consent task has not been completed', () => {
+      it('redirects to the _confirm consent_ page', async () => {
+        const application = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+          data: {
+            'confirm-eligibility': {
+              'confirm-eligibility': { isEligible: 'yes' },
+            },
+          },
+        })
 
         applicationService.findApplication.mockResolvedValue(application)
 
-        const requestHandler = applicationsController.submit()
+        const requestHandler = applicationsController.show()
         await requestHandler(request, response, next)
 
-        const error = new Error('You must confirm the information provided is complete, accurate and up to date.')
-
-        expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          error,
-          paths.applications.show({ id: application.id }),
+        expect(response.redirect).toHaveBeenCalledWith(
+          paths.applications.pages.show({
+            id: application.id,
+            task: 'confirm-consent',
+            page: 'confirm-consent',
+          }),
         )
       })
     })
-  })
 
-  describe('appendToList', () => {
-    const page = createMock<TaskListPage>({})
-
-    beforeEach(() => {
-      request.body = {
-        exampleField: 'example answer',
-      }
-      request.query = {}
-      request.params = {
-        id: 'abc123',
-        page: 'example-page',
-        task: 'example-task',
-      }
-
-      const PageConstructor = jest.fn()
-      ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
-
-      applicationService.initializePage.mockResolvedValue(page)
-    })
-
-    describe('when there is a redirect path', () => {
-      it('redirects to that path', async () => {
-        request.query = {
-          redirectPage: 'redirect-page',
+    describe('create', () => {
+      it('redirects to the new applications page on success', async () => {
+        request.body = {
+          crn: 'crn123',
+          prisonNumber: 'prisonNumber123',
         }
 
-        applicationService.appendToList.mockResolvedValue()
+        applicationService.createApplication.mockResolvedValue({} as Application)
 
-        const requestHandler = applicationsController.appendToList()
+        const requestHandler = applicationsController.create()
+        await requestHandler(request, response, next)
 
-        await requestHandler({ ...request }, response)
-
-        expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
-
-        expect(response.redirect).toHaveBeenCalledWith('/applications/abc123/tasks/example-task/pages/redirect-page')
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
       })
-    })
 
-    describe('when the page has a next page', () => {
-      it('saves data and calls next function', async () => {
-        page.next.mockReturnValue('next-page')
+      it('handles a not found error if person not found', async () => {
+        request.body = {
+          crn: 'crn123',
+          prisonNumber: 'prisonNumber123',
+        }
 
-        applicationService.appendToList.mockResolvedValue()
+        const requestHandler = applicationsController.create()
 
-        const requestHandler = applicationsController.appendToList()
+        const err = createHttpError(404)
 
-        await requestHandler({ ...request }, response)
-
-        expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
-
-        expect(response.redirect).toHaveBeenCalledWith(
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'next-page' }),
-        )
-      })
-    })
-
-    describe('when the page does not have a next page', () => {
-      it('redirects to the task list page', async () => {
-        page.next.mockReturnValue('')
-
-        applicationService.appendToList.mockResolvedValue()
-
-        const requestHandler = applicationsController.appendToList()
-
-        await requestHandler({ ...request }, response)
-
-        expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
-
-        expect(response.redirect).toHaveBeenCalledWith(paths.applications.show({ id: request.params.id }))
-      })
-    })
-
-    describe('when there are errors', () => {
-      it('passes error to error handler', async () => {
-        const err = new Error()
-        applicationService.appendToList.mockImplementation(() => {
+        applicationService.createApplication.mockImplementation(() => {
           throw err
         })
 
-        const requestHandler = applicationsController.appendToList()
+        await requestHandler(request, response, next)
 
-        await requestHandler({ ...request }, response)
-
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          err,
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'example-page' }),
+        expect(errorSummaryMock).toHaveBeenCalledWith(
+          'prisonNumber',
+          'No person found for prison number prisonNumber123, please try another number.',
         )
-      })
-    })
-  })
 
-  describe('removeFromList', () => {
-    const page = createMock<TaskListPage>({})
-
-    beforeEach(() => {
-      request.query = {
-        redirectPage: 'return-page',
-      }
-      request.params = {
-        id: 'abc123',
-        task: 'example-task',
-        page: 'example-page',
-        index: '0',
-      }
-
-      const PageConstructor = jest.fn()
-      ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
-
-      applicationService.initializePage.mockResolvedValue(page)
-    })
-
-    describe('when item is successfully removed', () => {
-      it('renders the page', async () => {
-        applicationService.removeFromList.mockResolvedValue()
-
-        const requestHandler = applicationsController.removeFromList()
-
-        await requestHandler({ ...request }, response)
-
-        expect(applicationService.removeFromList).toHaveBeenCalledWith(request)
-
-        expect(response.redirect).toHaveBeenCalledWith(
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'return-page' }),
+        expect(errorMessage).toHaveBeenCalledWith(
+          'prisonNumber',
+          'No person found for prison number prisonNumber123, please try another number.',
         )
-      })
-    })
 
-    describe('when an error occurs', () => {
-      it('passes error to error handler', async () => {
-        const err = new Error()
-        applicationService.removeFromList.mockImplementation(() => {
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
+      })
+
+      it('handles a forbidden error if person forbidden', async () => {
+        request.body = {
+          crn: 'crn123',
+          prisonNumber: 'prisonNumber123',
+        }
+
+        const requestHandler = applicationsController.create()
+
+        const err = createHttpError(403)
+
+        applicationService.createApplication.mockImplementation(() => {
           throw err
         })
 
-        const requestHandler = applicationsController.removeFromList()
+        await requestHandler(request, response, next)
 
-        await requestHandler({ ...request }, response)
-
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          err,
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'return-page' }),
+        expect(errorSummaryMock).toHaveBeenCalledWith(
+          'prisonNumber',
+          'You do not have permission to access the prison number prisonNumber123, please try another number.',
         )
+
+        expect(errorMessage).toHaveBeenCalledWith(
+          'prisonNumber',
+          'You do not have permission to access the prison number prisonNumber123, please try another number.',
+        )
+
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
+      })
+
+      it('throws a generic error if createApplication returns server error', async () => {
+        const requestHandler = applicationsController.create()
+
+        const err = new Error()
+
+        applicationService.createApplication.mockImplementation(() => {
+          throw err
+        })
+
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.new({}))
       })
     })
-  })
 
-  describe('update', () => {
-    const page = createMock<TaskListPage>({})
+    describe('new', () => {
+      it('renders the enter CRN template', async () => {
+        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+          return { errors: {}, errorSummary: [], userInput: {} }
+        })
 
-    const taskData = `{
+        const requestHandler = applicationsController.new()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/new', {
+          errors: {},
+          errorSummary: [],
+          pageHeading: "Enter the person's prison number",
+        })
+      })
+
+      it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+        const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+        ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+        const requestHandler = applicationsController.new()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/new', {
+          pageHeading: "Enter the person's prison number",
+          errors: errorsAndUserInput.errors,
+          errorSummary: errorsAndUserInput.errorSummary,
+          ...errorsAndUserInput.userInput,
+        })
+      })
+    })
+
+    describe('submit', () => {
+      describe('when the confirmation checkbox is checked', () => {
+        it('renders the application submission confirmation page', async () => {
+          const application = applicationFactory.build()
+
+          ;(buildDocument as jest.Mock).mockReturnValue({})
+
+          request.params.id = 'some-id'
+          request.body = { confirmation: 'submit' }
+
+          applicationService.findApplication.mockResolvedValue(application)
+
+          const requestHandler = applicationsController.submit()
+          await requestHandler(request, response, next)
+
+          expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
+          expect(applicationService.submit).toHaveBeenCalledWith(request.user.token, application)
+          expect(response.render).toHaveBeenCalledWith('applications/confirm', {
+            pageHeading: 'Application confirmation',
+          })
+        })
+      })
+
+      describe('when the confirmation checkbox is not checked', () => {
+        it('renders the application submission confirmation page', async () => {
+          const application = applicationFactory.build()
+
+          ;(buildDocument as jest.Mock).mockReturnValue({})
+
+          request.params.id = 'some-id'
+          request.body = undefined
+
+          applicationService.findApplication.mockResolvedValue(application)
+
+          const requestHandler = applicationsController.submit()
+          await requestHandler(request, response, next)
+
+          const error = new Error('You must confirm the information provided is complete, accurate and up to date.')
+
+          expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
+          expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+            request,
+            response,
+            error,
+            paths.applications.show({ id: application.id }),
+          )
+        })
+      })
+    })
+
+    describe('appendToList', () => {
+      const page = createMock<TaskListPage>({})
+
+      beforeEach(() => {
+        request.body = {
+          exampleField: 'example answer',
+        }
+        request.query = {}
+        request.params = {
+          id: 'abc123',
+          page: 'example-page',
+          task: 'example-task',
+        }
+
+        const PageConstructor = jest.fn()
+        ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
+
+        applicationService.initializePage.mockResolvedValue(page)
+      })
+
+      describe('when there is a redirect path', () => {
+        it('redirects to that path', async () => {
+          request.query = {
+            redirectPage: 'redirect-page',
+          }
+
+          applicationService.appendToList.mockResolvedValue()
+
+          const requestHandler = applicationsController.appendToList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
+
+          expect(response.redirect).toHaveBeenCalledWith('/applications/abc123/tasks/example-task/pages/redirect-page')
+        })
+      })
+
+      describe('when the page has a next page', () => {
+        it('saves data and calls next function', async () => {
+          page.next.mockReturnValue('next-page')
+
+          applicationService.appendToList.mockResolvedValue()
+
+          const requestHandler = applicationsController.appendToList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'next-page' }),
+          )
+        })
+      })
+
+      describe('when the page does not have a next page', () => {
+        it('redirects to the task list page', async () => {
+          page.next.mockReturnValue('')
+
+          applicationService.appendToList.mockResolvedValue()
+
+          const requestHandler = applicationsController.appendToList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
+
+          expect(response.redirect).toHaveBeenCalledWith(paths.applications.show({ id: request.params.id }))
+        })
+      })
+
+      describe('when there are errors', () => {
+        it('passes error to error handler', async () => {
+          const err = new Error()
+          applicationService.appendToList.mockImplementation(() => {
+            throw err
+          })
+
+          const requestHandler = applicationsController.appendToList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+            request,
+            response,
+            err,
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'example-page' }),
+          )
+        })
+      })
+    })
+
+    describe('removeFromList', () => {
+      const page = createMock<TaskListPage>({})
+
+      beforeEach(() => {
+        request.query = {
+          redirectPage: 'return-page',
+        }
+        request.params = {
+          id: 'abc123',
+          task: 'example-task',
+          page: 'example-page',
+          index: '0',
+        }
+
+        const PageConstructor = jest.fn()
+        ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
+
+        applicationService.initializePage.mockResolvedValue(page)
+      })
+
+      describe('when item is successfully removed', () => {
+        it('renders the page', async () => {
+          applicationService.removeFromList.mockResolvedValue()
+
+          const requestHandler = applicationsController.removeFromList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(applicationService.removeFromList).toHaveBeenCalledWith(request)
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'return-page' }),
+          )
+        })
+      })
+
+      describe('when an error occurs', () => {
+        it('passes error to error handler', async () => {
+          const err = new Error()
+          applicationService.removeFromList.mockImplementation(() => {
+            throw err
+          })
+
+          const requestHandler = applicationsController.removeFromList()
+
+          await requestHandler({ ...request }, response)
+
+          expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+            request,
+            response,
+            err,
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'return-page' }),
+          )
+        })
+      })
+    })
+
+    describe('update', () => {
+      const page = createMock<TaskListPage>({})
+
+      const taskData = `{
       "example-task": {
         "example-page": {
           "exmaplePageQuestion": "example text"
@@ -527,73 +599,74 @@ describe('applicationsController', () => {
       }
     }`
 
-    beforeEach(() => {
-      request.body = {
-        taskData,
-        pageName: 'example-page',
-        taskName: 'example-task',
-      }
+      beforeEach(() => {
+        request.body = {
+          taskData,
+          pageName: 'example-page',
+          taskName: 'example-task',
+        }
 
-      request.params = {
-        id: 'abc123',
-      }
+        request.params = {
+          id: 'abc123',
+        }
 
-      const PageConstructor = jest.fn()
-      ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
+        const PageConstructor = jest.fn()
+        ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
 
-      applicationService.initializePage.mockResolvedValue(page)
-    })
-
-    describe('when the page has a next page', () => {
-      it('saves data and calls next function', async () => {
-        page.next.mockReturnValue('next-page')
-
-        applicationService.saveData.mockResolvedValue()
-
-        const requestHandler = applicationsController.update()
-
-        await requestHandler({ ...request }, response, next)
-
-        expect(applicationService.saveData).toHaveBeenCalledWith(JSON.parse(taskData), request)
-
-        expect(response.redirect).toHaveBeenCalledWith(
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'next-page' }),
-        )
+        applicationService.initializePage.mockResolvedValue(page)
       })
-    })
-    describe('when the page does not have a next page', () => {
-      it('redirects to the task list page', async () => {
-        page.next.mockReturnValue('')
 
-        applicationService.saveData.mockResolvedValue()
+      describe('when the page has a next page', () => {
+        it('saves data and calls next function', async () => {
+          page.next.mockReturnValue('next-page')
 
-        const requestHandler = applicationsController.update()
+          applicationService.saveData.mockResolvedValue()
 
-        await requestHandler({ ...request }, response, next)
+          const requestHandler = applicationsController.update()
 
-        expect(applicationService.saveData).toHaveBeenCalledWith(JSON.parse(taskData), request)
+          await requestHandler({ ...request }, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(paths.applications.show({ id: request.params.id }))
-      })
-    })
+          expect(applicationService.saveData).toHaveBeenCalledWith(JSON.parse(taskData), request)
 
-    describe('when there are errors', () => {
-      it('passes error to error handler', async () => {
-        const err = new Error()
-        applicationService.saveData.mockImplementation(() => {
-          throw err
+          expect(response.redirect).toHaveBeenCalledWith(
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'next-page' }),
+          )
         })
+      })
+      describe('when the page does not have a next page', () => {
+        it('redirects to the task list page', async () => {
+          page.next.mockReturnValue('')
 
-        const requestHandler = applicationsController.update()
+          applicationService.saveData.mockResolvedValue()
 
-        await requestHandler({ ...request }, response, next)
+          const requestHandler = applicationsController.update()
 
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          err,
-          paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'example-page' }),
-        )
+          await requestHandler({ ...request }, response, next)
+
+          expect(applicationService.saveData).toHaveBeenCalledWith(JSON.parse(taskData), request)
+
+          expect(response.redirect).toHaveBeenCalledWith(paths.applications.show({ id: request.params.id }))
+        })
+      })
+
+      describe('when there are errors', () => {
+        it('passes error to error handler', async () => {
+          const err = new Error()
+          applicationService.saveData.mockImplementation(() => {
+            throw err
+          })
+
+          const requestHandler = applicationsController.update()
+
+          await requestHandler({ ...request }, response, next)
+
+          expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+            request,
+            response,
+            err,
+            paths.applications.pages.show({ id: request.params.id, task: 'example-task', page: 'example-page' }),
+          )
+        })
       })
     })
   })

--- a/server/form-pages/apply/before-you-start/confirm-consent/confirmConsent.test.ts
+++ b/server/form-pages/apply/before-you-start/confirm-consent/confirmConsent.test.ts
@@ -1,0 +1,88 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import ConfirmConsent from './confirmConsent'
+import { applicationFactory, personFactory } from '../../../../testutils/factories/index'
+import { getQuestions } from '../../../utils/questions'
+
+describe('ConfirmConsent', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  const questions = getQuestions('Roger Smith')
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new ConfirmConsent({}, application)
+
+      expect(page.title).toEqual("Confirm Roger Smith's consent to apply for Short-Term Accommodation (CAS-2)")
+    })
+  })
+
+  itShouldHaveNextValue(new ConfirmConsent({}, application), '')
+  itShouldHavePreviousValue(new ConfirmConsent({}, application), 'taskList')
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new ConfirmConsent({ hasGivenConsent: 'no' }, application)
+
+      expect(page.items('dateHtml', 'refusalDetailHtml')).toEqual([
+        {
+          value: 'yes',
+          text: questions['confirm-consent']['confirm-consent'].hasGivenConsent.answers.yes,
+          conditional: { html: 'dateHtml' },
+          checked: false,
+        },
+        {
+          value: 'no',
+          text: questions['confirm-consent']['confirm-consent'].hasGivenConsent.answers.no,
+          conditional: { html: 'refusalDetailHtml' },
+          checked: true,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when yes/no questions are blank', () => {
+      const page = new ConfirmConsent({}, application)
+
+      expect(page.errors()).toEqual({
+        hasGivenConsent: 'Confirm whether the applicant gave their consent',
+      })
+    })
+
+    it('should return an error when yes is selected but no date is provided', () => {
+      const page = new ConfirmConsent({ hasGivenConsent: 'yes' }, application)
+
+      expect(page.errors()).toEqual({
+        consentDate: 'Enter date applicant gave their consent',
+      })
+    })
+
+    it('should return an error when no is selected but no detail is provided', () => {
+      const page = new ConfirmConsent({ hasGivenConsent: 'no' }, application)
+
+      expect(page.errors()).toEqual({
+        consentRefusalDetail: 'Enter the applicant’s reason for refusing consent',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return the consent date if consent has been given', () => {
+      const page = new ConfirmConsent({ hasGivenConsent: 'yes', consentDate: '2023-11-01' }, application)
+
+      expect(page.response()).toEqual({
+        'Has Roger Smith given their consent to apply for CAS-2?': 'Yes, Roger Smith has given their consent',
+        'When did they give consent?': '1 November 2023',
+      })
+    })
+  })
+
+  it('should return the consent refusal detail if consent has been refused', () => {
+    const page = new ConfirmConsent({ hasGivenConsent: 'no', consentRefusalDetail: 'some reasons' }, application)
+
+    expect(page.response()).toEqual({
+      'Has Roger Smith given their consent to apply for CAS-2?': 'No, Roger Smith has not given their consent',
+      'Why was consent refused?': 'some reasons',
+    })
+  })
+})

--- a/server/form-pages/apply/before-you-start/confirm-consent/confirmConsent.ts
+++ b/server/form-pages/apply/before-you-start/confirm-consent/confirmConsent.ts
@@ -1,0 +1,101 @@
+import type { Radio, TaskListErrors, YesOrNo, ObjectWithDateParts } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { getQuestions } from '../../../utils/questions'
+import { dateBodyProperties } from '../../../utils'
+import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
+
+type ConfirmConsentBody = {
+  hasGivenConsent: YesOrNo
+  consentRefusalDetail: string
+} & ObjectWithDateParts<'consentDate'>
+
+@Page({
+  name: 'confirm-consent',
+  bodyProperties: ['hasGivenConsent', ...dateBodyProperties('consentDate'), 'consentRefusalDetail'],
+})
+export default class ConfirmConsent implements TaskListPage {
+  documentTitle = "Confirm the person's consent to apply for Short-Term Accommodation (CAS-2)"
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `Confirm ${this.personName}'s consent to apply for Short-Term Accommodation (CAS-2)`
+
+  questions
+
+  body: ConfirmConsentBody
+
+  constructor(
+    body: Partial<ConfirmConsentBody>,
+    private readonly application: Application,
+  ) {
+    if (body.hasGivenConsent === 'yes') {
+      body.consentRefusalDetail = ''
+    }
+    if (body.hasGivenConsent === 'no') {
+      body.consentDate = ''
+      body['consentDate-day'] = ''
+      body['consentDate-month'] = ''
+      body['consentDate-year'] = ''
+    }
+    this.body = body as ConfirmConsentBody
+
+    const applicationQuestions = getQuestions(this.personName)
+    this.questions = applicationQuestions['confirm-consent']['confirm-consent']
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.hasGivenConsent) {
+      errors.hasGivenConsent = 'Confirm whether the applicant gave their consent'
+    }
+    if (this.body.hasGivenConsent === 'yes' && !dateAndTimeInputsAreValidDates(this.body, 'consentDate')) {
+      errors.consentDate = 'Enter date applicant gave their consent'
+    }
+    if (this.body.hasGivenConsent === 'no' && !this.body.consentRefusalDetail) {
+      errors.consentRefusalDetail = 'Enter the applicant’s reason for refusing consent'
+    }
+    return errors
+  }
+
+  items(dateHtml: string, refusalDetailHtml: string) {
+    const items = convertKeyValuePairToRadioItems(
+      this.questions.hasGivenConsent.answers,
+      this.body.hasGivenConsent,
+    ) as Array<Radio>
+
+    items.forEach(item => {
+      if (item.value === 'yes') {
+        item.conditional = { html: dateHtml }
+      }
+      if (item.value === 'no') {
+        item.conditional = { html: refusalDetailHtml }
+      }
+    })
+
+    return items
+  }
+
+  response() {
+    return {
+      [this.questions.hasGivenConsent.question]: this.questions.hasGivenConsent.answers[this.body.hasGivenConsent],
+      ...(this.body.hasGivenConsent === 'yes' && {
+        [this.questions.consentDate.question]: DateFormats.isoDateToUIDate(this.body.consentDate, { format: 'medium' }),
+      }),
+      ...(this.body.hasGivenConsent === 'no' && {
+        [this.questions.consentRefusalDetail.question]: this.body.consentRefusalDetail,
+      }),
+    }
+  }
+}

--- a/server/form-pages/apply/before-you-start/confirm-consent/index.ts
+++ b/server/form-pages/apply/before-you-start/confirm-consent/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+
+import { Task } from '../../../utils/decorators'
+import ConfirmConsentPage from './confirmConsent'
+
+@Task({
+  name: 'Confirm consent to share information',
+  slug: 'confirm-consent',
+  pages: [ConfirmConsentPage],
+})
+export default class ConfirmConsent {}

--- a/server/form-pages/apply/before-you-start/index.ts
+++ b/server/form-pages/apply/before-you-start/index.ts
@@ -2,9 +2,10 @@
 
 import { Section } from '../../utils/decorators'
 import ConfirmEligibility from './confirm-eligibility'
+import ConfirmConsent from './confirm-consent'
 
 @Section({
   title: 'Before you start',
-  tasks: [ConfirmEligibility],
+  tasks: [ConfirmEligibility, ConfirmConsent],
 })
 export default class BeforeYouStart {}

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -31,6 +31,24 @@ export const getQuestions = (name: string) => {
         },
       },
     },
+    'confirm-consent': {
+      'confirm-consent': {
+        hasGivenConsent: {
+          question: `Has ${name} given their consent to apply for CAS-2?`,
+          answers: {
+            yes: `Yes, ${name} has given their consent`,
+            no: `No, ${name} has not given their consent`,
+          },
+        },
+        consentDate: {
+          question: 'When did they give consent?',
+          hint: 'For example, 27 3 2007',
+        },
+        consentRefusalDetail: {
+          question: 'Why was consent refused?',
+        },
+      },
+    },
     'address-history': {
       'previous-address': {
         hasPreviousAddress: {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -27,6 +27,21 @@ const eligibilityAnswer = (application: Application): string => {
   return application.data?.['confirm-eligibility']?.['confirm-eligibility']?.isEligible
 }
 
+export const firstPageOfConsentTask = (application: Application) => {
+  return paths.applications.pages.show({ id: application.id, task: 'confirm-consent', page: 'confirm-consent' })
+}
+
+export const consentIsConfirmed = (application: Application): boolean => {
+  return consentAnswer(application) === 'yes'
+}
+export const consentIsDenied = (application: Application): boolean => {
+  return consentAnswer(application) === 'no'
+}
+
+const consentAnswer = (application: Application): string => {
+  return application.data?.['confirm-consent']?.['confirm-consent']?.hasGivenConsent
+}
+
 export const getStatusTimelineEvents = (statusUpdates: Array<Cas2StatusUpdate>): Array<UiTimelineEvent> => {
   if (statusUpdates) {
     return statusUpdates

--- a/server/views/applications/consent-refused.njk
+++ b/server/views/applications/consent-refused.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  CAS-2: Consent refused - This person cannot apply for CAS-2 accommodation
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      {{ govukPanel({
+        titleText: panelText,
+        classes: "govuk-!-margin-bottom-9 govuk-panel--fail"
+      }) }}
+
+      <p class="govuk-body-l">
+        {{application.person.name}} has not given their consent so you cannot apply for Short-Term Accommodation (CAS-2) on their behalf.
+      </p>
+
+      {{ govukButton({
+           text: "Search for a different applicant",
+           classes: "govuk-!-margin-right-1",
+           href: newApplicationPath
+      }) }}
+
+      {{ govukButton({
+           text: "Change consent answer",
+           classes: "govuk-button--secondary",
+           href: changeAnswerPath
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/confirm-consent/confirm-consent.njk
+++ b/server/views/applications/pages/confirm-consent/confirm-consent.njk
@@ -1,0 +1,87 @@
+{% extends "../layout.njk" %}
+{% block questions %}
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  <div>
+    <p class="govuk-body">You need verbal consent from {{ page.application.person.name }} to send an application for Short-Term Accommodation (CAS-2) on their behalf.</p>
+
+    <p class="govuk-body">Check that {{ page.application.person.name }} understands:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+      <li>
+        that CAS-2 provides short-term housing and weekly support
+      </li>
+      <li>
+        they are responsible for paying for CAS-2 accommodation and support
+      </li>
+      <li>
+        what will be in the application form, including legal and confidential information about address history, offences, risks to themselves and others and health needs
+      </li>
+      <li>
+        their health needs will be collected from relevant sources, such as the prison drug and alcohol provider, mental health in-reach team and healthcare team
+      </li>
+      <li>
+        their information will be used to assess their suitability and ensure their safety
+      </li>
+      <li>
+        they must leave the CAS-2 accommodation at the end of their HDC licence period, and find accommodation to move on to with their support worker's help
+      </li>
+    </ul>
+  </div>
+
+  {% set consentDateHtml %}
+  {{ 
+    formPageDateInput( {
+      hint: {
+        text: page.questions.consentDate.hint
+      },
+      fieldName: "consentDate",
+      fieldset: {
+        legend: {
+          text: page.questions.consentDate.question,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: dateFieldValues('consentDate', errors)
+      }, 
+      fetchContext()) 
+  }}
+  {% endset %}
+
+  {% set consentRefusalDetailHtml %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'consentRefusalDetail',
+          label: {
+            text: page.questions.consentRefusalDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "hasGivenConsent",
+        fieldset: {
+          legend: {
+            text: page.questions.hasGivenConsent.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: page.items(consentDateHtml, consentRefusalDetailHtml)
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}
+
+{% block button %}
+  {{ govukButton({
+      text: "Save and continue"
+    }) }}
+{% endblock %}

--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -1,8 +1,8 @@
 {% extends "../layout.njk" %}
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.title }}</span>
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-  <div class="govuk-inset-text">
+  <div>
     <p class="govuk-body">Check {{ page.application.person.name }} meets the requirements for Short-Term Accommodation (CAS-2).</p>
 
     <p class="govuk-body">The applicant must:</p>


### PR DESCRIPTION
# Context

[Trello ticket](https://trello.com/c/xBJboq8O/181-verbal-consent-form)

# Changes in this PR

This PR adds the 'Confirm consent' task to the 'Before you start' section, and ensures that users will be redirected from 'Confirm eligibility' to 'Confirm consent' without having to navigate via the task list. The code that does this, in `applicationsController`, is a bit unwieldy, so let me know if you can see any good opportunities to refactor it.

## Screenshots of UI changes

![Screenshot 2023-12-06 at 16 20 01](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/15a5c43a-9b5d-4346-bedc-a91ebadf1ec1)

![Screenshot 2023-12-06 at 16 20 25](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/72d27fd8-5353-4cf5-a4cb-0733ae659f52)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
