### PR TITLE
Change submitted app link to go to overview

### DIFF
--- a/integration_tests/pages/submissions/submissionListPage.ts
+++ b/integration_tests/pages/submissions/submissionListPage.ts
@@ -27,7 +27,7 @@ export default class SubmissionListPage extends Page {
     applications.forEach(application => {
       const personName = nameOrPlaceholderCopy(application.person)
       cy.contains(personName)
-        .should('have.attr', 'href', paths.submittedApplications.show({ id: application.id }))
+        .should('have.attr', 'href', paths.submittedApplications.overview({ id: application.id }))
         .parent()
         .parent()
         .within(() => {

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -54,7 +54,7 @@ const nameAnchorElement = (name: string, applicationId: string, isAssessPath: bo
   return htmlValue(
     `<a href=${
       isAssessPath
-        ? assessPaths.submittedApplications.show({ id: applicationId })
+        ? assessPaths.submittedApplications.overview({ id: applicationId })
         : applyPaths.applications.show({ id: applicationId })
     } data-cy-id="${applicationId}">${name}</a>`,
   )


### PR DESCRIPTION
This is for the admin/referrer view of all submitted apps. 

This overview page makes more sense to link to, because the admin can see the history of status updates, and there's no way to go to the overview from the full application view.

![Screenshot 2024-01-10 at 12 28 43](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/eb30dfb6-c50c-4381-b717-7abdf412e94f)


