### PR TITLE
Change offence example in guidance to one eligible for HDC licence

### DIFF
--- a/server/views/applications/pages/current-offences/current-offence-data.njk
+++ b/server/views/applications/pages/current-offences/current-offence-data.njk
@@ -28,7 +28,7 @@
       {{ showErrorSummary(errorSummary) }}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
-        <p>Add one offence at a time. For example, you should record 3 sexual harassment offences as 3 separate offences.</p>
+        <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>
       </div>
 
       <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">

--- a/server/views/applications/pages/offending-history/offence-history-data.njk
+++ b/server/views/applications/pages/offending-history/offence-history-data.njk
@@ -19,7 +19,7 @@
               <li>information related to a pattern of behaviour</li>
             </ul>
         <p>
-        <p>Add one offence at a time. For example, you should record 3 sexual harassment offences as 3 separate offences.</p>
+        <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>
         <hr class="govuk-section-break govuk-section-break--m">
 
         <h2 class="govuk-heading-m">Check the offence is not spent</h2>   


### PR DESCRIPTION
Change the example of the types of offences the user needs to record separate from sexual harassment to drug-related as sexual harassment offences would make someone ineligible for Home Detention Curfew (HDC) licence (and the service at present).

[Trello ticket 728](https://trello.com/c/ZI6aEpVv/728-content-change-the-prompt-for-the-add-one-offence-to-one-that-isnt-sexual-harassment-to-an-offence-that-is-eligible-for-hdc)

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
