### PR TITLE
(754) Allow users with the CAS2_ADMIN role to bypass maintenance

### DIFF
--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -1,23 +1,9 @@
-import type { NextFunction, Request, Response } from 'express'
-import jwt from 'jsonwebtoken'
-import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { ServiceSection } from '@approved-premises/ui'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
 import { sectionsForUser } from '../utils/userUtils'
 
 import DashboardController from './dashboardController'
-
-function createToken(authorities: string[]) {
-  const payload = {
-    user_name: 'USER1',
-    scope: ['read', 'write'],
-    auth_source: 'nomis',
-    authorities,
-    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
-    client_id: 'clientid',
-  }
-
-  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
-}
 
 jest.mock('../utils/userUtils')
 
@@ -27,16 +13,6 @@ describe('DashboardController', () => {
 
   let dashboardController: DashboardController
 
-  function createResWithToken({ authorities }: { authorities: string[] }): Response {
-    return createMock<Response>({
-      locals: {
-        user: {
-          token: createToken(authorities),
-        },
-      },
-    })
-  }
-
   beforeEach(() => {
     dashboardController = new DashboardController()
   })
@@ -45,24 +21,20 @@ describe('DashboardController', () => {
     const sections = createMock<Array<ServiceSection>>()
     ;(sectionsForUser as jest.Mock).mockReturnValue(sections)
 
-    it('should extract the user roles from the jwt', () => {
-      const response = createResWithToken({ authorities: ['role_1', 'role_2'] })
+    it('should render the dashboard template', () => {
+      const response = createMock<Response>({
+        locals: {
+          user: {
+            roles: ['role_1', 'role_2'],
+          },
+        },
+      })
 
       const requestHandler = dashboardController.index()
 
       requestHandler(request, response, next)
 
       expect(sectionsForUser).toHaveBeenCalledWith(['role_1', 'role_2'])
-    })
-
-    it('should render the dashboard template', () => {
-      const response = createResWithToken({ authorities: [] })
-
-      const requestHandler = dashboardController.index()
-
-      requestHandler(request, response, next)
-
-      expect(sectionsForUser).toHaveBeenCalledWith([])
       expect(response.render).toHaveBeenCalledWith('dashboard/index', {
         pageHeading: 'CAS2: Short-term accommodation',
         sections,

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,13 +1,10 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { jwtDecode } from 'jwt-decode'
 import { sectionsForUser } from '../utils/userUtils'
 
 export default class DashboardController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
-      const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
-
-      const sections = sectionsForUser(roles)
+      const sections = sectionsForUser(res.locals.user.roles)
 
       res.render('dashboard/index', {
         pageHeading: 'CAS2: Short-term accommodation',

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -1,0 +1,38 @@
+import { createMock } from '@golevelup/ts-jest'
+
+import type { Request, Response } from 'express'
+import type { UserService } from '../services'
+import type { UserDetails } from '../services/userService'
+import populateCurrentUser from './populateCurrentUser'
+
+describe('populateCurrentUser', () => {
+  const userService = createMock<UserService>()
+
+  const userDetailsObject: UserDetails = {
+    name: 'FakeUser',
+    displayName: 'Fake Display Name',
+  }
+
+  beforeEach(() => {
+    userService.getUser.mockReset()
+  })
+
+  it('set user details from the user service if not already set', async () => {
+    const request: jest.Mocked<Request> = createMock<Request>()
+    const response: jest.Mocked<Response> = createMock<Response>({
+      locals: {
+        user: {
+          name: 'FakeUser',
+          displayName: 'Fake Display Name',
+        },
+      },
+    })
+    const next = jest.fn()
+
+    userService.getUser.mockResolvedValue(userDetailsObject)
+
+    populateCurrentUser(userService)(request, response, next)
+
+    expect(response.locals.user).toEqual(userDetailsObject)
+  })
+})

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -1,11 +1,33 @@
 import { createMock } from '@golevelup/ts-jest'
-
 import type { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
 import type { UserService } from '../services'
 import type { UserDetails } from '../services/userService'
 import populateCurrentUser from './populateCurrentUser'
 
 describe('populateCurrentUser', () => {
+  const createToken = (authorities: string[]) => {
+    const payload = {
+      user_name: 'USER1',
+      scope: ['read', 'write'],
+      auth_source: 'nomis',
+      authorities,
+      jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
+      client_id: 'clientid',
+    }
+    return jwt.sign(payload, 'secret', { expiresIn: '1h' })
+  }
+
+  const createResWithToken = ({ authorities }: { authorities: string[] }): Response =>
+    createMock<Response>({
+      locals: {
+        user: {
+          token: createToken(authorities),
+          roles: [],
+        },
+      },
+    })
+
   const userService = createMock<UserService>()
 
   const userDetailsObject: UserDetails = {
@@ -34,5 +56,17 @@ describe('populateCurrentUser', () => {
     populateCurrentUser(userService)(request, response, next)
 
     expect(response.locals.user).toEqual(userDetailsObject)
+  })
+
+  it('should extract the user roles from the jwt', async () => {
+    const request: jest.Mocked<Request> = createMock<Request>()
+    const response = createResWithToken({ authorities: ['role_1', 'role_2'] })
+    const next = jest.fn()
+
+    userService.getUser.mockResolvedValue(userDetailsObject)
+
+    await populateCurrentUser(userService)(request, response, next)
+
+    expect(response.locals.user.roles).toEqual(['role_1', 'role_2'])
   })
 })

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express'
+import { jwtDecode } from 'jwt-decode'
 import logger from '../../logger'
 import UserService from '../services/userService'
 
@@ -7,8 +8,9 @@ export default function populateCurrentUser(userService: UserService): RequestHa
     try {
       if (res.locals.user) {
         const user = res.locals.user && (await userService.getUser(res.locals.user.token))
+        const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
         if (user) {
-          res.locals.user = { ...user, ...res.locals.user }
+          res.locals.user = { ...user, ...res.locals.user, roles }
         } else {
           logger.info('No user available')
         }

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -7,7 +7,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
-        const user = res.locals.user && (await userService.getUser(res.locals.user.token))
+        const user = await userService.getUser(res.locals.user.token)
         const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
         if (user) {
           res.locals.user = { ...user, ...res.locals.user, roles }

--- a/server/middleware/setUpMaintenancePageRedirect.test.ts
+++ b/server/middleware/setUpMaintenancePageRedirect.test.ts
@@ -5,6 +5,15 @@ import setUpMaintenancePageRedirect from './setUpMaintenancePageRedirect'
 
 const setupApp = (): Express => {
   const app = express()
+
+  const roles = ['ROLE_POM']
+  app.use((req, res, next) => {
+    res.locals = res.locals || {}
+    res.locals.user = res.locals.user || {}
+    res.locals.user.roles = roles
+    next()
+  })
+
   app.use(setUpMaintenancePageRedirect())
 
   const allowedPaths = ['/known', '/maintenance', '/health', '/sign-in', '/sign-in/callback']
@@ -67,6 +76,74 @@ describe('setUpMaintenancePageRedirect', () => {
         const app = setupApp()
         return request(app).get('/sign-in/callback').expect(200)
       })
+    })
+
+    describe('when the user has the CAS2_ADMIN role', () => {
+      const setupAppWithRoleStubbed = (): Express => {
+        const app = express()
+
+        const roles = ['ROLE_CAS2_ADMIN']
+        app.use((req, res, next) => {
+          res.locals = res.locals || {}
+          res.locals.user = res.locals.user || {}
+          res.locals.user.roles = roles
+          next()
+        })
+
+        app.use(setUpMaintenancePageRedirect())
+
+        const allowedPaths = ['/known', '/maintenance', '/health', '/sign-in', '/sign-in/callback']
+
+        allowedPaths.forEach(path => {
+          app.get(path, (_req, res, _next) => {
+            res.send(path.slice(1))
+          })
+        })
+
+        return app
+      }
+
+      it('should not redirect to the maintenance page', () => {
+        config.flags.maintenanceMode = 'true'
+
+        const app = setupAppWithRoleStubbed()
+
+        return request(app).get('/known').expect(200)
+      })
+    })
+  })
+
+  describe('when the user has no roles', () => {
+    const setupAppWithRolesMissing = (): Express => {
+      const app = express()
+
+      app.use((req, res, next) => {
+        res.locals = res.locals || {}
+        res.locals.user = res.locals.user || {}
+        // The test here is to omit the roles object
+        // res.locals.user.roles = roles
+        next()
+      })
+
+      app.use(setUpMaintenancePageRedirect())
+
+      const allowedPaths = ['/known', '/maintenance', '/health', '/sign-in', '/sign-in/callback']
+
+      allowedPaths.forEach(path => {
+        app.get(path, (_req, res, _next) => {
+          res.send(path.slice(1))
+        })
+      })
+
+      return app
+    }
+
+    it('should not error', () => {
+      config.flags.maintenanceMode = 'false'
+
+      const app = setupAppWithRolesMissing()
+
+      return request(app).get('/known').expect(200)
     })
   })
 })

--- a/server/middleware/setUpMaintenancePageRedirect.ts
+++ b/server/middleware/setUpMaintenancePageRedirect.ts
@@ -6,7 +6,11 @@ export default function setUpMaintenancePageRedirect(): Router {
   const allowedPaths = ['/sign-in', '/sign-in/callback', '/health', '/maintenance']
 
   router.use((req, res, next) => {
-    if (config.flags.maintenanceMode === 'true' && !allowedPaths.includes(req.path)) {
+    if (
+      config.flags.maintenanceMode === 'true' &&
+      !allowedPaths.includes(req.path) &&
+      !res.locals.user?.roles.includes('ROLE_CAS2_ADMIN')
+    ) {
       return res.redirect(302, `/maintenance`)
     }
     return next()

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,7 +1,7 @@
-import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
+import { convertToTitleCase } from '../utils/utils'
 
-interface UserDetails {
+export interface UserDetails {
   name: string
   displayName: string
 }


### PR DESCRIPTION
# Context

https://trello.com/c/QqHdrhLZ

# Changes in this PR

- The maintenance page can be bypassed by any user with role CAS2_ADMIN. This will allow the team to test the service is performing properly and debug any issues before disabling maintenance mode.
- The extraction of user roles was handled by the `dashboardController` so we went into a rabbit hole to try and bring that behaviour into the `populateCurrentUser` middleware to make it centralised.
- The data should probably be stored in res.session rather than res.session but that felt like one rabbit hole too far for this one

## Screenshots of UI changes

https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/2ca85435-3e87-4120-b7be-ea9805d59883


### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
