### PR TITLE
Restrict tiles for CAS2_ADMIN to 'Submitted applications'

### DIFF
--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -62,7 +62,7 @@ context('Dashboard', () => {
     const page = Page.verifyOnPage(DashboardPage)
 
     //  Then see the correct cards
-    page.shouldShowCards(['referrals', 'new-referral', 'submitted-applications'])
+    page.shouldShowCards(['submitted-applications'])
   })
 
   //  Scenario: viewing the dashboard page as an assessor

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -12,7 +12,7 @@ describe('userUtils', () => {
     })
 
     it('should return correct sections for an admin', () => {
-      const expected = [sections.referral, sections.newReferral, sections.submittedApplications]
+      const expected = [sections.submittedApplications]
       expect(sectionsForUser(['ROLE_CAS2_ADMIN'])).toEqual(expected)
     })
 

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -42,7 +42,7 @@ export const hasRole = (userRoles: Array<string>, role: string): boolean => {
 export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection> => {
   const items = []
 
-  if (hasRole(userRoles, 'ROLE_POM') || hasRole(userRoles, 'ROLE_CAS2_ADMIN')) {
+  if (hasRole(userRoles, 'ROLE_POM')) {
     items.push(sections.referral)
     items.push(sections.newReferral)
   }


### PR DESCRIPTION
This removes the 'view/create referrals' tiles from the dashboard home page for Admin's. 

Previously we thought that Admin's should be able to make applications, but we are now restricting that to POM's only. Admin's such as contract managers should only be able to view submitted applications. 



