### PR TITLE
turn on error handling in environments that are not dev/local

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -60,7 +60,8 @@ export default function createApp(controllers: Controllers, services: Services):
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   setUpSentryErrorHandler(app)
-  app.use(errorHandler(process.env.NODE_ENV === 'production'))
+
+  app.use(errorHandler(process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test'))
 
   return app
 }

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest'
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
 
-const setupApp = (production: boolean): Express => {
+const setupApp = (isDevelopment: boolean): Express => {
   const app = express()
   app.set('view engine', 'njk')
 
@@ -16,7 +16,7 @@ const setupApp = (production: boolean): Express => {
     res.send('known')
   })
   app.use((req, res, next) => next(createError(404, 'Not found')))
-  app.use(errorHandler(production))
+  app.use(errorHandler(isDevelopment))
 
   return app
 }
@@ -27,7 +27,7 @@ afterEach(() => {
 
 describe('GET 404', () => {
   it('should render content with stack in dev mode', () => {
-    const app = setupApp(false)
+    const app = setupApp(true)
 
     return request(app)
       .get('/unknown')
@@ -40,7 +40,7 @@ describe('GET 404', () => {
   })
 
   it('should render content without stack in production mode', () => {
-    const app = setupApp(true)
+    const app = setupApp(false)
 
     return request(app)
       .get('/unknown')

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -4,7 +4,7 @@ import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
 
-export default function createErrorHandler(production: boolean) {
+export default function createErrorHandler(isDevelopment: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
 
@@ -13,11 +13,11 @@ export default function createErrorHandler(production: boolean) {
       return res.redirect('/sign-out')
     }
 
-    res.locals.message = production
-      ? 'Something went wrong. The error has been logged. Please try again'
-      : error.message
+    res.locals.message = isDevelopment
+      ? error.message
+      : 'Something went wrong. The error has been logged. Please try again'
     res.locals.status = error.status
-    res.locals.stack = production ? null : error.stack
+    res.locals.stack = isDevelopment ? error.stack : null
 
     res.status(error.status || 500)
 


### PR DESCRIPTION
We want the error handling as close as possible to prod in our test environment, this ensures that error messages and stack traces are shared in environments that are NOT test or production.


https://trello.com/c/nsMHl851/667-tech-task-turn-on-error-handling-in-preprod-and-test