### PR TITLE
Add outstanding charge eligibility criterion and tweak outstanding charge question

### DIFF
--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -773,7 +773,7 @@ export const getQuestions = (name: string) => {
           hint: offenceSummaryHintHtml,
         },
         outstandingCharges: {
-          question: `Are there any outstanding charges?`,
+          question: `Are there outstanding charges committed prior to the current sentence?`,
           answers: yesOrNo,
         },
         outstandingChargesDetail: {

--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -25,11 +25,14 @@
       <li>
         not have the ‘no recourse to public funds’ (NRPF) condition applied to their permission to enter or remain in the UK
       </li>
+       <li>
+        be able to live independently. This means they are able to cook, clean and shop for themselves, and manage their own personal hygiene and medication
+      </li>
       <li>
         if a Home Detention Curfew (HDC) applicant, not be currently in prison having been recalled for failing to comply with HDC licence conditions
       </li>
       <li>
-        be able to live independently. This means they are able to cook, clean and shop for themselves, and manage their own personal hygiene and medication
+        if a Home Detention Curfew (HDC) applicant, not have an outstanding charge related to an offence committed during their current sentence. This would make them ineligible for HDC and CAS-2
       </li>
     </ul>
   </div>


### PR DESCRIPTION
1. Add outstanding charge committed during current sentence as a new criterion on the eligibility checklist
2. Tweak outstanding charge question when adding a current offence to specify the type of outstanding charge

[Trello ticket 727](https://trello.com/c/vlC5mMkK/727-content-outstanding-charges-and-hdc-licence-eligibility)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
