### PR TITLE
Render applicant details on application

### DIFF
--- a/integration_tests/pages/apply/confirmApplicantPage.ts
+++ b/integration_tests/pages/apply/confirmApplicantPage.ts
@@ -13,7 +13,7 @@ export default class ConfirmApplicantPage extends Page {
     cy.get('.govuk-error-summary').contains('There was an error creating the application, please try again')
   }
 
-  hasApplicantDetails = (applicant: FullPerson): void => {
+  hasApplicantInformation = (applicant: FullPerson): void => {
     const expectedApplicantData = [
       ['Full name', applicant.name],
       ['Date of birth', DateFormats.isoDateToUIDate(applicant.dateOfBirth, { format: 'short' })],

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,6 +1,9 @@
 import { ApplicationDocument } from '@approved-premises/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
+import { Cas2Application } from '../../server/@types/shared/models/Cas2Application'
+import { Cas2SubmittedApplication } from '../../server/@types/shared/models/Cas2SubmittedApplication'
+import { FullPerson } from '../../server/@types/shared/models/FullPerson'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -134,5 +137,27 @@ export default abstract class Page {
     this.clickPrintButton()
 
     cy.get('@printStub').should('be.calledOnce')
+  }
+
+  hasApplicantDetails(application: Cas2Application | Cas2SubmittedApplication): void {
+    const person = application.person as FullPerson
+    cy.get(`[data-cy-check-your-answers-section="applicant-details"]`).within(() => {
+      this.checkTermAndDescription('Full name', person.name)
+      this.checkTermAndDescription(
+        'Date of birth',
+        DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+      )
+      this.checkTermAndDescription('Nationality', person.nationality)
+      this.checkTermAndDescription('Sex', person.sex)
+      this.checkTermAndDescription('Prison number', person.nomsNumber)
+      cy.get('dt')
+        .contains(/Prison $/)
+        .parent()
+        .within(() => {
+          cy.get('dd').invoke('text').should('contain', person.prisonName)
+        })
+      this.checkTermAndDescription('PNC number', person.pncNumber)
+      this.checkTermAndDescription('NDelius CRN number', person.crn)
+    })
   }
 }

--- a/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
+++ b/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
@@ -48,6 +48,7 @@ context('Check your answers page', () => {
     const page = Page.verifyOnPage(CheckYourAnswersPage, this.application)
 
     //  Then I see a list of questions and answers for the application
+    page.hasApplicantDetails(this.application)
     page.shouldShowConfirmEligibilityAnswers()
     page.shouldShowFundingInformationAnswers()
     page.shouldShowEqualityAndDiversityAnswers()

--- a/integration_tests/tests/apply/confirm_applicant_details.cy.ts
+++ b/integration_tests/tests/apply/confirm_applicant_details.cy.ts
@@ -49,7 +49,7 @@ context('Find by prison number', () => {
     prisonNumberPage.clickSubmit()
 
     const confirmationPage = Page.verifyOnPage(ConfirmApplicantPage, person.name)
-    confirmationPage.hasApplicantDetails(person)
+    confirmationPage.hasApplicantInformation(person)
 
     //  When I confirm these are the correct detaiks
 

--- a/integration_tests/tests/apply/view_submitted_application_as_referrer.cy.ts
+++ b/integration_tests/tests/apply/view_submitted_application_as_referrer.cy.ts
@@ -44,6 +44,7 @@ context('View submitted application', () => {
     const submittedApplicationPage = SubmissionPage.visit(this.application)
     //  Then I should see the read-only version of the answers submitted
     submittedApplicationPage.hasExpectedSummaryData()
+    submittedApplicationPage.hasApplicantDetails(this.application)
     submittedApplicationPage.hasQuestionsAndAnswersFromDocument(this.application.document)
 
     //  And I see a print button

--- a/integration_tests/tests/assess/view_submitted_application.cy.ts
+++ b/integration_tests/tests/assess/view_submitted_application.cy.ts
@@ -60,6 +60,7 @@ context('Assessor views submitted application', () => {
     Page.verifyOnPage(SubmittedApplicationPage, this.submittedApplication)
     const page = new SubmittedApplicationPage(this.submittedApplication)
     page.hasExpectedSummaryData()
+    page.hasApplicantDetails(this.submittedApplication)
     page.hasQuestionsAndAnswersFromDocument(this.submittedApplication.document)
 
     //  And I see a print button

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -1,4 +1,4 @@
-import { Cas2Application as Application } from '@approved-premises/api'
+import { Cas2Application as Application, Cas2SubmittedApplication, FullPerson } from '@approved-premises/api'
 import { SummaryListItem, FormSection, QuestionAndAnswer } from '@approved-premises/ui'
 import Apply from '../form-pages/apply/index'
 import CheckYourAnswers from '../form-pages/apply/check-your-answers'
@@ -8,6 +8,7 @@ import { nameOrPlaceholderCopy } from './utils'
 import { formatLines } from './viewUtils'
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
 import { UnknownPageError } from './errors'
+import { DateFormats } from './dateUtils'
 
 export const checkYourAnswersSections = (application: Application) => {
   const sections = getSections()
@@ -207,4 +208,76 @@ export const getPage = (taskName: string, pageName: string): TaskListPageInterfa
   }
 
   return Page as TaskListPageInterface
+}
+
+export const getApplicantDetails = (application: Application | Cas2SubmittedApplication): Array<SummaryListItem> => {
+  const { crn, nomsNumber, pncNumber, name, dateOfBirth, nationality, sex, prisonName } =
+    application.person as FullPerson
+
+  return [
+    {
+      key: {
+        text: 'Full name',
+      },
+      value: {
+        html: name,
+      },
+    },
+    {
+      key: {
+        text: 'Date of birth',
+      },
+      value: {
+        html: DateFormats.isoDateToUIDate(dateOfBirth, { format: 'short' }),
+      },
+    },
+    {
+      key: {
+        text: 'Nationality',
+      },
+      value: {
+        html: nationality,
+      },
+    },
+    {
+      key: {
+        text: 'Sex',
+      },
+      value: {
+        html: sex,
+      },
+    },
+    {
+      key: {
+        text: 'Prison number',
+      },
+      value: {
+        html: nomsNumber,
+      },
+    },
+    {
+      key: {
+        text: 'Prison',
+      },
+      value: {
+        html: prisonName,
+      },
+    },
+    {
+      key: {
+        text: 'PNC number',
+      },
+      value: {
+        html: pncNumber,
+      },
+    },
+    {
+      key: {
+        text: 'NDelius CRN number',
+      },
+      value: {
+        html: crn,
+      },
+    },
+  ]
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -18,7 +18,7 @@ import {
 import * as TaskListUtils from './taskListUtils'
 import * as OasysImportUtils from './oasysImportUtils'
 import { dateFieldValues } from './formUtils'
-import { checkYourAnswersSections } from './checkYourAnswersUtils'
+import { checkYourAnswersSections, getApplicantDetails } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
 import { getApplicationTimelineEvents } from './applications/utils'
 import { applicationStatusRadios } from './assessUtils'
@@ -91,6 +91,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
 
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
+  njkEnv.addGlobal('getApplicantDetails', getApplicantDetails)
 
   njkEnv.addGlobal('getApplicationTimelineEvents', getApplicationTimelineEvents)
   njkEnv.addGlobal('applicationStatusRadios', applicationStatusRadios)

--- a/server/views/applications/pages/check-your-answers/check-your-answers.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% from "../../../partials/applicantDetails.njk" import applicantDetails %}
+
 {% extends "../layout.njk" %}
 
 {% set mainClasses = "app-container govuk-body" %}
@@ -19,6 +21,8 @@
       <h1 class="govuk-heading-xl">
         {{ page.title }}
       </h1>
+
+      {{ applicantDetails(page.application) }}
 
       {% for section in checkYourAnswersSections(page.application) %}
         <h2 class="govuk-heading-l">{{ section.title }}</h2>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% from "../partials/documentSummaryList.njk" import documentSummaryList %}
+{% from "../partials/applicantDetails.njk" import applicantDetails %}
 {% from "../components/printButton/macro.njk" import printButtonScript,
 printButton %}
 
@@ -43,6 +44,8 @@ printButton %}
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      {{ applicantDetails(application) }}
 
       {% if application.document.sections | length %}
         {{ documentSummaryList(application) }}

--- a/server/views/assess/applications/show.njk
+++ b/server/views/assess/applications/show.njk
@@ -4,6 +4,7 @@
 
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/documentSummaryList.njk" import documentSummaryList %}
+{% from "../../partials/applicantDetails.njk" import applicantDetails %}
 {% from "../../components/printButton/macro.njk" import printButtonScript,
 printButton %}
 
@@ -60,6 +61,8 @@ printButton %}
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      {{ applicantDetails(application) }}
 
       {% if application.document.sections | length %}
         {{ documentSummaryList(application) }}

--- a/server/views/partials/applicantDetails.njk
+++ b/server/views/partials/applicantDetails.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro applicantDetails(application) %}
+
+  <div class="main-box" data-cy-check-your-answers-section="applicant-details">
+    <div class="box-content">
+      {{
+        govukSummaryList({
+          card: {
+            title: {
+              text: "Applicant details"
+            }
+          },
+          rows: getApplicantDetails(application)
+        })
+      }}
+    </div>
+  </div>
+
+{% endmacro %}


### PR DESCRIPTION
# Context

This is a reduced version of this PR https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/360 

With just the code to render the person details on CYA and submitted applications. 

![290186781-0ef8cdd4-db00-4f7e-884e-a4eb3b0d600c](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/771d79da-dff6-4f13-8c5b-6aa583659683)

Note:
When we first confirm the applicant details on the API we use the `nomsNumber` to make a call to `probation-offender-search` and show the person's details
Subsequent calls to get the Person are via the community api, which might not necessarily have the same or all the data, hence some missing fields (pnc and nationality) locally for Aadland. We'll have to do some API work to prevent this.


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
