### PR TITLE
Use fieldset for working mobile phone page header

### DIFF
--- a/server/views/applications/pages/personal-information/working-mobile-phone.njk
+++ b/server/views/applications/pages/personal-information/working-mobile-phone.njk
@@ -1,8 +1,7 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% extends "../layout.njk" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">{{ page.questions.hasWorkingMobilePhone.question }}</h1>
-
   {% set smartphoneGuidanceHtml %}
     <p>A smart phone is a mobile phone that allows the user to browse the Web, send and receive e-mail, view audio and video files, play games, read e-books, and access other computer applications, as well as to make phone calls.</p>
   {% endset %}
@@ -55,30 +54,40 @@
 
   {% endset %}
 
-  {{
-    formPageRadios(
-      {
-        fieldName: "hasWorkingMobilePhone",
-        items: [
-          {
-            value: "yes",
-            text: "Yes",
-            conditional: { html: mobilePhoneDetailHtml }
-          },
-          {
-            value: "no",
-            text: "No"
-          },
-          {
-            divider: 'or'
-          },
-          {
-            value: "dontKnow",
-            text: "I don't know"
-          }
-        ]
-      },
-      fetchContext()
-    )
-  }}
+  {% call govukFieldset({
+    legend: {
+      text: page.questions.hasWorkingMobilePhone.question,
+      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6",
+      isPageHeading: true
+    }
+  }) %}
+
+    {{
+      formPageRadios(
+        {
+          fieldName: "hasWorkingMobilePhone",
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              conditional: { html: mobilePhoneDetailHtml }
+            },
+            {
+              value: "no",
+              text: "No"
+            },
+            {
+              divider: 'or'
+            },
+            {
+              value: "dontKnow",
+              text: "I don't know"
+            }
+          ]
+        },
+        fetchContext()
+      )
+    }}
+
+  {% endcall %}
 {% endblock %}


### PR DESCRIPTION
# Context
We want to be able to e2e test this page. As there are two identical
radio inputs with the "Yes" label, we want a way to differentiate
between the two.

We do this by using the page heading as the fieldset `legend`, to
associate the heading with the form.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![Screenshot 2023-12-12 at 11 18 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/3ba0256b-dbd3-4ef4-8649-910c6d38e4ba)

### After (no change)
![Screenshot 2023-12-12 at 11 18 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/7dfc8b94-03be-4537-bbee-2bcb8debc356)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
