### PR TITLE
765 download application status updates report

### DIFF
--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -19,12 +19,12 @@ export default class ManagementInfoDownloadsPage extends Page {
 
   shouldShowManagementInfoDownloads(): void {
     cy.contains('Download management information in spreadsheet format')
-    cy.contains('Submitted applications').should(
+    cy.contains("Download 'Submitted applications' report").should(
       'have.attr',
       'href',
       paths.report.create({ name: 'submitted-applications' }),
     )
-    cy.contains('Application status updates').should(
+    cy.contains("Download 'Application status updates' report").should(
       'have.attr',
       'href',
       paths.report.create({ name: 'application-status-updates' }),

--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -24,5 +24,10 @@ export default class ManagementInfoDownloadsPage extends Page {
       'href',
       paths.report.create({ name: 'submitted-applications' }),
     )
+    cy.contains('Application status updates').should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'application-status-updates' }),
+    )
   }
 }

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -5,24 +5,110 @@
 {% block content %}
   <div class="govuk-grid-row">
     <h1 class="govuk-heading-l">Management information reports</h1>
-    <p>Download management information in spreadsheet format</p>
 
-    {% block button %}
-      <div class="govuk-button-group">
-        {{ govukButton({
-              text: "Submitted applications",
-              href: paths.report.create({
-                      name: "submitted-applications"
-                    })
-      }) }}
+    <p class="govuk-body">Download management information in spreadsheet format (.xlsx):</p>
 
-        {{ govukButton({
-              text: "Application status updates",
-              href: paths.report.create({
-                      name: "application-status-updates"
-                    })
-      }) }}
+    <h2 class="govuk-heading-m">
+      Submitted applications
+    </h2>
+
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Report details
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        Key information about submitted applications e.g.:
+        <ul class="govuk-list govuk-list govuk-!-margin-left-5 govuk-!-margin-top-5 govuk-body-s">
+          <li>
+            <code>eventId: 63cbe435-768e-43ab-9164-a57784926f91</code>
+          </li>
+          <li>
+            <code>applicationId: 6620721f-eba5-4a10-affb-dd3309b04f41</code>
+          </li>
+          <li>
+            <code>personCrn: X320741</code>
+          </li>
+          <li>
+            <code>personNoms: A1234AI</code>
+          </li>
+          <li>
+            <code>referringPrisonCode: LEI (Agency ID)</code>
+          </li>
+          <li>
+            <code>preferredAreas: Leeds | Bradford</code>
+          </li>
+          <li>
+            <code>hdcEligibilityDate: 2023-03-30</code>
+          </li>
+          <li>
+            <code>conditionalReleaseDate: 2023-04-29</code>
+          </li>
+          <li>
+            <code>submittedOn: 2024-01-03</code>
+          </li>
+          <li>
+            <code>submittedBy: NOMIS_USER_NAME</code>
+          </li>
+        </ul>
       </div>
-    {% endblock %}
-  </div>
+    </details>
+
+    {{ govukButton({
+            text: "Download 'Submitted applications' report",
+            classes: "govuk-button--secondary",
+            href: paths.report.create({
+                    name: "submitted-applications"
+                  })
+    }) }}
+  </li>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">
+        Application status updates
+  </h2>
+
+  <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+          Report details
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        Key information about status updates attached to applications e.g.:
+        <ul class="govuk-list govuk-list govuk-!-margin-left-5 govuk-!-margin-top-5 govuk-body-s">
+        <li>
+          <code>eventId: "364145f9-0af8-488e-9901-b4c46cd9ba37"</code>
+        </li>
+        <li>
+          <code>applicationId "3fa85f64-5717-4562-b3fc-2c963f66afa6"</code>
+        </li>
+        <li>
+          <code>personCrn: "X320741"</code>
+        </li>
+        <li>
+          <code>personNoms: "A1234AI"</code>
+        </li>
+        <li>
+          <code>updatedBy: "CAS2_ASSESSOR_USER"</code>
+        </li>
+        <li>
+          <code>updatedAt: "2024-01-09T09:17:55"</code>
+        </li>
+        <li>
+          <code>newStatus: "moreInfoRequested"</code>
+        </li>
+      </ul>
+    </div>
+  </details>
+
+  {{ govukButton({
+            text: "Download 'Application status updates' report",
+            classes: "govuk-button--secondary",
+            href: paths.report.create({
+                    name: "application-status-updates"
+                  })
+    }) }}
+
+</div>
 {% endblock %}

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -15,6 +15,13 @@
                       name: "submitted-applications"
                     })
       }) }}
+
+        {{ govukButton({
+              text: "Application status updates",
+              href: paths.report.create({
+                      name: "application-status-updates"
+                    })
+      }) }}
       </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
# MI User can download new report on 'Application status updates'

[Trello 765](https://trello.com/c/GV3HWCzy/765-download-application-status-updates-report)

## Screenshots of UI changes

### Before

<img width="833" alt="reports_index_2" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/60f038d1-e3b5-4874-a1cc-8f0fb1293b91">


### After

![mi_downloads_page](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/6d8a0592-5e2c-4751-9d57-dcf381e5174d)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [x] Does this rely on changes being deployed to the CAS API? -> Yes: requests for the new report will 404 until https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1315 is deployed

