### PR TITLE
Remove hint text from additional support question (tweak to 711)

### DIFF
--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -28,6 +28,9 @@
       <li>
         if a Home Detention Curfew (HDC) applicant, not be currently in prison having been recalled for failing to comply with HDC licence conditions
       </li>
+      <li>
+        be able to live independently. This means they are able to cook, clean and shop for themselves, and manage their own personal hygiene and medication
+      </li>
     </ul>
   </div>
 

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -244,13 +244,6 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
-         hint: {
-            html: '
-                <div id="addition-physical-support-hint" class="govuk-hint">
-                <p class="govuk-hint">State if they need a mobility scooter, stair lift, wet room, grip rails in the shower or bath, or wider door frames and ramps</p>
-               </div>
-                '
-                },
         items: [
         {
           value: "yes",

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -111,6 +111,13 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
+           hint: {
+            html: '
+                <div id="physical-health-needs-hint" class="govuk-hint">
+                <p class="govuk-hint">This includes needing a mobility scooter, stair lift, wet room, grip rails in the shower or bath, or wider door frames and ramps</p>
+               </div>
+                '
+                },
         items: [
         {
           value: "yes",
@@ -237,6 +244,13 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
+         hint: {
+            html: '
+                <div id="addition-physical-support-hint" class="govuk-hint">
+                <p class="govuk-hint">State if they need a mobility scooter, stair lift, wet room, grip rails in the shower or bath, or wider door frames and ramps</p>
+               </div>
+                '
+                },
         items: [
         {
           value: "yes",

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -195,6 +195,20 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
+        hint: {
+            html: '
+                <div id="live-independently-details-hint" class="govuk-hint">
+                <p class="govuk-hint">Someone can live independently if they can:</p>
+                <ul class="govuk-list govuk-list--bullet govuk-hint"> 
+                <li>cook for themselves</li>
+                <li>clean for themselves</li>
+                <li>manage their own personal hygiene</li>
+                <li>shop for themselves</li>
+                <li>manage their own medication</li>
+                </ul>
+               </div>
+                '
+                },
         items: [
         {
           value: "yes",


### PR DESCRIPTION
Remove hint text from additional support question in physical health (originally part of [this PR](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/356)) as no longer needed

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
