### PR TITLE
MI user downloads "report" spreadsheet of metrics

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -25,3 +25,14 @@ export declare global {
     }
   }
 }
+
+declare module 'express' {
+  interface TypedRequest<T extends Query, U = Body> extends Express.Request {
+    body: U
+    params: T
+  }
+
+  interface TypedRequestHandler<T, U = Response> extends Express.RequestHandler {
+    (req: T, res: U, next: () => void): void
+  }
+}

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -7,17 +7,20 @@ import PeopleController from './peopleController'
 import SubmittedApplicationsController from './assess/submittedApplicationsController'
 import StatusUpdateController from './assess/statusUpdateController'
 import DashboardController from './dashboardController'
+import ReportsController from './report/reportsController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
   const peopleController = new PeopleController(services.applicationService, services.personService)
   const submittedApplicationsController = new SubmittedApplicationsController(services.submittedApplicationService)
   const statusUpdateController = new StatusUpdateController(services.submittedApplicationService)
+  const reportController = new ReportsController(services.reportService)
   return {
     dashboardController,
     submittedApplicationsController,
     statusUpdateController,
     peopleController,
+    reportController,
     ...applyControllers(services),
   }
 }

--- a/server/controllers/report/reportsController.test.ts
+++ b/server/controllers/report/reportsController.test.ts
@@ -1,0 +1,68 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import ReportsController from './reportsController'
+
+import ReportService from '../../services/reportService'
+import paths from '../../paths/report'
+
+jest.mock('../../utils/validation')
+
+describe('reportsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const reportService = createMock<ReportService>({})
+
+  let reportsController: ReportsController
+
+  beforeEach(() => {
+    reportsController = new ReportsController(reportService)
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    jest.clearAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the template', async () => {
+      const applicationId = 'some-id'
+
+      request.params.id = applicationId
+
+      const requestHandler = reportsController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('reports/new', {})
+    })
+  })
+
+  describe('create', () => {
+    const applicationId = 'some-id'
+
+    beforeEach(() => {
+      request.params.id = applicationId
+    })
+
+    it('calls the service method to download the report', async () => {
+      const requestHandler = reportsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(reportService.getReport).toHaveBeenCalledWith(token, response)
+    })
+
+    it('redirects back to new if there is an error', async () => {
+      ;(reportService.getReport as jest.Mock).mockRejectedValue(new Error())
+
+      const requestHandler = reportsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(paths.report.new({}))
+    })
+  })
+})

--- a/server/controllers/report/reportsController.ts
+++ b/server/controllers/report/reportsController.ts
@@ -1,0 +1,23 @@
+import { Request, RequestHandler, Response, TypedRequestHandler } from 'express'
+import paths from '../../paths/report'
+import ReportService from '../../services/reportService'
+
+export default class ReportsController {
+  constructor(private readonly reportsService: ReportService) {}
+
+  new(): RequestHandler {
+    return async (_req: Request, res: Response) => {
+      return res.render('reports/new', {})
+    }
+  }
+
+  create(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      try {
+        return await this.reportsService.getReport(req.user.token, res)
+      } catch (error) {
+        return res.redirect(paths.report.new({}))
+      }
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ buildAppInsightsClient()
 import HmppsAuthClient from './hmppsAuthClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
+import ReportClient from './reportClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -27,6 +28,7 @@ export const dataAccess = () => ({
   submittedApplicationClient: ((token: string) =>
     new SubmittedApplicationClient(token)) as RestClientBuilder<SubmittedApplicationClient>,
   referenceDataClient: ((token: string) => new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
+  reportClient: ((token: string) => new ReportClient(token)) as RestClientBuilder<ReportClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -1,0 +1,46 @@
+import { Response } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+
+import ReportClient from './reportClient'
+import paths from '../paths/api'
+
+import describeClient from '../testutils/describeClient'
+
+describeClient('ReportClient', provider => {
+  let client: ReportClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    client = new ReportClient(token)
+  })
+
+  describe('getReport', () => {
+    it('should pipe the report from the API', async () => {
+      const response = createMock<Response>({})
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get application reports ',
+        withRequest: {
+          method: 'GET',
+          path: paths.reports.exampleReport({}),
+          query: {},
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await client.getReport(response)
+
+      expect(response.set).toHaveBeenCalledWith(
+        'Content-Disposition',
+        `attachment; filename="cas2-example-report.xlsx"`,
+      )
+    })
+  })
+})

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -1,0 +1,26 @@
+import type { Response } from 'express'
+
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+import paths from '../paths/api'
+
+export default class ReportClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('reportClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async getReport(response: Response): Promise<void> {
+    const filename = `cas2-example-report.xlsx`
+    response.set('Content-Disposition', `attachment; filename="${filename}"`)
+
+    await this.restClient.pipe(
+      {
+        path: paths.reports.exampleReport({}),
+      },
+      response,
+    )
+  }
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -8,6 +8,7 @@ const singleApplicationPath = applicationsPath.path(':id')
 const submissionsPath = path('/cas2/submissions')
 const singleSubmissionPath = submissionsPath.path(':id')
 const referenceDataPath = path('/cas2/reference-data')
+const reportsPath = path('/cas2/reports')
 
 export default {
   people: {
@@ -36,5 +37,8 @@ export default {
   },
   applicationStatusUpdates: {
     create: singleSubmissionPath.path('status-updates'),
+  },
+  reports: {
+    exampleReport: reportsPath.path('example-report'),
   },
 }

--- a/server/paths/report.ts
+++ b/server/paths/report.ts
@@ -1,0 +1,10 @@
+import { path } from 'static-path'
+
+const reportPath = path('/reports')
+
+export default {
+  report: {
+    new: reportPath,
+    create: reportPath.path('download'),
+  },
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import { actions } from './utils'
 import paths from '../paths/apply'
 import applyRoutes from './apply'
 import assessRoutes from './assess'
+import reportRoutes from './report'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(controllers: Controllers, services: Services): Router {
@@ -26,6 +27,7 @@ export default function routes(controllers: Controllers, services: Services): Ro
 
   applyRoutes(controllers, router, services)
   assessRoutes(controllers, router, services)
+  reportRoutes(controllers, router, services)
 
   return router
 }

--- a/server/routes/report.ts
+++ b/server/routes/report.ts
@@ -1,0 +1,23 @@
+/* istanbul ignore file */
+
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import paths from '../paths/report'
+import { Services } from '../services'
+import { actions } from './utils'
+
+export default function reportRoutes(controllers: Controllers, router: Router, services: Services): Router {
+  const { get } = actions(router, services.auditService)
+
+  const { reportController } = controllers
+
+  get(paths.report.new.pattern, reportController.new(), {
+    auditEvent: 'LIST_REPORTS',
+  })
+  get(paths.report.create.pattern, reportController.create(), {
+    auditEvent: 'DOWNLOAD_REPORT',
+  })
+
+  return router
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -9,16 +9,24 @@ import SubmittedApplicationService from './submittedApplicationService'
 import TaskListService from './taskListService'
 import AuditService from './auditService'
 import config from '../config'
+import ReportService from './reportService'
 
 export const services = () => {
-  const { hmppsAuthClient, personClient, applicationClient, submittedApplicationClient, referenceDataClient } =
-    dataAccess()
+  const {
+    hmppsAuthClient,
+    personClient,
+    applicationClient,
+    submittedApplicationClient,
+    referenceDataClient,
+    reportClient,
+  } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
   const personService = new PersonService(personClient)
   const applicationService = new ApplicationService(applicationClient)
   const submittedApplicationService = new SubmittedApplicationService(submittedApplicationClient, referenceDataClient)
   const auditService = new AuditService(config.apis.audit)
+  const reportService = new ReportService(reportClient)
 
   return {
     userService,
@@ -26,6 +34,7 @@ export const services = () => {
     applicationService,
     submittedApplicationService,
     auditService,
+    reportService,
   }
 }
 

--- a/server/services/reportService.test.ts
+++ b/server/services/reportService.test.ts
@@ -1,0 +1,29 @@
+import { Response } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+
+import ReportClient from '../data/reportClient'
+import ReportService from './reportService'
+
+describe('ReportService', () => {
+  const reportClient = new ReportClient(null) as jest.Mocked<ReportClient>
+  const reportClientFactory = jest.fn()
+
+  const service = new ReportService(reportClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    reportClientFactory.mockReturnValue(reportClient)
+  })
+
+  describe('getReport', () => {
+    it('calls the getReport API client method', () => {
+      const response = createMock<Response>({})
+      service.getReport(token, response).then(() => {
+        expect(reportClientFactory).toHaveBeenCalledWith(token)
+        expect(reportClient.getReport).toHaveBeenCalledWith(response)
+      })
+    })
+  })
+})

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -1,0 +1,15 @@
+import type { Response } from 'express'
+
+import type { RestClientBuilder } from '../data'
+
+import ReportClient from '../data/reportClient'
+
+export default class ReportService {
+  constructor(private readonly reportClientFactory: RestClientBuilder<ReportClient>) {}
+
+  async getReport(token: string, response: Response): Promise<void> {
+    const client = this.reportClientFactory(token)
+
+    return client.getReport(response)
+  }
+}

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -39,6 +39,7 @@ expect.extend({
           sed -E 's@/applications@/cas2/applications@g' |
           sed -E 's@/submissions@/cas2/submissions@g' |
           sed -E 's@/people@/cas2/people@g' |
+          sed -E 's@/reports@/cas2/reports@g' |
           sed -E 's@/reference-data/@/cas2/reference-data/@g' > ${openAPIPath}
         fi
       `)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,6 +8,7 @@ import express from 'express'
 import { PersonStatus, ErrorMessages } from '@approved-premises/ui'
 import applicationPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
+import reportPaths from '../paths/report'
 import config from '../config'
 import { initialiseName, removeBlankSummaryListItems } from './utils'
 import {
@@ -70,7 +71,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('OasysImportUtils', OasysImportUtils)
 
-  njkEnv.addGlobal('paths', { ...applicationPaths, ...assessPaths })
+  njkEnv.addGlobal('paths', { ...applicationPaths, ...assessPaths, ...reportPaths })
   njkEnv.addGlobal('TaskListUtils', TaskListUtils)
 
   njkEnv.addGlobal('inProgressApplicationTableRows', inProgressApplicationTableRows)

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -1,0 +1,20 @@
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <h1 class="govuk-heading-l">Reports</h1>
+  <p>Download a report</p>
+
+  {% block button %}
+    <div class="govuk-button-group">
+      {{ govukButton({
+              text: "Download report",
+              href: paths.report.create()
+      }) }}
+    </div>
+  {% endblock %}
+</div>
+{% endblock %}


### PR DESCRIPTION
# Context

[Trello 719](https://trello.com/c/0HPZIytR/719-placeholder-mi-view-for-ithc)

This PR provides an initial user-interface to download a "report" of management information. The download is in `.xlsx` format and is only available to users with the `CAS2_MI` role. It's exposed via the `/reports` url.

The report itself is an example placeholder report `cas2-example-report.xlsx`.

The purpose of this work is to implement the framework for providing downloadable spreadsheets to users.

Note that the authorisation control is implemented at the API. i.e. a user without the required role can navigate to `/reports` and attempt to "Download report". They will receive a 403 Forbidden response. In the future we *may* implement authorisation controls in the UI to prevent the `/reports` url from being accessed.

## Screenshot

![mi_reports_to_download](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/c9686088-5fbc-4574-aedc-883ce5f96251)


# To do

This work is required for the ITHC to verify that the correct authorisation controls are in place (only users with the `CAS2_MI` role can download). The following are missing and will be added later as we implement the real reports:

- integration tests
- end-to-end tests in Playwright

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [x] If you've added a new route, have you added a new -> Yes, done
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [x] Does this rely on changes being deployed to the CAS API? - Yes, we need to merge [API PR 1255](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1255)


