### PR TITLE
Add a link for MI_USER to download 'Un-submitted applications' report

### DIFF
--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -29,5 +29,10 @@ export default class ManagementInfoDownloadsPage extends Page {
       'href',
       paths.report.create({ name: 'application-status-updates' }),
     )
+    cy.contains("Download 'Un-submitted applications' report").should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'unsubmitted-applications' }),
+    )
   }
 }

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -110,5 +110,45 @@
                   })
     }) }}
 
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">
+    Un-submitted applications
+  </h2>
+
+  <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+          Report details
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        Key information about applications which have not been submitted e.g.:
+        <ul class="govuk-list govuk-list govuk-!-margin-left-5 govuk-!-margin-top-5 govuk-body-s">
+        <li>
+          <code>applicationId "3fa85f64-5717-4562-b3fc-2c963f66afa6"</code>
+        </li>
+        <li>
+          <code>personCrn: "X320741"</code>
+        </li>
+        <li>
+          <code>personNoms: "A1234AI"</code>
+        </li>
+        <li>
+          <code>startedBy: "POM_USER"</code>
+        </li>
+        <li>
+          <code>startedAt: "2024-01-09T09:17:55"</code>
+        </li>
+      </ul>
+    </div>
+  </details>
+
+  {{ govukButton({
+            text: "Download 'Un-submitted applications' report",
+            classes: "govuk-button--secondary",
+            href: paths.report.create({
+                    name: "unsubmitted-applications"
+                  })
+    }) }}
+
 </div>
 {% endblock %}


### PR DESCRIPTION
# MI User downloads "Un-submitted applications" report

See [Trello 766](https://trello.com/c/vN0AmVz2/766-download-un-submitted-applications-report)

# Changes in this PR

Adds a link to download from API: `/cas2/reports/unsubmitted-applications`

## Screenshots of UI changes

![unsubmitted-applications](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/41b18654-178e-4427-aa5c-2e9f8c41b097)



