### PR TITLE
Add OASys dates and RoSH summary data to check your answers

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -243,7 +243,6 @@
         "riskToPublic": "Very High",
         "riskToKnownAdult": "Medium",
         "riskToStaff": "Low",
-        "lastUpdated": "2022-11-02"
       }
     },
     "summary": {

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -192,13 +192,17 @@
     }
   },
   "risk-to-self": {
-    "oasys-import": { "oasysImportDate": "2023-09-21T15:47:51.430Z" },
-    "vulnerability": {
-      "vulnerabilityDetail": "example answer vulnerability",
-      "confirmation": "confirmed"
+    "oasys-import": {
+      "oasysImportedDate": "2023-09-21T15:47:51.430Z",
+      "oasysStartedDate": "2023-09-10",
+      "oasysCompletedDate": "2023-09-11"
     },
     "current-risk": {
-      "currentRiskDetail": "example answer current risk",
+      "currentRiskDetail": "[R8.1.1] Review 06.10.21:\r\n\r\n        There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...",
+      "confirmation": "confirmed"
+    },
+    "vulnerability": {
+      "vulnerabilityDetail": "example answer vulnerability",
       "confirmation": "confirmed"
     },
     "historical-risk": {
@@ -233,16 +237,18 @@
     }
   },
   "risk-of-serious-harm": {
-    "oasys-import": { "oasysImportDate": "2023-09-21T15:47:51.430Z" },
+    "oasys-import": { "oasysImportedDate": "2023-09-21T15:47:51.430Z" },
     "summary-data": {
-      "dateOfOasysImport": "2023-09-21T15:47:51.430Z",
+      "oasysImportedDate": "2023-09-21T15:47:51.430Z",
+      "oasysStartedDate": "2023-09-10",
+      "oasysCompletedDate": "2023-09-11",
       "status": "retrieved",
       "value": {
         "overallRisk": "High",
         "riskToChildren": "High",
         "riskToPublic": "Very High",
         "riskToKnownAdult": "Medium",
-        "riskToStaff": "Low",
+        "riskToStaff": "Low"
       }
     },
     "summary": {

--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -29,7 +29,7 @@ export default class ApplyPage extends Page {
   }
 
   shouldShowOasysImportDate(application: Application, task: string): void {
-    const date = application.data[task]['oasys-import'].oasysImportDate
+    const date = application.data[task]['oasys-import'].oasysImportedDate
 
     cy.get('p').contains(`Imported from OASys on ${DateFormats.isoDateToUIDate(date, { format: 'medium' })}`)
   }

--- a/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-of-serious-harm/roshSummaryPage.ts
@@ -29,8 +29,6 @@ export default class RoshSummaryPage extends ApplyPage {
     cy.get('p').contains(
       `Imported from OASys on ${DateFormats.isoDateToUIDate(oasysImportDate, {
         format: 'medium',
-      })}, last updated on ${DateFormats.isoDateToUIDate(risks.value.lastUpdated, {
-        format: 'medium',
       })}`,
     )
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -84,7 +84,7 @@ export default abstract class Page {
     cy.get('a').contains('Remove').click()
   }
 
-  removeWhiteSpaceAndLineBreaks(stringToReplace: string): string {
+  removeWhiteSpaceAndLineBreaks(stringToReplace: string = ''): string {
     return stringToReplace.trim().replace(/(\r\n|\n|\r)/gm, '')
   }
 

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
@@ -214,7 +214,7 @@ context('Visit "Risks and needs" section', () => {
 
       const body = JSON.parse(requests[0].body)
 
-      expect(body.data['risk-of-serious-harm']['oasys-import']).to.have.keys('oasysImportDate')
+      expect(body.data['risk-of-serious-harm']['oasys-import']).to.have.keys('oasysImportedDate')
       expect(body.data['risk-of-serious-harm']).to.have.keys(
         'summary-data',
         'risk-factors',

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/oasys_import.cy.ts
@@ -216,11 +216,19 @@ context('Visit "Risks and needs" section', () => {
 
       expect(body.data['risk-of-serious-harm']['oasys-import']).to.have.keys('oasysImportedDate')
       expect(body.data['risk-of-serious-harm']).to.have.keys(
+        'summary',
         'summary-data',
         'risk-factors',
         'oasys-import',
         'reducing-risk',
         'risk-to-others',
+      )
+      expect(body.data['risk-of-serious-harm']['summary-data']).to.have.keys(
+        'status',
+        'value',
+        'oasysImportedDate',
+        'oasysStartedDate',
+        'oasysCompletedDate',
       )
     })
   })

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/rosh_summary.cy.ts
@@ -101,7 +101,7 @@ context('Visit "RoSH summary" page', () => {
     //    Then I see the data presented on the page
     page.shouldShowRiskData(
       riskSummaryData,
-      this.application.data['risk-of-serious-harm']['oasys-import'].oasysImportDate,
+      this.application.data['risk-of-serious-harm']['oasys-import'].oasysImportedDate,
     )
   })
 

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/oasys_import_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/oasys_import_page.cy.ts
@@ -153,7 +153,11 @@ context('Visit "Risks and needs" section', () => {
       const body = JSON.parse(requests[0].body)
 
       expect(body.data['risk-to-self']).to.have.keys('oasys-import', 'current-risk', 'historical-risk', 'vulnerability')
-      expect(body.data['risk-to-self']['oasys-import']).to.have.keys('oasysImportDate')
+      expect(body.data['risk-to-self']['oasys-import']).to.have.keys(
+        'oasysImportedDate',
+        'oasysStartedDate',
+        'oasysCompletedDate',
+      )
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.test.ts
@@ -75,9 +75,12 @@ describe('OasysImport', () => {
 
         const taskData = {
           'risk-of-serious-harm': {
+            summary: {},
             'summary-data': {
               ...riskSummary,
-              dateOfOasysImport: now,
+              oasysImportedDate: now,
+              oasysStartedDate: oasys.dateStarted,
+              oasysCompletedDate: oasys.dateCompleted,
             },
             'risk-to-others': {
               whoIsAtRisk: 'who is at risk answer',
@@ -90,7 +93,7 @@ describe('OasysImport', () => {
             'reducing-risk': {
               factorsLikelyToReduceRisk: 'circumstances likely to reduce risk answer',
             },
-            'oasys-import': { oasysImportDate: now },
+            'oasys-import': { oasysImportedDate: now },
           },
         }
 
@@ -135,7 +138,7 @@ describe('OasysImport', () => {
       it('returns the Rosh summary page', async () => {
         const roshData = {
           'risk-of-serious-harm': {
-            'oasys-import': { oasysImportDate: now },
+            'oasys-import': { oasysImportedDate: now },
             'risk-factors': { circumstancesLikelyToIncreaseRisk: 'some answer' },
           },
         } as RoshTaskData

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/oasysImport.ts
@@ -13,10 +13,10 @@ type OasysImportBody = Record<string, never>
 export type RoshTaskData = {
   'risk-of-serious-harm': {
     'oasys-import': {
-      oasysImportDate: Date
+      oasysImportedDate: Date
     }
     summary: RoshRisksEnvelope & {
-      dateOfOasysImport: Date
+      oasysImportedDate: Date
     }
     'risk-to-others': {
       whoIsAtRisk: string
@@ -105,19 +105,22 @@ export default class OasysImport implements TaskListPage {
 
   private static isRoshApplicationDataImportedFromOASys(application: Application): boolean {
     const rosh = application.data['risk-of-serious-harm']
-    if (rosh?.['oasys-import']?.oasysImportDate) {
+    if (rosh?.['oasys-import']?.oasysImportedDate) {
       return true
     }
     return false
   }
 
   private static getTaskData(oasysSections: OASysRiskOfSeriousHarm, risks: RoshRisksEnvelope): Partial<RoshTaskData> {
-    const taskData = { 'risk-of-serious-harm': {} } as Partial<RoshTaskData>
+    const taskData = { 'risk-of-serious-harm': { summary: {} } } as Partial<RoshTaskData>
+
     const today = new Date()
 
     taskData['risk-of-serious-harm']['summary-data'] = {
       ...risks,
-      dateOfOasysImport: today,
+      oasysImportedDate: today,
+      oasysStartedDate: oasysSections.dateStarted,
+      oasysCompletedDate: oasysSections.dateCompleted,
     } as SummaryData
 
     oasysSections.rosh.forEach(question => {
@@ -156,7 +159,7 @@ export default class OasysImport implements TaskListPage {
       }
     })
 
-    taskData['risk-of-serious-harm']['oasys-import'] = { oasysImportDate: today }
+    taskData['risk-of-serious-harm']['oasys-import'] = { oasysImportedDate: today }
 
     return taskData
   }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -141,7 +141,7 @@ describe('Summary', () => {
     }
 
     const expectedResponse = {
-      'Over all risk rating': roshSummaryData.value.overallRisk,
+      'Overall risk rating': roshSummaryData.value.overallRisk,
       'Risk to children': roshSummaryData.value.riskToChildren,
       'Risk to known adult': roshSummaryData.value.riskToKnownAdult,
       'Risk to public': roshSummaryData.value.riskToPublic,

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -49,7 +49,7 @@ describe('Summary', () => {
       it('sets the risks to undefined', () => {
         const roshSummaryDataWithoutValue = {
           status: 'not_found' as const,
-          dateOfOasysImport: new Date('2023-09-15'),
+          oasysImportedDate: new Date('2023-09-15'),
         } as SummaryData
 
         const page = new Summary(
@@ -68,7 +68,7 @@ describe('Summary', () => {
       it('sets the risks to undefined', () => {
         const roshSummaryDataWithoutValue = {
           status: 'retrieved' as const,
-          dateOfOasysImport: new Date('2023-09-15'),
+          oasysImportedDate: new Date('2023-09-15'),
         } as SummaryData
 
         const page = new Summary(

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -108,6 +108,9 @@ describe('Summary', () => {
     }
 
     const expectedResponse = {
+      'OASys started': '30 January 2023',
+      'OASys completed': 'Unknown',
+      'OASys imported': '15 September 2023',
       'Overall risk rating': roshSummaryData.value.overallRisk,
       'Risk to children': roshSummaryData.value.riskToChildren,
       'Risk to known adult': roshSummaryData.value.riskToKnownAdult,

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -5,14 +5,15 @@ import Summary, { SummaryData } from './summary'
 describe('Summary', () => {
   const roshSummaryData = {
     status: 'retrieved' as const,
-    dateOfOasysImport: new Date('2023-09-15'),
+    oasysImportedDate: new Date('2023-09-15'),
+    oasysStartedDate: '2023-01-30',
+    oasysCompletedDate: '2023-01-31',
     value: {
       overallRisk: 'a risk',
       riskToChildren: 'another risk',
       riskToPublic: 'a third risk',
       riskToKnownAdult: 'a fourth risk',
       riskToStaff: 'a fifth risk',
-      lastUpdated: '2023-09-17',
     },
   } as SummaryData
 
@@ -44,40 +45,6 @@ describe('Summary', () => {
   })
 
   describe('risks', () => {
-    describe('if there is a last updated date', () => {
-      it('sets the last updated date to UI friendly string', () => {
-        const page = new Summary({}, applicationWithSummaryData)
-
-        expect(page.risks.lastUpdated).toBe('17 September 2023')
-      })
-    })
-
-    describe('if there is not a last updated date', () => {
-      it('sets the last updated date to null', () => {
-        const roshSummaryDataWithoutLastUpdated = {
-          status: 'retrieved' as const,
-          dateOfOasysImport: new Date('2023-09-15'),
-          value: {
-            overallRisk: 'a risk',
-            riskToChildren: 'another risk',
-            riskToPublic: 'a third risk',
-            riskToKnownAdult: 'a fourth risk',
-            riskToStaff: 'a fifth risk',
-          },
-        } as SummaryData
-
-        const page = new Summary(
-          {},
-          {
-            ...applicationWithSummaryData,
-            data: { 'risk-of-serious-harm': { 'summary-data': roshSummaryDataWithoutLastUpdated } },
-          },
-        )
-
-        expect(page.risks.lastUpdated).toBe(null)
-      })
-    })
-
     describe('if the risks have not been found', () => {
       it('sets the risks to undefined', () => {
         const roshSummaryDataWithoutValue = {
@@ -112,14 +79,14 @@ describe('Summary', () => {
           },
         )
 
-        expect(page.risks.lastUpdated).toBe(null)
+        expect(page.risks.value).toBe(undefined)
       })
     })
 
     describe('if risk values exists', () => {
       it('sets the risks', () => {
         const page = new Summary({}, applicationWithSummaryData)
-        expect(page.risks).toEqual({ ...roshSummaryData, lastUpdated: '17 September 2023' })
+        expect(page.risks).toEqual(roshSummaryData)
       })
     })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -80,7 +80,7 @@ export default class Summary implements TaskListPage {
     if (this.isSummaryDataRetrieved(this.application)) {
       const riskRatings = this.application.data['risk-of-serious-harm']['summary-data'].value
       response = {
-        'Over all risk rating': riskRatings.overallRisk,
+        'Overall risk rating': riskRatings.overallRisk,
         'Risk to children': riskRatings.riskToChildren,
         'Risk to known adult': riskRatings.riskToKnownAdult,
         'Risk to public': riskRatings.riskToPublic,

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -11,7 +11,11 @@ export type SummaryBody = {
   additionalComments?: string
 }
 
-export type SummaryData = RoshRisksEnvelope & { dateOfOasysImport: Date }
+export type SummaryData = RoshRisksEnvelope & {
+  oasysImportedDate: Date
+  oasysStartedDate: string
+  oasysCompletedDate?: string
+}
 
 @Page({
   name: 'summary',
@@ -75,13 +79,18 @@ export default class Summary implements TaskListPage {
   response() {
     let response = {}
     if (this.isSummaryDataRetrieved(this.application)) {
-      const riskRatings = this.application.data['risk-of-serious-harm']['summary-data'].value
+      const oasysData = this.application.data['risk-of-serious-harm']['summary-data']
       response = {
-        'Overall risk rating': riskRatings.overallRisk,
-        'Risk to children': riskRatings.riskToChildren,
-        'Risk to known adult': riskRatings.riskToKnownAdult,
-        'Risk to public': riskRatings.riskToPublic,
-        'Risk to staff': riskRatings.riskToStaff,
+        'OASys started': DateFormats.isoDateToUIDate(oasysData.oasysStartedDate, { format: 'medium' }),
+        'OASys completed': oasysData.dateCompleted
+          ? DateFormats.isoDateToUIDate(oasysData.oasysCompletedDate, { format: 'medium' })
+          : 'Unknown',
+        'OASys imported': DateFormats.dateObjtoUIDate(oasysData.oasysImportedDate, { format: 'medium' }),
+        'Overall risk rating': oasysData.value.overallRisk,
+        'Risk to children': oasysData.value.riskToChildren,
+        'Risk to known adult': oasysData.value.riskToKnownAdult,
+        'Risk to public': oasysData.value.riskToPublic,
+        'Risk to staff': oasysData.value.riskToStaff,
       }
     }
     if (this.body.additionalComments) {

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -26,7 +26,7 @@ export default class Summary implements TaskListPage {
 
   body: SummaryBody
 
-  risks: SummaryData & { lastUpdated: string }
+  risks: SummaryData
 
   questions: {
     additionalComments: string
@@ -45,9 +45,6 @@ export default class Summary implements TaskListPage {
       const summaryData = application.data['risk-of-serious-harm']['summary-data'] as SummaryData
       this.risks = {
         ...summaryData,
-        lastUpdated: summaryData.value?.lastUpdated
-          ? DateFormats.isoDateToUIDate(summaryData.value.lastUpdated, { format: 'medium' })
-          : null,
       }
     }
     const roshQuestions = getQuestions(this.personName)['risk-of-serious-harm']

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/currentRisk.ts
@@ -7,6 +7,7 @@ import { getOasysImportDateFromApplication } from '../../../utils'
 import { convertKeyValuePairToCheckboxItems } from '../../../../utils/formUtils'
 import errorLookups from '../../../../i18n/en/errors.json'
 import { getQuestions } from '../../../utils/questions'
+import { DateFormats } from '../../../../utils/dateUtils'
 
 type CurrentRiskBody = { currentRiskDetail: string; confirmation: string }
 
@@ -59,5 +60,26 @@ export default class CurrentRisk implements TaskListPage {
     return convertKeyValuePairToCheckboxItems({ confirmed: this.questions.confirmation.question }, [
       this.body.confirmation,
     ])
+  }
+
+  response() {
+    const oasysData = this.application.data?.['risk-to-self']?.['oasys-import']
+
+    if (oasysData) {
+      return {
+        'OASys started': DateFormats.isoDateToUIDate(oasysData.oasysStartedDate, { format: 'medium' }),
+        'OASys completed': oasysData.oasysCompletedDate
+          ? DateFormats.isoDateToUIDate(oasysData.oasysCompletedDate, { format: 'medium' })
+          : 'Unknown',
+        'OASys imported': DateFormats.dateObjtoUIDate(oasysData.oasysImportedDate, { format: 'medium' }),
+        [this.questions.currentRiskDetail.question]: this.body.currentRiskDetail,
+        [this.questions.confirmation.question]: this.questions.confirmation.answers[this.body.confirmation],
+      }
+    }
+
+    return {
+      [this.questions.currentRiskDetail.question]: this.body.currentRiskDetail,
+      [this.questions.confirmation.question]: this.questions.confirmation.answers[this.body.confirmation],
+    }
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.test.ts
@@ -69,7 +69,11 @@ describe('OasysImport', () => {
             'current-risk': { currentRiskDetail: 'self harm answer' },
             vulnerability: { vulnerabilityDetail: 'vulnerability answer' },
             'historical-risk': { historicalRiskDetail: 'historical answer' },
-            'oasys-import': { oasysImportDate: now },
+            'oasys-import': {
+              oasysImportedDate: now,
+              oasysStartedDate: oasys.dateStarted,
+              oasysCompletedDate: oasys.dateCompleted,
+            },
           },
         }
 

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/custom-forms/oasysImport.ts
@@ -12,7 +12,9 @@ type GuidanceBody = Record<string, never>
 export type RiskToSelfTaskData = {
   'risk-to-self': {
     'oasys-import': {
-      oasysImportDate: Date
+      oasysImportedDate: Date
+      oasysStartedDate: string
+      oasysCompletedDate: string
     }
     'current-risk': {
       currentRiskDetail: string
@@ -115,7 +117,11 @@ export default class OasysImport implements TaskListPage {
       }
     })
 
-    taskData['risk-to-self']['oasys-import'] = { oasysImportDate: today }
+    taskData['risk-to-self']['oasys-import'] = {
+      oasysImportedDate: today,
+      oasysStartedDate: oasysSections.dateStarted,
+      oasysCompletedDate: oasysSections.dateCompleted,
+    }
 
     return taskData
   }

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -169,7 +169,7 @@ describe('utils', () => {
   describe('getOasysImportDateFromApplication', () => {
     it('calls date formatting function when as OASys import date exists', () => {
       const application = applicationFactory.build({
-        data: { 'risk-to-self': { 'oasys-import': { oasysImportDate: 'some date' } } },
+        data: { 'risk-to-self': { 'oasys-import': { oasysImportedDate: 'some date' } } },
       })
 
       ;(DateFormats.isoDateToUIDate as jest.Mock).mockImplementation(() => null)

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -88,8 +88,8 @@ export function pageDataFromApplication(Page: TaskListPageInterface, application
 }
 
 export function getOasysImportDateFromApplication(application: Application, taskName: string): string | null {
-  if (application.data?.[taskName]?.['oasys-import']?.oasysImportDate) {
-    return DateFormats.isoDateToUIDate(application.data?.[taskName]?.['oasys-import']?.oasysImportDate, {
+  if (application.data?.[taskName]?.['oasys-import']?.oasysImportedDate) {
+    return DateFormats.isoDateToUIDate(application.data?.[taskName]?.['oasys-import']?.oasysImportedDate, {
       format: 'medium',
     })
   }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -670,7 +670,6 @@ export const getQuestions = (name: string) => {
         riskToPublic: { question: 'Risk to the public' },
         riskToKnownAdult: { question: 'Risk to a known adult' },
         riskToStaff: { question: 'Risk to staff' },
-        lastUpdated: { question: 'Last updated' },
         additionalComments: { question: 'Additional comments (optional)' },
       },
       'risk-to-others': {

--- a/server/testutils/factories/risks.ts
+++ b/server/testutils/factories/risks.ts
@@ -24,7 +24,6 @@ export const roshRisksEnvelopeFactory = Factory.define<PersonRisks['roshRisks']>
     riskToPublic: faker.helpers.arrayElement(riskLevels),
     riskToKnownAdult: faker.helpers.arrayElement(riskLevels),
     riskToStaff: faker.helpers.arrayElement(riskLevels),
-    lastUpdated: DateFormats.dateObjToIsoDate(faker.date.past()),
   },
 }))
 

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -19,6 +19,7 @@ const {
   checkYourAnswersSections,
   getSections,
   getPage,
+  getPages,
 } = checkYourAnswersUtils
 
 const { getQuestions } = getQuestionsUtil
@@ -191,23 +192,6 @@ describe('checkYourAnswersUtils', () => {
         })
 
         expect(items).toEqual(expected)
-      })
-
-      it(`does not add to items array if question keys don't refer to questions`, () => {
-        jest.spyOn(checkYourAnswersUtils, 'getPage').mockReturnValueOnce(jest.fn())
-
-        const items: Array<SummaryListItem> = []
-
-        addPageAnswersToItemsArray({
-          items,
-          application,
-          task: 'risk-to-self',
-          pageKey: 'oasys-import',
-          questions,
-          outputFormat: 'checkYourAnswers',
-        })
-
-        expect(items).toEqual([])
       })
 
       it('does not add questions to the items array if there is no answer', () => {
@@ -453,6 +437,19 @@ describe('checkYourAnswersUtils', () => {
       const sections = getSections()
 
       expect(sections.filter(section => section.name === 'Check answers')).toHaveLength(0)
+    })
+  })
+
+  describe('getPages', () => {
+    it('returns an array of page keys without oasys-import for risk to self', () => {
+      expect(getPages(application, 'risk-to-self')).toEqual([
+        'current-risk',
+        'vulnerability',
+        'historical-risk',
+        'acct',
+        'acct-data',
+        'additional-information',
+      ])
     })
   })
 })

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -433,6 +433,19 @@ describe('checkYourAnswersUtils', () => {
 
       expect(summaryListItemForQuestion(application, 'task1', 'page1', question)).toEqual(expected)
     })
+
+    describe('when the question is OASys imported', () => {
+      it('returns the task response as a Summary List item without the actions object', () => {
+        const question = { question: 'OASys imported', answer: 'an answer' }
+
+        const expected = {
+          key: { html: 'OASys imported' },
+          value: { html: 'an answer' },
+        }
+
+        expect(summaryListItemForQuestion(application, 'task1', 'page1', question)).toEqual(expected)
+      })
+    })
   })
 
   describe('getSections', () => {

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -167,7 +167,7 @@ export const getSections = (): Array<FormSection> => {
 }
 
 export const getPages = (application: Application, task: string) => {
-  const pagesWithoutQuestions = ['summary', 'summary-data']
+  const pagesWithoutQuestions = ['summary-data', 'oasys-import']
   const pages = application.data[task]
 
   // TODO: Remove the early return before we go live (or feature flag for testing)
@@ -182,7 +182,7 @@ export const getPages = (application: Application, task: string) => {
 }
 
 const containsQuestions = (questionKeys: Array<string>): boolean => {
-  if (!questionKeys.length || (questionKeys.length === 1 && questionKeys[0] === 'oasysImportDate')) {
+  if (!questionKeys.length) {
     return false
   }
   return true

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -136,21 +136,27 @@ export const summaryListItemForQuestion = (
   pageKey: string,
   questionAndAnswer: Record<string, string>,
 ) => {
+  const nonEditablePages = ['summary']
+  const nonEditableQuestions = ['OASys started', 'OASys completed', 'OASys imported']
+
   const { question, answer } = questionAndAnswer
+
+  const actions = {
+    items: [
+      {
+        href: paths.applications.pages.show({ task, page: pageKey, id: application.id }),
+        text: 'Change',
+        visuallyHiddenText: question,
+      },
+    ],
+  }
+
   return {
     key: {
       html: question,
     },
     value: { html: formatLines(answer as string) },
-    actions: {
-      items: [
-        {
-          href: paths.applications.pages.show({ task, page: pageKey, id: application.id }),
-          text: 'Change',
-          visuallyHiddenText: question,
-        },
-      ],
-    },
+    ...(nonEditablePages.includes(pageKey) || nonEditableQuestions.includes(question) ? {} : { actions }),
   }
 }
 

--- a/server/views/applications/pages/risk-of-serious-harm/summary.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/summary.njk
@@ -23,15 +23,9 @@
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   {% if page.importDate %}
-    {% if page.risks.lastUpdated%}
-      <p class="govuk-hint">
-        Imported from OASys on <strong>{{page.importDate}}</strong>, last updated on <strong>{{ page.risks.lastUpdated }}</strong>
-      </p>
-    {% else %}
-      <p class="govuk-hint">
-        Imported from OASys on <strong>{{page.importDate}}</strong>, last updated: <strong>not known</strong>
-      </p>
-    {% endif %}
+    <p class="govuk-hint">
+        Imported from OASys on <strong>{{page.importDate}}</strong>
+    </p>
   {% endif %}
 
   {{ roshWidget(page.risks) }}


### PR DESCRIPTION
# Context

[Trello ticket ](https://trello.com/c/517sYjty/631-cya-sa-add-oasys-dates)

# Changes in this PR

This PR renders OASys started, completed and imported dates to the user on the check your answers and submitted application pages. It also renders the RoSH summary data on these pages. I have saved this data on the oasys-import pages for RoSH and risk to self, and created custom responses on the RoSH summary and risk to self 'current risk' pages to render this data. This is not ideal and requires the page to handle data unrelated to current risk, but for now it appears the least intrusive solution.

The PR also removes the 'last updated' OASys data across the service, since we have learned that it is based entirely on the date started and date completed data. Rather than extrapolating to a value with questionable accuracy, we have chosen simply to render the date started and date completed to users.

## Screenshots of UI changes

### Before

![Screenshot 2024-01-09 at 15 44 13](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/71102ce0-778f-44a3-933c-6400dd670086)

![Screenshot 2024-01-09 at 15 44 25](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/0afffc57-4c7b-4be1-876b-e96dcc920b26)

### After

![Screenshot 2024-01-09 at 15 43 04](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/2910fe14-c94d-4eb9-b36d-4d41da8a0598)

![Screenshot 2024-01-09 at 15 43 19](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/65517769-6a57-4806-8115-9f8549c46949)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
