### PR TITLE
Add confirmation panel to the top of the screen when save and add another has been used

### DIFF
--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -37,4 +37,11 @@ export default class ApplyPage extends Page {
   clickConfirm(): void {
     this.checkCheckboxByValue('confirmed')
   }
+
+  shouldShowSuccessMessage(message: string): void {
+    cy.get('.govuk-notification-banner').within(() => {
+      cy.get('h2').contains('Success')
+      cy.get('h3').contains(message)
+    })
+  }
 }

--- a/integration_tests/tests/apply/offence_and_licence_information/current-offences/current_offence_data.cy.ts
+++ b/integration_tests/tests/apply/offence_and_licence_information/current-offences/current_offence_data.cy.ts
@@ -16,6 +16,7 @@
 //    Given I have filled in required information for an offence
 //    When I save and add another
 //    Then I am taken to a blank "Add current offence" page
+//    And I see a success message
 
 import CurrentOffenceDataPage from '../../../../pages/apply/offence_and_licence_information/current-offences/currentOffenceDataPage'
 import CurrentOffencesPage from '../../../../pages/apply/offence_and_licence_information/current-offences/currentOffencesPage'
@@ -90,5 +91,8 @@ context('Visit "Offence and licence" section', () => {
     //  Then I am taken to a blank "Add current offence" page
     Page.verifyOnPage(CurrentOffenceDataPage, this.application)
     page.assertFormisEmpty()
+
+    //  And I see a success message
+    page.shouldShowSuccessMessage('The offence has been saved')
   })
 })

--- a/integration_tests/tests/apply/offence_and_licence_information/offending-history/offence_history_data.cy.ts
+++ b/integration_tests/tests/apply/offence_and_licence_information/offending-history/offence_history_data.cy.ts
@@ -16,6 +16,7 @@
 //    Given I have filled in required information for an offence
 //    When I save and add another
 //    Then I am taken to a blank "Add a previous offence" page
+//    And I see a success message
 
 import OffenceHistoryDataPage from '../../../../pages/apply/offence_and_licence_information/offending-history/offenceHistoryDataPage'
 import OffenceHistoryPage from '../../../../pages/apply/offence_and_licence_information/offending-history/offenceHistoryPage'
@@ -90,5 +91,8 @@ context('Visit "Offence and licence" section', () => {
     //    Then I am taken to a blank "Add a previous offence" page
     Page.verifyOnPage(OffenceHistoryDataPage, this.application)
     page.assertFormisEmpty()
+
+    //  And I see a success message
+    page.shouldShowSuccessMessage('The offence has been saved')
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/behaviour_notes_data.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/behaviour_notes_data.cy.ts
@@ -16,6 +16,7 @@
 //    Given I have filled in required information for a behaviour note
 //    When I save and add another
 //    Then I am taken to a blank "Add a behaviour note" page
+//    And I see a success message
 
 import BehaviourNotesPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotesPage'
 import BehaviourNotesDataPage from '../../../../pages/apply/risks-and-needs/risk-of-serious-harm/behaviourNotesDataPage'
@@ -81,9 +82,11 @@ context('Visit "Risks and needs" section', () => {
 
       const body = JSON.parse(requests[0].body)
 
-      expect(body.data['risk-of-serious-harm']['behaviour-notes-data']).to.have.deep.members([
-        { behaviourDetail: 'some detail' },
-      ])
+      cy.wrap(body.data['risk-of-serious-harm']['behaviour-notes-data'][0]).should(
+        'have.property',
+        'behaviourDetail',
+        'some detail',
+      )
     })
   })
 
@@ -100,5 +103,8 @@ context('Visit "Risks and needs" section', () => {
     //    Then I am taken to a blank "Add a behaviour note" page
     Page.verifyOnPage(BehaviourNotesDataPage, this.application)
     page.assertFormisEmpty()
+
+    //  And I see a success message
+    page.shouldShowSuccessMessage('The behaviour note has been saved')
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/risk-to-self/acct_data.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-to-self/acct_data.cy.ts
@@ -16,6 +16,7 @@
 //    Given I have filled in required information for an ACCT
 //    When I save and add another
 //    Then I am taken to a blank "Add an ACCT" page
+//    And I see a success message
 
 import AcctPage from '../../../../pages/apply/risks-and-needs/risk-to-self/acctPage'
 import AcctDataPage from '../../../../pages/apply/risks-and-needs/risk-to-self/acctDataPage'
@@ -90,5 +91,8 @@ context('Visit "Risks and needs" section', () => {
     //    Then I am taken to a blank "Add an ACCT" page
     Page.verifyOnPage(AcctDataPage, this.application)
     page.assertFormisEmpty()
+
+    //  And I see a success message
+    page.shouldShowSuccessMessage('The ACCT has been saved')
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -425,6 +425,7 @@ describe('applicationsController', () => {
           page: 'example-page',
           task: 'example-task',
         }
+        request.flash = jest.fn()
 
         const PageConstructor = jest.fn()
         ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
@@ -445,6 +446,8 @@ describe('applicationsController', () => {
           await requestHandler({ ...request }, response)
 
           expect(applicationService.appendToList).toHaveBeenCalledWith(page, request)
+
+          expect(request.flash).toHaveBeenCalledWith('success', '')
 
           expect(response.redirect).toHaveBeenCalledWith('/applications/abc123/tasks/example-task/pages/redirect-page')
         })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -16,6 +16,7 @@ import {
   firstPageOfConsentTask,
   consentIsConfirmed,
   consentIsDenied,
+  generateSuccessMessage,
 } from '../../utils/applications/utils'
 import TaskListService from '../../services/taskListService'
 import paths from '../../paths/apply'
@@ -204,7 +205,10 @@ export default class ApplicationsController {
 
       try {
         await this.applicationService.appendToList(page, req)
+
+        req.flash('success', generateSuccessMessage(pageName))
         const next = page.next()
+
         if (redirectPage) {
           res.redirect(paths.applications.pages.show({ id, task: taskName, page: redirectPage as string }))
         } else if (next) {

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.test.ts
@@ -82,7 +82,7 @@ describe('CurrentOffences', () => {
   })
 
   itShouldHaveNextValue(new CurrentOffences({}, application), '')
-  itShouldHavePreviousValue(new CurrentOffences({}, application), 'current-offence-data')
+  itShouldHavePreviousValue(new CurrentOffences({}, application), 'taskList')
 
   describe('errors', () => {
     it('returns an empty object where there is current offence data', () => {

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.ts
@@ -90,7 +90,7 @@ export default class CurrentOffences implements TaskListPage {
   }
 
   previous() {
-    return 'current-offence-data'
+    return 'taskList'
   }
 
   next() {

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
@@ -28,7 +28,7 @@ describe('CurrentOffenceData', () => {
   })
 
   itShouldHaveNextValue(new CurrentOffenceData({}, application), 'current-offences')
-  itShouldHavePreviousValue(new CurrentOffenceData({}, application), '')
+  itShouldHavePreviousValue(new CurrentOffenceData({}, application), 'current-offences')
 
   describe('errors', () => {
     describe('when there are no errors', () => {

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
@@ -78,7 +78,7 @@ export default class CurrentOffenceData implements TaskListPage {
   }
 
   previous() {
-    return ''
+    return 'current-offences'
   }
 
   next() {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -87,3 +87,18 @@ export const getApplicationTimelineEvents = (application: Cas2SubmittedApplicati
     getSubmittedTimelineEvent(application.submittedBy.name, application.submittedAt),
   ]
 }
+
+export const generateSuccessMessage = (pageName: string): string => {
+  switch (pageName) {
+    case 'current-offence-data':
+      return 'The offence has been saved'
+    case 'offence-history-data':
+      return 'The offence has been saved'
+    case 'behaviour-notes-data':
+      return 'The behaviour note has been saved'
+    case 'acct-data':
+      return 'The ACCT has been saved'
+    default:
+      return ''
+  }
+}

--- a/server/views/applications/pages/current-offences/current-offence-data.njk
+++ b/server/views/applications/pages/current-offences/current-offence-data.njk
@@ -55,6 +55,16 @@
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       {{ showErrorSummary(errorSummary) }}
+
+      {% if successMessages %}
+        {% for message in successMessages %}
+          {{ govukNotificationBanner({
+                html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+                type: 'success',
+                titleId: 'success-title'
+              }) }}
+        {% endfor %}
+      {% endif %}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
         <p>Add one offence at a time. For example, you should record 3 drug-related offences as 3 separate offences.</p>

--- a/server/views/applications/pages/offending-history/offence-history-data.njk
+++ b/server/views/applications/pages/offending-history/offence-history-data.njk
@@ -10,6 +10,16 @@
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       {{ showErrorSummary(errorSummary) }}
+
+      {% if successMessages %}
+        {% for message in successMessages %}
+          {{ govukNotificationBanner({
+                html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+                type: 'success',
+                titleId: 'success-title'
+              }) }}
+        {% endfor %}
+      {% endif %}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
         <p>You must include unspent offences involving:

--- a/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/behaviour-notes-data.njk
@@ -9,6 +9,16 @@
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-three-quarters") }}">
       {{ showErrorSummary(errorSummary) }}
+
+      {% if successMessages %}
+        {% for message in successMessages %}
+          {{ govukNotificationBanner({
+                html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+                type: 'success',
+                titleId: 'success-title'
+              }) }}
+        {% endfor %}
+      {% endif %}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <div class="govuk-body">
         <p>Behaviour notes are positive or negative notes about an applicant's behaviour.</p>

--- a/server/views/applications/pages/risk-to-self/acct-data.njk
+++ b/server/views/applications/pages/risk-to-self/acct-data.njk
@@ -28,6 +28,16 @@
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       {{ showErrorSummary(errorSummary) }}
+
+      {% if successMessages %}
+        {% for message in successMessages %}
+          {{ govukNotificationBanner({
+                html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+                type: 'success',
+                titleId: 'success-title'
+              }) }}
+        {% endfor %}
+      {% endif %}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
       <p class="govuk-body">An Assessment, Care in Custody and Teamwork (ACCT) 
           is a tailored plan to support someone in prison at risk of self harm or suicide.</p>


### PR DESCRIPTION
# Context

[Trello ticket](https://trello.com/c/qN2NwjFw/555-add-confirmation-panel-to-the-top-of-the-screen-when-save-and-add-another-has-been-used)

# Changes in this PR

Adds success notification banners for ACCTs, behaviour notes, current and historic offences. These will render when the user selects 'Save and add another', remaining on the same page, so that they understand that their previous entry has been saved.

## Screenshots of UI changes

### Before
![Screenshot 2024-01-12 at 11 08 15](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/70701ab2-2d1b-4072-9de2-1b781c3f8e21)

### After

![Screenshot 2024-01-12 at 13 45 09](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/e007a7da-dd3f-4e6a-9310-f3ba362e1fdf)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
