### PR TITLE
Add privacy notice bullet point to consent page

### DIFF
--- a/server/views/applications/pages/confirm-consent/confirm-consent.njk
+++ b/server/views/applications/pages/confirm-consent/confirm-consent.njk
@@ -17,10 +17,13 @@
         what will be in the application form, including legal and confidential information about address history, offences, risks to themselves and others and health needs
       </li>
       <li>
+        how and why their personal data will be collected and used by reading the <a href="#" class="govuk-link">privacy notice (opens in new tab)</a>
+      </li>
+      <li>
         their health needs will be collected from relevant sources, such as the prison drug and alcohol provider, mental health in-reach team and healthcare team
       </li>
       <li>
-        their information will be used to assess their suitability and ensure their safety
+        their personal data will be used to assess their suitability and ensure their safety
       </li>
       <li>
         they must leave the CAS-2 accommodation at the end of their HDC licence period, and find accommodation to move on to with their support worker's help


### PR DESCRIPTION
Change to consent page to:

- add bullet point to reference privacy notice for users to show applicants (link to privacy notice page to be added in a following PR)
- tweak wording in existing bullet point from "information" to "personal data" for consistency with new privacy notice bullet

[Trello ticket 452](https://trello.com/c/qzRGzf4n/452-content-privacy-notice)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
