### PR TITLE
(685) Add confirmation checkbox to check your answers page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -349,7 +349,7 @@
   },
   "check-your-answers": {
     "check-your-answers": {
-      "reviewed": "1"
+      "checkYourAnswers": "confirmed"
     }
   }
 }

--- a/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
+++ b/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
@@ -17,6 +17,7 @@ context('Check your answers page', () => {
     cy.task('stubAuthUser')
 
     cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['check-your-answers']['check-your-answers']
       const application = applicationFactory.build({
         id: 'abc123',
         person,
@@ -56,5 +57,26 @@ context('Check your answers page', () => {
     page.shouldShowRiskToSelfAnswers()
     page.shouldShowRoshAnswers()
     page.shouldShowOffendingHistoryAnswers()
+  })
+
+  //  Scenario: check my answers
+  //  When I view the 'check your answers' page
+  //  And I confirm the information is correct
+  //  Then I am taken to the task list page
+  it('navigates to the task list page once the referrer confirms details are correct', function test() {
+    //  When I view the 'check your answers' page
+    TaskListPage.visit(this.application)
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.visitTask('Check your answers')
+    const page = Page.verifyOnPage(CheckYourAnswersPage, this.application)
+
+    //  When I confirm the information is correct
+    page.checkCheckboxByValue('confirmed')
+
+    //  When I continue to the next task / page
+    page.clickSubmit()
+
+    //  Then I am taken to the task list page
+    Page.verifyOnPage(TaskListPage, this.application)
   })
 })

--- a/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.test.ts
+++ b/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.test.ts
@@ -7,7 +7,7 @@ describe('CheckYourAnswers', () => {
   const application = applicationFactory.build({})
 
   const body = {
-    reviewed: '1',
+    checkYourAnswers: 'confirmed',
   }
 
   describe('body', () => {
@@ -22,10 +22,13 @@ describe('CheckYourAnswers', () => {
   itShouldHavePreviousValue(new CheckYourAnswers(body, application), 'dashboard')
 
   describe('errors', () => {
-    it('should return an empty object', () => {
+    it('should return an error when page has not been reviewed', () => {
       const page = new CheckYourAnswers({}, application)
 
-      expect(page.errors()).toEqual({})
+      expect(page.errors()).toEqual({
+        checkYourAnswers:
+          'You must confirm the information provided is accurate and, where required, it has been verified by all relevant prison departments.',
+      })
     })
   })
 })

--- a/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.ts
+++ b/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.ts
@@ -4,14 +4,18 @@ import { Page } from '../../../utils/decorators'
 
 import TaskListPage from '../../../taskListPage'
 
-@Page({ name: 'check-your-answers', bodyProperties: ['reviewed'] })
+type CheckYourAnswersBody = {
+  checkYourAnswers?: string
+}
+
+@Page({ name: 'check-your-answers', bodyProperties: ['checkYourAnswers'] })
 export default class CheckYourAnswers implements TaskListPage {
   documentTitle = 'Check your answers'
 
   title = 'Check your answers'
 
   constructor(
-    public body: { reviewed?: string },
+    public body: Partial<CheckYourAnswersBody>,
     readonly application: Application,
   ) {}
 
@@ -25,6 +29,11 @@ export default class CheckYourAnswers implements TaskListPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
+
+    if (this.body?.checkYourAnswers !== 'confirmed') {
+      errors.checkYourAnswers =
+        'You must confirm the information provided is accurate and, where required, it has been verified by all relevant prison departments.'
+    }
 
     return errors
   }

--- a/server/views/applications/pages/check-your-answers/check-your-answers.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers.njk
@@ -1,8 +1,10 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
 
 {% from "../../../partials/applicantDetails.njk" import applicantDetails %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../layout.njk" %}
 
@@ -18,6 +20,9 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
+
+      {{ showErrorSummary(errorSummary) }}
+
       <h1 class="govuk-heading-xl">
         {{ page.title }}
       </h1>
@@ -44,13 +49,32 @@
         {% endfor %}
       {% endfor %}
 
-      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post" class="govuk-!-margin-top-8">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        <input type="hidden" name="reviewed" value="1"/>
+        {{
+          formPageCheckboxes(
+            {
+              fieldName: "checkYourAnswers",
+              fieldset: {
+                legend: {
+                  text: "Confirm your answers",
+                  classes: "govuk-fieldset__legend--l"
+                }
+              },
+              items: [
+                {
+                  value: "confirmed",
+                  text: "I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments."
+                }
+              ]
+            },
+            fetchContext()
+          )
+        }}
 
         {{ govukButton({
-          text: "Continue",
+          text: "Save and continue",
           preventDoubleClick: true
         }) }}
       </form>


### PR DESCRIPTION
# Context
In another PR the checkbox was removed from the task list page[1].

This piece of work adds it to the check your answers page and requires the referrer to check the box before marking as complete.

[1]
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/378

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Screenshots of UI changes

### Before
![Screenshot 2023-12-18 at 16 54 14](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/77fcaeca-41cc-47ee-947e-95cb441b3809)

### After
![image](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/2c9b2574-5116-43dd-9892-31f59e1945dd)

#### Save and continue without confirming
![image](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/431ebff7-e83b-49ca-a1c8-b321f5345560)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
