### PR TITLE
CircleCI can deploy to prod with a manual check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,23 +270,20 @@ workflows:
             - hmpps-community-accommodation-tier-2-ui-preprod
           requires:
             - request-preprod-approval
-      # - request-prod-approval:
-      #      type: approval
-      #      requires:
-      #        - deploy_preprod
-      # - hmpps/deploy_env:
-      #      name: deploy_prod
-      #      env: "prod"
-      #      jira_update: true
-      #      jira_env_type: production
-      #      slack_notification: true
-      #      slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-      #      context:
-      #        - hmpps-common-vars
-      #        - hmpps-community-accommodation-tier-2-ui-prod
-      #      requires:
-      #        - request-prod-approval
-      #      helm_timeout: 5m
+      - request-prod-approval:
+           type: approval
+           requires:
+             - deploy_preprod
+      - hmpps/deploy_env:
+           name: deploy_prod
+           env: "prod"
+           slack_notification: true
+           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+           context:
+             - hmpps-common-vars
+             - hmpps-community-accommodation-tier-2-ui-prod
+           requires:
+             - request-prod-approval
 
   security:
     triggers:


### PR DESCRIPTION
# Context

https://trello.com/c/EFt2j3Lz

# Changes in this PR

Now we are close to having a production environment we want to be able to release code to it. We extend the established deployment pattern by chaining prod as a manual step after the successful deploy of preprod.

We remove jira config and helm_timeout in line with what the other CAS frontends[1] ended up with.

[1] https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/9b9caa0f2eb1c59879b38b05e9bb8930c0bafaff

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
