### PR TITLE
IN_MAINTENANCE_MODE will accept true as a string or a boolean

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -101,7 +101,7 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
-    maintenanceMode: get('IN_MAINTENANCE_MODE', 'false'),
+    maintenanceMode: get('IN_MAINTENANCE_MODE', false),
   },
   analytics: {
     tagManagerId: get('TAG_MANAGER_ID', null),

--- a/server/middleware/setUpMaintenancePageRedirect.test.ts
+++ b/server/middleware/setUpMaintenancePageRedirect.test.ts
@@ -45,11 +45,22 @@ describe('setUpMaintenancePageRedirect', () => {
   })
 
   describe('when the IN_MAINTENANCE_MODE environment is set to true', () => {
-    it('should redirect to the maintenance page', async () => {
-      config.flags.maintenanceMode = 'true'
-      const app = setupApp()
-      const response = await request(app).get('/known').expect(302)
-      expect(response.text).toContain('Found. Redirecting to /maintenance')
+    describe('and the value is a string', () => {
+      it('should redirect to the maintenance page', async () => {
+        config.flags.maintenanceMode = 'true'
+        const app = setupApp()
+        const response = await request(app).get('/known').expect(302)
+        expect(response.text).toContain('Found. Redirecting to /maintenance')
+      })
+    })
+
+    describe('and the value is a boolean', () => {
+      it('should redirect to the maintenance page', async () => {
+        config.flags.maintenanceMode = true
+        const app = setupApp()
+        const response = await request(app).get('/known').expect(302)
+        expect(response.text).toContain('Found. Redirecting to /maintenance')
+      })
     })
 
     describe('and the requested page should not be redirected', () => {

--- a/server/middleware/setUpMaintenancePageRedirect.ts
+++ b/server/middleware/setUpMaintenancePageRedirect.ts
@@ -7,7 +7,7 @@ export default function setUpMaintenancePageRedirect(): Router {
 
   router.use((req, res, next) => {
     if (
-      config.flags.maintenanceMode === 'true' &&
+      (config.flags.maintenanceMode === 'true' || config.flags.maintenanceMode === true) &&
       !allowedPaths.includes(req.path) &&
       !res.locals.user?.roles.includes('ROLE_CAS2_ADMIN')
     ) {


### PR DESCRIPTION
We aren't seeing the maintenance page on preprod desipite the flag being on and nobody being an admin. https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/

When loading this variable through Helm on preprod (when the value is set to `false`) we get the value coming out of the pod:

```
IN_MAINTENANCE_MODE=true
```

This is on the face of it ok as it’s how we set it locally with .env:

```
IN_MAINTENANCE_MODE=false
```

I think it’s not working because .env loads it as a string but YAML recognises it as a boolean[1].

[1] https://helm.sh/docs/chart_best_practices/values/#make-types-clear

Given we want to use .env locally we continue to check for string for wider compatibility. We could also go the other way and explicitly set it as a string in YAML.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
