### PR TITLE
(456) Provide options for immigration status page 

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -54,7 +54,7 @@
       "isSmartPhone": "yes"
     },
     "immigration-status": {
-      "immigrationStatus": "British"
+      "immigrationStatus": "UK citizen"
     }
   },
   "address-history": {

--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -97,7 +97,7 @@
             },
             {
               "question": "What is Aadland Bertrand immigration status?",
-              "answer": "British"
+              "answer": "UK citizen"
             }
           ]
         },

--- a/integration_tests/pages/apply/about_the_person/personal_information/immigrationStatusPage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/immigrationStatusPage.ts
@@ -24,6 +24,6 @@ export default class ImmigrationStatusPage extends ApplyPage {
   }
 
   completeForm(): void {
-    this.getTextInputByIdAndEnterDetails('immigrationStatus', 'British')
+    this.getSelectInputByIdAndSelectAnEntry('immigrationStatus', 'UK citizen')
   }
 }

--- a/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.test.ts
@@ -22,11 +22,11 @@ describe('ImmigrationStatus', () => {
   })
 
   describe('errors', () => {
-    it('returns an error if immigrationStatus is not set', () => {
-      const page = new ImmigrationStatus({ immigrationStatus: null }, application)
+    it('returns an error if immigrationStatus is not selected', () => {
+      const page = new ImmigrationStatus({ immigrationStatus: 'choose' }, application)
 
       expect(page.errors()).toEqual({
-        immigrationStatus: 'Enter the immigration status',
+        immigrationStatus: 'Select their immigration status',
       })
     })
   })

--- a/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.ts
@@ -1,5 +1,5 @@
 import { Cas2Application as Application } from '@approved-premises/api'
-import { TaskListErrors } from '@approved-premises/ui'
+import { SelectItem, TaskListErrors } from '@approved-premises/ui'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
@@ -24,11 +24,34 @@ export default class ImmigrationStatus implements TaskListPage {
 
   body: ImmigrationStatusBody
 
+  immigrationStatusSelectItems: Array<SelectItem>
+
   constructor(
     body: Partial<ImmigrationStatusBody>,
     private readonly application: Application,
   ) {
     this.body = body as ImmigrationStatusBody
+    this.immigrationStatusSelectItems = this.getImmigrationStatusAsItemsForSelect(this.body.immigrationStatus)
+  }
+
+  private getImmigrationStatusAsItemsForSelect(selectedItem: string): Array<SelectItem> {
+    const items = [
+      {
+        value: 'choose',
+        text: 'Select immigration status',
+        selected: selectedItem === '',
+      },
+    ]
+
+    Object.keys(this.questions.immigrationStatus.answers).forEach(value => {
+      items.push({
+        value,
+        text: this.questions.immigrationStatus.answers[value] as string,
+        selected: selectedItem === value,
+      })
+    })
+
+    return items
   }
 
   previous() {
@@ -42,8 +65,8 @@ export default class ImmigrationStatus implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (!this.body.immigrationStatus) {
-      errors.immigrationStatus = 'Enter the immigration status'
+    if (this.body.immigrationStatus === 'choose') {
+      errors.immigrationStatus = 'Select their immigration status'
     }
 
     return errors

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -64,7 +64,20 @@ export const getQuestions = (name: string) => {
       'immigration-status': {
         immigrationStatus: {
           question: `What is ${name}'s immigration status?`,
-          hint: 'For example, British',
+          hint: 'Select their immigration status',
+          answers: {
+            ukCitizen: 'UK citizen',
+            leaveToRemain: 'Leave to remain',
+            indefiniteLeaveToRemain: 'Indefinite leave to remain',
+            discretionaryLeaveToRemain: 'Discretionary leave to remain',
+            eeaNational: 'EEA national',
+            refugee: 'Refugee',
+            asylumSeekerAwaitingDecision: 'Asylum seeker awaiting decision',
+            spousePartnerSponsorship: 'Spouse or partner sponsorship',
+            workVisa: 'Work visa',
+            studyVisa: 'Study visa',
+            notKnown: 'Not known',
+          },
         },
       },
     },

--- a/server/views/applications/pages/personal-information/immigration-status.njk
+++ b/server/views/applications/pages/personal-information/immigration-status.njk
@@ -1,23 +1,29 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% extends "../layout.njk" %}
 
 {% block questions %}
 
+  {% call govukFieldset({
+    legend: {
+      text: page.questions.immigrationStatus.question,
+      classes: "govuk-fieldset__legend--l",
+      isPageHeading: true
+    }
+  })%}
+
     {{
-      formPageInput(
-        {
-          fieldName: "immigrationStatus",
-          label: {
-            text: page.questions.immigrationStatus.question,
-            isPageHeading: true,
-            classes: "govuk-label--l"
-          },
-          hint: {
-            text: page.questions.immigrationStatus.hint
-          },
-          classes: "govuk-!-width-one-third"
+      govukSelect({
+        hint: {
+          text: page.questions.immigrationStatus.hint
         },
-        fetchContext()
-      )
+        id: "immigrationStatus",
+        name: "immigrationStatus",
+        items: page.immigrationStatusSelectItems,
+        errorMessage: errors.immigrationStatus
+      })
     }}
+
+  {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
# Context
We want referrers to easily choose an applicant's immigration status by
providing pre-determined options.

## Screenshots of UI changes

### Before
![Screenshot 2023-12-12 at 14 38 46](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/0ce0e25e-a04f-4da7-bc50-6f520a24ef21)

### After
![Screenshot 2023-12-12 at 14 48 53](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/90e82e32-bb14-4b6a-9450-c0eb2730fb7c)
![image](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/a439868b-bdb2-425a-aede-0688f593b2b6)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
