### PR TITLE
Tweak homepage tile content

### DIFF
--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -6,15 +6,15 @@ export const sections = {
   referral: {
     id: 'referrals',
     title: 'View referrals',
-    description: 'View all in progress and submitted referrals.',
+    description: 'View all in progress and submitted CAS-2 referrals.',
     shortTitle: 'Referrals',
     href: paths.applications.index({}),
   },
   newReferral: {
     id: 'new-referral',
-    title: 'New referral',
-    description: 'Make a new CAS-2 referral.',
-    shortTitle: 'New referral',
+    title: 'Start a new referral',
+    description: 'Start a new CAS-2 referral for a HDC applicant.',
+    shortTitle: 'Start a new referral',
     href: paths.applications.beforeYouStart({}),
   },
 }

--- a/server/views/applications/pages/offending-history/offence-history-data.njk
+++ b/server/views/applications/pages/offending-history/offence-history-data.njk
@@ -12,11 +12,16 @@
       {{ showErrorSummary(errorSummary) }}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
-        <p>You should include:
+        <p>You must include unspent offences involving:
             <ul>
-              <li>serious offences from the last 10 years</li>
-              <li>non-serious offences from the last 5 years</li>
-              <li>information related to a pattern of behaviour</li>
+              <li>stalking or harassment</li>
+              <li>weapons or firearms</li>
+              <li>arson</li>
+              <li>violence</li>
+              <li>domestic abuse</li>
+              <li>hate crimes</li>
+              <li>drugs</li>
+              <li>any behaviour where the applicant is a risk to themselves or others</li>
             </ul>
         <p>
         <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>


### PR DESCRIPTION
Tweak homepage tile content to:
- change ‘New referral’ tile to describe action the user is taking with a verb (like we have with ‘View referrals')
- edit description in the new referral tile to specify that new referrals are for HDC applicants only

[Trello ticket 724](https://trello.com/c/ms8FWLuQ/724-check-homepage-tile-content)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
