### PR TITLE
Remove 'serious' from offence history guidance

### DIFF
--- a/server/views/applications/pages/offending-history/offence-history.njk
+++ b/server/views/applications/pages/offending-history/offence-history.njk
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
         <p>
-        The CAS-2 referral team needs an overview of serious and recent unspent offences to assess risk and make sure people are placed safely.
+        The CAS-2 referral team needs an overview of unspent offences to assess risk and make sure people are placed safely.
         </p>
         <div>
           {{ govukButton({


### PR DESCRIPTION
Remove 'serious' from offence history guidance

Related to [Trello ticket 729](https://trello.com/c/P1e8i40k/729-content-define-serious-and-non-serious-in-offence-sections)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
