### PR TITLE
Remove e2e test dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ workflows:
           type: approval
           requires:
             - deploy_dev
-            - e2e_environment_test
       - hmpps/deploy_env:
           name: deploy_test
           env: 'test'


### PR DESCRIPTION
we would like to temporarily remove the requirement for e2e tests to be
passing for a product review - we are aware the tests are failing
because a new task (Check information) has been added to the task list.