### PR TITLE
Add hint text to independent living question in physical health

### DIFF
--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -195,6 +195,20 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
+        hint: {
+            html: '
+                <div id="live-independently-details-hint" class="govuk-hint">
+                  <p class="govuk-hint">Someone can live independently if they can:</p>
+                  <ul class="govuk-list govuk-list--bullet govuk-hint">
+                    <li>cook for themselves</li>
+                    <li>clean for themselves</li>
+                    <li>manage their own personal hygiene</li>
+                    <li>shop for themselves</li>
+                    <li>manage their own medication</li>
+                  </ul>
+               </div>
+            '
+        },
         items: [
         {
           value: "yes",


### PR DESCRIPTION
Another go at adding hint text to specify what living independently means to the related question in physical health. 

[Trello ticket 702](https://trello.com/c/rbGwzD3y/702-content-tweak-physical-health-add-hint-text-to-can-they-live-independently)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
