### PR TITLE
Disable autocomplete on all form fields

### DIFF
--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -12,7 +12,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <form action="{{ paths.applications.people.find() }}" method="post">
+      <form action="{{ paths.applications.people.find() }}" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}
@@ -43,5 +43,3 @@
     </div>
   </div>
 {% endblock %}
-
-

--- a/server/views/applications/pages/current-offences/current-offence-data.njk
+++ b/server/views/applications/pages/current-offences/current-offence-data.njk
@@ -31,7 +31,7 @@
         <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>
       </div>
 
-      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
+      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -32,7 +32,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
-      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}

--- a/server/views/applications/pages/offending-history/offence-history-data.njk
+++ b/server/views/applications/pages/offending-history/offence-history-data.njk
@@ -14,32 +14,32 @@
       <div class="govuk-body">
         <p>You should include:
             <ul>
-              <li>serious offences from the last 10 years</li>
-              <li>non-serious offences from the last 5 years</li>
-              <li>information related to a pattern of behaviour</li>
-            </ul>
-        <p>
-        <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>
-        <hr class="govuk-section-break govuk-section-break--m">
+            <li>serious offences from the last 10 years</li>
+            <li>non-serious offences from the last 5 years</li>
+            <li>information related to a pattern of behaviour</li>
+          </ul>
+          <p>
+            <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>
+            <hr class="govuk-section-break govuk-section-break--m">
 
-        <h2 class="govuk-heading-m">Check the offence is not spent</h2>   
-        <p>
+            <h2 class="govuk-heading-m">Check the offence is not spent</h2>
+            <p>
           You should <a href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution" class="govuk-link govuk-link--no-visited-state" rel="noreferrer noopener" target="_blank">check if a caution or conviction is spent (opens in a new tab)</a> first.
         </p>
 
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
             Spent convictions are protected under law and should not be disclosed. If a current risk, such as a restraining order, is linked to a spent conviction, you should add it to the relevant section.
           </strong>
-        </div>
-      </div>
-      <hr class="govuk-section-break govuk-section-break--m">
-      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+            </div>
+          </div>
+          <hr class="govuk-section-break govuk-section-break--m">
+          <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{
+            {{
             formPageInput(
               {
                 label: { 
@@ -56,7 +56,7 @@
             )
         }}
 
-        {{
+            {{
             govukSelect({
                   label: { 
                     text: page.questions.offenceCategory.question,
@@ -70,9 +70,9 @@
                   items: page.offenceCategories,
                   errorMessage: errors.offenceCategory
               })
-        }}        
+        }}
 
-        {{ 
+            {{ 
           formPageDateInput( {
             hint: {
               text: page.questions.offenceDate.hint
@@ -89,7 +89,7 @@
             fetchContext()) 
         }}
 
-        {{
+            {{
             formPageInput(
               {
                 label: { 
@@ -106,7 +106,7 @@
             )
         }}
 
-        {{
+            {{
             formPageTextArea(
               {
                 fieldName: "summary",
@@ -122,41 +122,41 @@
             )
         }}
 
-        <div>
-          {{ govukButton({
+            <div>
+              {{ govukButton({
             id: "add-another",
             text: "Save and add another",
             classes: "govuk-button--secondary govuk-!-margin-bottom-4"
           }) }}
-        </div>
+            </div>
 
-        {% block button %}
-          <div class="govuk-button-group">
-            {{ govukButton({
+            {% block button %}
+              <div class="govuk-button-group">
+                {{ govukButton({
                   text: "Save and continue"
               }) }}
-            <a class="govuk-link" href="{{ paths.applications.pages.show({ id: applicationId, task: 'offending-history', page: 'offence-history' }) }}">
+                <a class="govuk-link" href="{{ paths.applications.pages.show({ id: applicationId, task: 'offending-history', page: 'offence-history' }) }}">
                 Cancel
             </a>
-          </div>
-        {% endblock %}
-      </form>
-    </div>
-  </div>
+              </div>
+            {% endblock %}
+          </form>
+        </div>
+      </div>
 
-{% endblock %}
+    {% endblock %}
 
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    function addRedirect(event) {
-      const form = document.getElementById('form')
-      form.action = form.action + '&redirectPage=offence-history-data'
-    }
+    {% block extraScripts %}
+      <script type="text/javascript" nonce="{{ cspNonce }}">
+        function addRedirect(event) {
+          const form = document.getElementById('form')
+          form.action = form.action + '&redirectPage=offence-history-data'
+        }
 
-    document.addEventListener('DOMContentLoaded', function () {
-      document
-        .getElementById('add-another')
-        .addEventListener('click', (event) => addRedirect(event));
-    });
-  </script>
-{% endblock %}
+        document.addEventListener('DOMContentLoaded', function () {
+          document
+            .getElementById('add-another')
+            .addEventListener('click', (event) => addRedirect(event));
+        });
+      </script>
+    {% endblock %}

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
@@ -29,7 +29,7 @@
               text: "Protective factors can counteract negative influences. Individual protective factors include education, employment, leisure activities, goals and ambitions. Community and family protective factors include receiving professional support and having positive (prosocial) relationships."
         }) }}
       </div>
-      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
+      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{

--- a/server/views/applications/pages/risk-to-self/acct-data.njk
+++ b/server/views/applications/pages/risk-to-self/acct-data.njk
@@ -5,7 +5,7 @@
 {% extends "../layout.njk" %}
 
 {% set closedDate %}
-        {{ 
+{{ 
           formPageDateInput( {
             hint: {
               text: page.questions.closedDate.hint
@@ -31,7 +31,7 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <p class="govuk-body">An Assessment, Care in Custody and Teamwork (ACCT) 
           is a tailored plan to support someone in prison at risk of self harm or suicide.</p>
-      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post">
+      <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ 

--- a/server/views/assess/statusUpdate/new.njk
+++ b/server/views/assess/statusUpdate/new.njk
@@ -31,7 +31,7 @@
         </p>
       </div>
 
-      <form action="{{ paths.statusUpdate.create({id: application.id}) }}" method="post">
+      <form action="{{ paths.statusUpdate.create({id: application.id}) }}" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}


### PR DESCRIPTION
# Context

[Trello ticket ](https://trello.com/c/WTc3jGN0/731-disable-autocomplete-on-all-form-fields)

# Changes in this PR

Sets auutocomplete to "off" on all relevant forms, as well as the status update form, where there is currently no text input but there may plausibly be in the future.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
