### PR TITLE
(775) Add a 'warning' notice that MI data is limited to past year.

### DIFF
--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -5,6 +5,7 @@ export default class ManagementInfoDownloadsPage extends Page {
   constructor() {
     super('Management information reports', undefined)
     this.pageHasMiTitle()
+    this.pageIncludesDataLimitNotice()
   }
 
   static visit(): ManagementInfoDownloadsPage {
@@ -15,6 +16,10 @@ export default class ManagementInfoDownloadsPage extends Page {
 
   pageHasMiTitle(): void {
     cy.title().should('include', 'Download reports')
+  }
+
+  pageIncludesDataLimitNotice(): void {
+    cy.contains('The data in these reports is limited to the last 12 months.')
   }
 
   shouldShowManagementInfoDownloads(): void {

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block head %}
   <!--[if !IE 8]><!-->

--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -6,6 +6,11 @@
   <div class="govuk-grid-row">
     <h1 class="govuk-heading-l">Management information reports</h1>
 
+    {{ govukWarningText({
+      text: "The data in these reports is limited to the last 12 months.",
+      iconFallbackText: "Warning"
+    }) }}
+
     <p class="govuk-body">Download management information in spreadsheet format (.xlsx):</p>
 
     <h2 class="govuk-heading-m">


### PR DESCRIPTION
See [Trello 775](https://trello.com/c/yBEek6bp/775-limit-mi-reports-to-last-12-months)

We use the "warning text" component:

https://design-system.service.gov.uk/components/warning-text/

## Screenshots of UI changes

![mi_data_limit_warning](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/c3aa5857-a81e-4a0e-862f-05cf93f7071a)


