### PR TITLE
Add hint text to conditional outstanding charges detail question

### DIFF
--- a/server/views/applications/pages/current-offences/current-offence-data.njk
+++ b/server/views/applications/pages/current-offences/current-offence-data.njk
@@ -6,6 +6,34 @@
 
 {% extends "../layout.njk" %}
 
+{% set outstandingChargesFollowUpHintHtml %}
+<p class="govuk-hint">Include details where the applicant's behaviour could be a risk to:</p>
+
+<ul class="govuk-list govuk-list--bullet govuk-hint">
+  <li>
+        the applicant themselves
+      </li>
+  <li>
+        other people staying at the property
+      </li>
+  <li>
+        staff members
+      </li>
+  <li>
+        neighbours
+      </li>
+  <li>
+        visitors
+      </li>
+  <li>
+        contractors
+      </li>
+  <li>
+        the property (for example, arson)
+      </li>
+</ul>
+{% endset %}
+
 {% set outstandingChargesFollowUp %}
 {{
       formPageTextArea(
@@ -14,7 +42,8 @@
           label: {
             text: page.questions.outstandingChargesDetail.question,
             classes: "govuk-label--s"
-          }
+          },
+          hint: { html: outstandingChargesFollowUpHintHtml }
         },
         fetchContext()
       )


### PR DESCRIPTION
Add hint text to conditional outstanding charges detail question to specify which outstanding charges the user should provide.

[Trello ticket 727](https://trello.com/c/vlC5mMkK/727-content-outstanding-charges-and-hdc-licence-eligibility)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
