### PR TITLE
(742) Download "submitted applications" report

### DIFF
--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -1,0 +1,28 @@
+import Page from '../page'
+import paths from '../../../server/paths/report'
+
+export default class ManagementInfoDownloadsPage extends Page {
+  constructor() {
+    super('Management information reports', undefined)
+    this.pageHasMiTitle()
+  }
+
+  static visit(): ManagementInfoDownloadsPage {
+    cy.visit(paths.report.new.pattern)
+
+    return new ManagementInfoDownloadsPage()
+  }
+
+  pageHasMiTitle(): void {
+    cy.title().should('include', 'Download reports')
+  }
+
+  shouldShowManagementInfoDownloads(): void {
+    cy.contains('Download management information in spreadsheet format')
+    cy.contains('Submitted applications').should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'submitted-applications' }),
+    )
+  }
+}

--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -18,6 +18,11 @@
 //      Given I am logged in as an assessor
 //      When I visit the dashboard page
 //      Then I see no cards
+//
+//  Scenario: viewing the dashboard page as an Management Info user
+//      Given I am logged in as an MI user
+//      When I visit the dashboard page
+//      Then I see the management info report downloads card
 
 import DashboardPage from '../pages/dashboardPage'
 import Page from '../pages/page'
@@ -73,5 +78,20 @@ context('Dashboard', () => {
 
     //  Then I see no cards
     page.shouldNotShowCards(['referrals', 'new-referral'])
+  })
+
+  //  Scenario: viewing the dashboard page as an Management Info user
+  it('Management info user sees reports download tile', () => {
+    // Given I am logged in as an MI user
+    cy.task('stubSignIn', ['ROLE_CAS2_MI'])
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    // When I visit the dashboard page
+    DashboardPage.visit()
+    const page = Page.verifyOnPage(DashboardPage)
+
+    // Then I see the management info report downloads card
+    page.shouldShowCards(['management-information-reports'])
   })
 })

--- a/integration_tests/tests/reports/download_management_info.cy.ts
+++ b/integration_tests/tests/reports/download_management_info.cy.ts
@@ -1,0 +1,33 @@
+//  Feature: Management Info user views download links
+//    So that I can analyse usage of the service
+//    As a MI User
+//    I want to download reports based on domain events
+//
+//    Scenario: download management information
+//      Given I am logged in as an Management Information user
+//      When I visit the management info reports page
+//      Then I see the download links
+
+import Page from '../../pages/page'
+import ManagementInfoDownloadsPage from '../../pages/reports/managementInfoDownloadsPage'
+
+context('Management information downloads', () => {
+  beforeEach(() => {
+    cy.task('reset')
+  })
+
+  //  Scenario: download management information
+  it('provides a list of download links', function test() {
+    // Given I am logged in as a Management Information user
+    cy.task('stubSignIn', ['ROLE_CAS2_MI'])
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    //  When I visit the management info reports page
+    ManagementInfoDownloadsPage.visit()
+    const page = Page.verifyOnPage(ManagementInfoDownloadsPage)
+
+    //  Then see the download links
+    page.shouldShowManagementInfoDownloads()
+  })
+})

--- a/server/@types/shared/models/SubmitCas2Application.ts
+++ b/server/@types/shared/models/SubmitCas2Application.ts
@@ -2,14 +2,18 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { AnyValue } from './AnyValue';
-
 export type SubmitCas2Application = {
     translatedDocument: AnyValue;
     /**
      * Id of the application being submitted
      */
     applicationId: string;
+    /**
+     * First and second preferences for where the accommodation should be located, pipe-separated
+     */
+    preferredAreas?: string;
+    hdcEligibilityDate?: string;
+    conditionalReleaseDate?: string;
 };
 

--- a/server/controllers/report/reportsController.test.ts
+++ b/server/controllers/report/reportsController.test.ts
@@ -28,10 +28,6 @@ describe('reportsController', () => {
 
   describe('new', () => {
     it('renders the template', async () => {
-      const applicationId = 'some-id'
-
-      request.params.id = applicationId
-
       const requestHandler = reportsController.new()
 
       await requestHandler(request, response, next)
@@ -41,12 +37,6 @@ describe('reportsController', () => {
   })
 
   describe('create', () => {
-    const applicationId = 'some-id'
-
-    beforeEach(() => {
-      request.params.id = applicationId
-    })
-
     it('calls the service method to download the report', async () => {
       const requestHandler = reportsController.create()
 

--- a/server/controllers/report/reportsController.test.ts
+++ b/server/controllers/report/reportsController.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../utils/validation')
 
 describe('reportsController', () => {
   const token = 'SOME_TOKEN'
+  const name = 'report-name'
 
   let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
   let response: DeepMocked<Response> = createMock<Response>({})
@@ -21,7 +22,7 @@ describe('reportsController', () => {
 
   beforeEach(() => {
     reportsController = new ReportsController(reportService)
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { token }, params: { name } })
     response = createMock<Response>({})
     jest.clearAllMocks()
   })
@@ -37,12 +38,14 @@ describe('reportsController', () => {
   })
 
   describe('create', () => {
-    it('calls the service method to download the report', async () => {
+    it('calls the service method with the name of the report to download', async () => {
       const requestHandler = reportsController.create()
 
       await requestHandler(request, response, next)
 
-      expect(reportService.getReport).toHaveBeenCalledWith(token, response)
+      expect(paths.report.create({ name })).toEqual('/reports/report-name')
+
+      expect(reportService.getReport).toHaveBeenCalledWith(name, token, response)
     })
 
     it('redirects back to new if there is an error', async () => {

--- a/server/controllers/report/reportsController.ts
+++ b/server/controllers/report/reportsController.ts
@@ -14,7 +14,7 @@ export default class ReportsController {
   create(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       try {
-        return await this.reportsService.getReport(req.user.token, res)
+        return await this.reportsService.getReport(req.params.name, req.user.token, res)
       } catch (error) {
         return res.redirect(paths.report.new({}))
       }

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -16,15 +16,15 @@ describeClient('ReportClient', provider => {
   })
 
   describe('getReport', () => {
-    it('should pipe the report from the API', async () => {
+    it('should pipe the requested report from the API', async () => {
       const response = createMock<Response>({})
 
       provider.addInteraction({
         state: 'Server is healthy',
-        uponReceiving: 'A request to get application reports ',
+        uponReceiving: 'A request to get an application report',
         withRequest: {
           method: 'GET',
-          path: paths.reports.exampleReport({}),
+          path: paths.reports.show({ name: 'report-name' }),
           query: {},
           headers: {
             authorization: `Bearer ${token}`,
@@ -35,11 +35,11 @@ describeClient('ReportClient', provider => {
         },
       })
 
-      await client.getReport(response)
+      await client.getReport('report-name', response)
 
       expect(response.set).toHaveBeenCalledWith(
         'Content-Disposition',
-        `attachment; filename="cas2-example-report.xlsx"`,
+        `attachment; filename="cas2-report-name-report.xlsx"`,
       )
     })
   })

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -12,13 +12,13 @@ export default class ReportClient {
     this.restClient = new RestClient('reportClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async getReport(response: Response): Promise<void> {
-    const filename = `cas2-example-report.xlsx`
+  async getReport(name: string, response: Response): Promise<void> {
+    const filename = `cas2-${name}-report.xlsx`
     response.set('Content-Disposition', `attachment; filename="${filename}"`)
 
     await this.restClient.pipe(
       {
-        path: paths.reports.exampleReport({}),
+        path: paths.reports.show({ name }),
       },
       response,
     )

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,6 +9,7 @@ const submissionsPath = path('/cas2/submissions')
 const singleSubmissionPath = submissionsPath.path(':id')
 const referenceDataPath = path('/cas2/reference-data')
 const reportsPath = path('/cas2/reports')
+const singleReportPath = reportsPath.path(':name')
 
 export default {
   people: {
@@ -41,5 +42,6 @@ export default {
   },
   reports: {
     exampleReport: reportsPath.path('example-report'),
+    show: singleReportPath,
   },
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -41,7 +41,6 @@ export default {
     create: singleSubmissionPath.path('status-updates'),
   },
   reports: {
-    exampleReport: reportsPath.path('example-report'),
     show: singleReportPath,
   },
 }

--- a/server/paths/report.ts
+++ b/server/paths/report.ts
@@ -1,10 +1,11 @@
 import { path } from 'static-path'
 
 const reportPath = path('/reports')
+const singleReportPath = reportPath.path(':name')
 
 export default {
   report: {
     new: reportPath,
-    create: reportPath.path('download'),
+    create: singleReportPath,
   },
 }

--- a/server/services/reportService.test.ts
+++ b/server/services/reportService.test.ts
@@ -18,11 +18,11 @@ describe('ReportService', () => {
   })
 
   describe('getReport', () => {
-    it('calls the getReport API client method', () => {
+    it('calls the getReport API client method with the name of the report to get', () => {
       const response = createMock<Response>({})
-      service.getReport(token, response).then(() => {
+      service.getReport('report-name', token, response).then(() => {
         expect(reportClientFactory).toHaveBeenCalledWith(token)
-        expect(reportClient.getReport).toHaveBeenCalledWith(response)
+        expect(reportClient.getReport).toHaveBeenCalledWith('report-name', response)
       })
     })
   })

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -7,9 +7,9 @@ import ReportClient from '../data/reportClient'
 export default class ReportService {
   constructor(private readonly reportClientFactory: RestClientBuilder<ReportClient>) {}
 
-  async getReport(token: string, response: Response): Promise<void> {
+  async getReport(name: string, token: string, response: Response): Promise<void> {
     const client = this.reportClientFactory(token)
 
-    return client.getReport(response)
+    return client.getReport(name, response)
   }
 }

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,7 +28,7 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-cas2-api-spec.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/c992d51c6f96778515ce9c6ca003a1a9000afe2f/src/main/resources/static/codegen/built-cas2-api-spec.yml'
 
     const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'cas2-api.yml')
 

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,4 +1,5 @@
 import { applicationFactory } from '../../testutils/factories'
+import applicationDataJson from '../../../integration_tests/fixtures/applicationData.json'
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 
 describe('getApplicationUpdateData', () => {
@@ -13,10 +14,14 @@ describe('getApplicationUpdateData', () => {
 
 describe('getApplicationSubmissionData', () => {
   it('returns the submission data', () => {
-    const mockApplication = applicationFactory.build()
+    const mockApplication = applicationFactory.build({ data: applicationDataJson })
+
     expect(getApplicationSubmissionData(mockApplication)).toEqual({
       applicationId: mockApplication.id,
       translatedDocument: mockApplication.document,
+      preferredAreas: 'London | Birmingham',
+      hdcEligibilityDate: '2024-02-28',
+      conditionalReleaseDate: '2024-02-22',
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,5 +1,11 @@
 import { Cas2Application as Application, SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
 
+import {
+  preferredAreasFromAppData,
+  hdcEligibilityDateFromAppData,
+  conditionalReleaseDateFromAppData,
+} from './managementInfoFromAppData'
+
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
     type: 'CAS2',
@@ -11,5 +17,8 @@ export const getApplicationSubmissionData = (application: Application): SubmitCa
   return {
     translatedDocument: application.document,
     applicationId: application.id,
+    preferredAreas: preferredAreasFromAppData(application),
+    hdcEligibilityDate: hdcEligibilityDateFromAppData(application),
+    conditionalReleaseDate: conditionalReleaseDateFromAppData(application),
   }
 }

--- a/server/utils/applications/managementInfoFromAppData.test.ts
+++ b/server/utils/applications/managementInfoFromAppData.test.ts
@@ -1,4 +1,4 @@
-import { preferredAreasFromAppData } from './managementInfoFromAppData'
+import { preferredAreasFromAppData, hdcEligibilityDateFromAppData } from './managementInfoFromAppData'
 
 import { applicationFactory } from '../../testutils/factories'
 
@@ -38,6 +38,28 @@ describe('managementInfoFromAppData', () => {
         },
       })
       expect(preferredAreasFromAppData(application)).toEqual('Bradford')
+    })
+  })
+
+  describe('hdcEligibilityDateFromAppData', () => {
+    it('returns the given date', () => {
+      const application = applicationFactory.build({
+        data: {
+          'hdc-licence-and-cpp-details': {
+            'hdc-licence-dates': { hdcEligibilityDate: '2024-02-27' },
+          },
+        },
+      })
+      expect(hdcEligibilityDateFromAppData(application)).toEqual('2024-02-27')
+    })
+
+    it('returns null if no date is given', () => {
+      const application = applicationFactory.build({
+        data: {
+          'hdc-licence-and-cpp-details': null,
+        },
+      })
+      expect(hdcEligibilityDateFromAppData(application)).toEqual(null)
     })
   })
 })

--- a/server/utils/applications/managementInfoFromAppData.test.ts
+++ b/server/utils/applications/managementInfoFromAppData.test.ts
@@ -1,0 +1,43 @@
+import { preferredAreasFromAppData } from './managementInfoFromAppData'
+
+import { applicationFactory } from '../../testutils/factories'
+
+describe('managementInfoFromAppData', () => {
+  describe('preferredAreasFromAppData', () => {
+    it('concatenates the first and second choices into a pipe-delimited string', () => {
+      const application = applicationFactory.build({
+        data: {
+          'area-information': {
+            'first-preferred-area': { preferredArea: 'Bradford' },
+            'second-preferred-area': { preferredArea: 'Leeds' },
+          },
+        },
+      })
+      expect(preferredAreasFromAppData(application)).toEqual('Bradford | Leeds')
+    })
+
+    it('returns an empty string when no areas are specified', () => {
+      const application = applicationFactory.build({
+        data: {
+          'area-information': {
+            'first-preferred-area': { preferredArea: '' },
+            'second-preferred-area': { preferredArea: '' },
+          },
+        },
+      })
+      expect(preferredAreasFromAppData(application)).toEqual('')
+    })
+
+    it('does not include a pipe when only one area is specified', () => {
+      const application = applicationFactory.build({
+        data: {
+          'area-information': {
+            'first-preferred-area': { preferredArea: 'Bradford' },
+            'second-preferred-area': { preferredArea: '' },
+          },
+        },
+      })
+      expect(preferredAreasFromAppData(application)).toEqual('Bradford')
+    })
+  })
+})

--- a/server/utils/applications/managementInfoFromAppData.test.ts
+++ b/server/utils/applications/managementInfoFromAppData.test.ts
@@ -1,4 +1,8 @@
-import { preferredAreasFromAppData, hdcEligibilityDateFromAppData } from './managementInfoFromAppData'
+import {
+  preferredAreasFromAppData,
+  hdcEligibilityDateFromAppData,
+  conditionalReleaseDateFromAppData,
+} from './managementInfoFromAppData'
 
 import { applicationFactory } from '../../testutils/factories'
 
@@ -60,6 +64,28 @@ describe('managementInfoFromAppData', () => {
         },
       })
       expect(hdcEligibilityDateFromAppData(application)).toEqual(null)
+    })
+  })
+
+  describe('conditionalReleaseDateFromAppData', () => {
+    it('returns the given date', () => {
+      const application = applicationFactory.build({
+        data: {
+          'hdc-licence-and-cpp-details': {
+            'hdc-licence-dates': { conditionalReleaseDate: '2024-03-15' },
+          },
+        },
+      })
+      expect(conditionalReleaseDateFromAppData(application)).toEqual('2024-03-15')
+    })
+
+    it('returns null if no date is given', () => {
+      const application = applicationFactory.build({
+        data: {
+          'hdc-licence-and-cpp-details': null,
+        },
+      })
+      expect(conditionalReleaseDateFromAppData(application)).toEqual(null)
     })
   })
 })

--- a/server/utils/applications/managementInfoFromAppData.ts
+++ b/server/utils/applications/managementInfoFromAppData.ts
@@ -12,4 +12,12 @@ const preferredAreasFromAppData = (application: Application): string => {
   return [firstPreference, secondPreference].filter(x => x).join(' | ')
 }
 
-export { preferredAreasFromAppData }
+const hdcEligibilityDateFromAppData = (application: Application): string => {
+  const date: string = (application.data as Record<string, unknown>)?.['hdc-licence-and-cpp-details']?.[
+    'hdc-licence-dates'
+  ]?.hdcEligibilityDate
+
+  return date || null
+}
+
+export { preferredAreasFromAppData, hdcEligibilityDateFromAppData }

--- a/server/utils/applications/managementInfoFromAppData.ts
+++ b/server/utils/applications/managementInfoFromAppData.ts
@@ -20,4 +20,12 @@ const hdcEligibilityDateFromAppData = (application: Application): string => {
   return date || null
 }
 
-export { preferredAreasFromAppData, hdcEligibilityDateFromAppData }
+const conditionalReleaseDateFromAppData = (application: Application): string => {
+  const date: string = (application.data as Record<string, unknown>)?.['hdc-licence-and-cpp-details']?.[
+    'hdc-licence-dates'
+  ]?.conditionalReleaseDate
+
+  return date || null
+}
+
+export { preferredAreasFromAppData, hdcEligibilityDateFromAppData, conditionalReleaseDateFromAppData }

--- a/server/utils/applications/managementInfoFromAppData.ts
+++ b/server/utils/applications/managementInfoFromAppData.ts
@@ -1,0 +1,15 @@
+import { Cas2Application as Application } from '@approved-premises/api'
+
+const preferredAreasFromAppData = (application: Application): string => {
+  const firstPreference: string = (application.data as Record<string, unknown>)?.['area-information']?.[
+    'first-preferred-area'
+  ]?.preferredArea
+
+  const secondPreference: string = (application.data as Record<string, unknown>)?.['area-information']?.[
+    'second-preferred-area'
+  ]?.preferredArea
+
+  return [firstPreference, secondPreference].filter(x => x).join(' | ')
+}
+
+export { preferredAreasFromAppData }

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -15,5 +15,10 @@ describe('userUtils', () => {
       const expected = [sections.referral, sections.newReferral, sections.submittedApplications]
       expect(sectionsForUser(['ROLE_CAS2_ADMIN'])).toEqual(expected)
     })
+
+    it('should return correct sections for a management information user', () => {
+      const expected = [sections.managementInformationReports]
+      expect(sectionsForUser(['ROLE_CAS2_MI'])).toEqual(expected)
+    })
   })
 })

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -2,6 +2,7 @@ import { ServiceSection } from '@approved-premises/ui'
 
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
+import reportsPaths from '../paths/report'
 
 export const sections = {
   referral: {
@@ -25,6 +26,13 @@ export const sections = {
     shortTitle: 'Submitted applications',
     href: assessPaths.submittedApplications.index.pattern,
   },
+  managementInformationReports: {
+    id: 'management-information-reports',
+    title: 'Management information reports',
+    description: 'View all CAS-2 management information reports to download',
+    shortTitle: 'Management information reports',
+    href: reportsPaths.report.new.pattern,
+  },
 }
 
 export const hasRole = (userRoles: Array<string>, role: string): boolean => {
@@ -40,6 +48,9 @@ export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection>
   }
   if (hasRole(userRoles, 'ROLE_CAS2_ADMIN')) {
     items.push(sections.submittedApplications)
+  }
+  if (hasRole(userRoles, 'ROLE_CAS2_MI')) {
+    items.push(sections.managementInformationReports)
   }
 
   return Array.from(new Set(items))

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -1,11 +1,11 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}{% endblock %}
+{% block pageTitle %}Download reports{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
-    <h1 class="govuk-heading-l">Reports</h1>
-    <p>Download a report</p>
+    <h1 class="govuk-heading-l">Management information reports</h1>
+    <p>Download management information in spreadsheet format</p>
 
     {% block button %}
       <div class="govuk-button-group">

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -1,20 +1,21 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-{% endblock %}
+{% block pageTitle %}{% endblock %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <h1 class="govuk-heading-l">Reports</h1>
-  <p>Download a report</p>
+  <div class="govuk-grid-row">
+    <h1 class="govuk-heading-l">Reports</h1>
+    <p>Download a report</p>
 
-  {% block button %}
-    <div class="govuk-button-group">
-      {{ govukButton({
-              text: "Download report",
-              href: paths.report.create()
+    {% block button %}
+      <div class="govuk-button-group">
+        {{ govukButton({
+              text: "Submitted applications",
+              href: paths.report.create({
+                      name: "submitted-applications"
+                    })
       }) }}
-    </div>
-  {% endblock %}
-</div>
+      </div>
+    {% endblock %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
# "MI user" downloads spreadsheet detailing submitted applications

[Trello 742](https://trello.com/c/GEIpAHHy/742-generate-report-of-applicationsubmitted-events)

# Changes in this PR

A user with the `CAS2_MI` role can now download a spreadsheet of information about submitted applications. 

See 

- https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1284 and
- https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1294

for information about the download. It features the following columns:

```
- eventId: 63cbe435-768e-43ab-9164-a57784926f91
- applicationId: 6620721f-eba5-4a10-affb-dd3309b04f41
- personCrn: X320741
- personNoms: A1234AI
- referringPrisonCode: LEI
- preferredAreas: Leeds | Bradford
- hdcEligibilityDate: 2023-03-30
- conditionalReleaseDate: 2023-04-29
- submittedOn: 2024-01-03
- submittedBy: POM_USER
```

## Screenshots of UI changes

### MI User's dashboard
<img width="816" alt="mi_user_dashboard" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/3ce16b25-32b3-417c-a0d2-3b9873d1b2d4">


### UI
<img width="833" alt="reports_index_2" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/6d9793da-983b-40f8-aedd-39fe3299838f">


### Download
<img width="914" alt="downloaded_file" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/9a2ed02e-72c6-4e75-ae73-240397cab0a5">

### Spreadsheet
<img width="1049" alt="downloaded_spreadsheet" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/af364681-6c40-495a-95ca-608e7da6bed8">




# Release checklist

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [x] If you've added a new route, have you added a new
  `auditEvent`? - the existing auditing is working: `Sending audit message DOWNLOAD_REPORT ({"name":"submitted-applications"})`
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [x] Does this rely on changes being deployed to the CAS API? - yes relies on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1284


