### PR TITLE
Remove offence codes

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -289,7 +289,7 @@
   "current-offences": {
     "current-offence-data": [
       {
-        "titleAndNumber": "Arson (09000)",
+        "titleAndNumber": "Arson",
         "offenceCategory": "Arson",
         "offenceDate-day": "5",
         "offenceDate-month": "6",
@@ -300,7 +300,7 @@
         "outstandingChargesDetail": "outstanding charges detail"
       },
       {
-        "titleAndNumber": "Stalking (08000)",
+        "titleAndNumber": "Stalking",
         "offenceCategory": "Stalking",
         "offenceDate-day": "6",
         "offenceDate-month": "7",
@@ -316,7 +316,7 @@
     "any-previous-convictions": { "hasAnyPreviousConvictions": "yes" },
     "offence-history-data": [
       {
-        "titleAndNumber": "Arson (09000)",
+        "titleAndNumber": "Arson",
         "offenceCategory": "Arson",
         "offenceDate-day": "5",
         "offenceDate-month": "6",
@@ -325,7 +325,7 @@
         "summary": "summary detail"
       },
       {
-        "titleAndNumber": "Stalking (08000)",
+        "titleAndNumber": "Stalking",
         "offenceCategory": "Stalking",
         "offenceDate-day": "6",
         "offenceDate-month": "7",

--- a/integration_tests/pages/apply/offence_and_licence_information/current-offences/currentOffencesPage.ts
+++ b/integration_tests/pages/apply/offence_and_licence_information/current-offences/currentOffencesPage.ts
@@ -24,7 +24,7 @@ export default class CurrentOffencesPage extends ApplyPage {
   }
 
   hasListOfOffences(): void {
-    cy.get('.govuk-summary-card__title').contains('Arson (09000)')
+    cy.get('.govuk-summary-card__title').contains('Arson')
     cy.get('.govuk-summary-list').contains('summary detail')
     cy.get('.govuk-summary-list').contains('2 months')
     cy.get('.govuk-summary-list').contains('outstanding charges detail')

--- a/integration_tests/pages/apply/offence_and_licence_information/offending-history/offenceHistoryPage.ts
+++ b/integration_tests/pages/apply/offence_and_licence_information/offending-history/offenceHistoryPage.ts
@@ -24,7 +24,7 @@ export default class OffenceHistoryPage extends ApplyPage {
   }
 
   hasListOfOffences(): void {
-    cy.get('.govuk-summary-card__title').contains('Arson (09000)')
+    cy.get('.govuk-summary-card__title').contains('Arson')
     cy.get('.govuk-summary-list').contains('summary detail')
     cy.get('.govuk-summary-list').contains('2 months')
   }

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/currentOffences.test.ts
@@ -14,7 +14,7 @@ describe('CurrentOffences', () => {
       'current-offences': {
         'current-offence-data': [
           {
-            titleAndNumber: 'Stalking (08000)',
+            titleAndNumber: 'Stalking',
             offenceCategory: 'stalkingOrHarassment',
             'offenceDate-day': '1',
             'offenceDate-month': '2',
@@ -25,7 +25,7 @@ describe('CurrentOffences', () => {
             outstandingChargesDetail: 'some detail',
           },
           {
-            titleAndNumber: 'Arson (09000)',
+            titleAndNumber: 'Arson',
             offenceCategory: 'arson',
             'offenceDate-day': '5',
             'offenceDate-month': '6',
@@ -55,7 +55,7 @@ describe('CurrentOffences', () => {
 
         expect(page.offences).toEqual([
           {
-            titleAndNumber: 'Stalking (08000)',
+            titleAndNumber: 'Stalking',
             offenceCategoryTag: '<strong class="govuk-tag govuk-tag--blue">Stalking or Harassment</strong>',
             offenceCategoryText: 'Stalking or Harassment',
             offenceDate: '1 February 2023',
@@ -66,7 +66,7 @@ describe('CurrentOffences', () => {
             removeLink: `/applications/${applicationWithData.id}/tasks/current-offences/pages/current-offence-data/0/removeFromList?redirectPage=current-offences`,
           },
           {
-            titleAndNumber: 'Arson (09000)',
+            titleAndNumber: 'Arson',
             offenceCategoryTag: '<strong class="govuk-tag govuk-tag--yellow">Arson</strong>',
             offenceCategoryText: 'Arson',
             offenceDate: '5 June 1940',
@@ -101,9 +101,9 @@ describe('CurrentOffences', () => {
       const page = new CurrentOffences({}, applicationWithData)
       expect(page.response()).toEqual({
         'Current offence 1':
-          'Stalking (08000)\r\nStalking or Harassment\r\n1 February 2023\r\n12 months\r\n\nSummary: summary detail\r\nOutstanding charges: Yes\r\nDetails of outstanding charges: some detail',
+          'Stalking\r\nStalking or Harassment\r\n1 February 2023\r\n12 months\r\n\nSummary: summary detail\r\nOutstanding charges: Yes\r\nDetails of outstanding charges: some detail',
         'Current offence 2':
-          'Arson (09000)\r\nArson\r\n5 June 1940\r\n3 years\r\n\nSummary: second summary detail\r\nOutstanding charges: No',
+          'Arson\r\nArson\r\n5 June 1940\r\n3 years\r\n\nSummary: second summary detail\r\nOutstanding charges: No',
       })
     })
 

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
@@ -7,7 +7,7 @@ describe('CurrentOffenceData', () => {
 
   const currentOffenceData = [
     {
-      titleAndNumber: 'Stalking (08000)',
+      titleAndNumber: 'Stalking',
       offenceCategory: 'Arson',
       'offenceDate-day': '1',
       'offenceDate-month': '2',
@@ -40,7 +40,7 @@ describe('CurrentOffenceData', () => {
 
     describe('when there are errors', () => {
       const requiredFields = [
-        ['titleAndNumber', 'Enter offence title and number'],
+        ['titleAndNumber', 'Enter the offence title'],
         ['offenceCategory', 'Select the offence category'],
         ['offenceDate', 'Enter the date the offence was committed'],
         ['sentenceLength', 'Enter the sentence length'],
@@ -58,7 +58,7 @@ describe('CurrentOffenceData', () => {
       it('when outstanding charges are selected but no detail is provided', () => {
         const page = new CurrentOffenceData(
           {
-            titleAndNumber: 'Stalking (08000)',
+            titleAndNumber: 'Stalking',
             offenceCategory: 'Arson',
             'offenceDate-day': '1',
             'offenceDate-month': '2',

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
@@ -89,7 +89,7 @@ export default class CurrentOffenceData implements TaskListPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.titleAndNumber) {
-      errors.titleAndNumber = 'Enter offence title and number'
+      errors.titleAndNumber = 'Enter the offence title'
     }
     if (this.body.offenceCategory === 'choose') {
       errors.offenceCategory = 'Select the offence category'

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.test.ts
@@ -7,7 +7,7 @@ describe('OffenceHistoryData', () => {
 
   const offenceHistoryData = [
     {
-      titleAndNumber: 'Stalking (08000)',
+      titleAndNumber: 'Stalking',
       offenceCategory: 'Arson',
       'offenceDate-day': '1',
       'offenceDate-month': '2',
@@ -37,7 +37,7 @@ describe('OffenceHistoryData', () => {
     })
 
     const requiredFields = [
-      ['titleAndNumber', 'Enter offence title and number'],
+      ['titleAndNumber', 'Enter the offence title'],
       ['offenceCategory', 'Select the offence category'],
       ['offenceDate', 'Enter the date the offence was committed'],
       ['sentenceLength', 'Enter the sentence length'],

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.ts
@@ -85,7 +85,7 @@ export default class OffenceHistoryData implements TaskListPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.titleAndNumber) {
-      errors.titleAndNumber = 'Enter offence title and number'
+      errors.titleAndNumber = 'Enter the offence title'
     }
     if (this.body.offenceCategory === 'choose') {
       errors.offenceCategory = 'Select the offence category'

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/offenceHistory.test.ts
@@ -11,7 +11,7 @@ describe('OffenceHistory', () => {
       'offending-history': {
         'offence-history-data': [
           {
-            titleAndNumber: 'Stalking (08000)',
+            titleAndNumber: 'Stalking',
             offenceCategory: 'stalkingOrHarassment',
             'offenceDate-day': '1',
             'offenceDate-month': '2',
@@ -20,7 +20,7 @@ describe('OffenceHistory', () => {
             summary: 'summary detail',
           },
           {
-            titleAndNumber: 'Arson (09000)',
+            titleAndNumber: 'Arson',
             offenceCategory: 'arson',
             'offenceDate-day': '5',
             'offenceDate-month': '6',
@@ -48,7 +48,7 @@ describe('OffenceHistory', () => {
 
         expect(page.offences).toEqual([
           {
-            titleAndNumber: 'Stalking (08000)',
+            titleAndNumber: 'Stalking',
             offenceCategoryTag: '<strong class="govuk-tag govuk-tag--blue">Stalking or Harassment</strong>',
             offenceCategoryText: 'Stalking or Harassment',
             offenceDate: '1 February 2023',
@@ -57,7 +57,7 @@ describe('OffenceHistory', () => {
             removeLink: `/applications/${applicationWithData.id}/tasks/offending-history/pages/offence-history-data/0/removeFromList?redirectPage=offence-history`,
           },
           {
-            titleAndNumber: 'Arson (09000)',
+            titleAndNumber: 'Arson',
             offenceCategoryTag: '<strong class="govuk-tag govuk-tag--yellow">Arson</strong>',
             offenceCategoryText: 'Arson',
             offenceDate: '5 June 1940',
@@ -85,8 +85,8 @@ describe('OffenceHistory', () => {
       const page = new OffenceHistory({}, applicationWithData)
       expect(page.response()).toEqual({
         'Historical offence 1':
-          'Stalking (08000)\r\nStalking or Harassment\r\n1 February 2023\r\n12 months\r\n\nSummary: summary detail',
-        'Historical offence 2': 'Arson (09000)\r\nArson\r\n5 June 1940\r\n3 years\r\n\nSummary: second summary detail',
+          'Stalking\r\nStalking or Harassment\r\n1 February 2023\r\n12 months\r\n\nSummary: summary detail',
+        'Historical offence 2': 'Arson\r\nArson\r\n5 June 1940\r\n3 years\r\n\nSummary: second summary detail',
       })
     })
 

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -759,8 +759,8 @@ export const getQuestions = (name: string) => {
     'current-offences': {
       'current-offence-data': {
         titleAndNumber: {
-          question: 'Offence title and number',
-          hint: "For example, 'Stalking (08000)'",
+          question: 'Offence title',
+          hint: "For example, 'Stalking'",
         },
         offenceCategory,
         offenceDate: {
@@ -793,8 +793,8 @@ export const getQuestions = (name: string) => {
       },
       'offence-history-data': {
         titleAndNumber: {
-          question: 'Offence title and number',
-          hint: "For example, 'Stalking (08000)'",
+          question: 'Offence title',
+          hint: "For example, 'Stalking'",
         },
         offenceCategory,
         offenceDate: {


### PR DESCRIPTION
# Context

https://trello.com/c/XLkKfuLw/769-remove-the-oasys-code-number-request-on-offences-entries-in-current-offence-and-offence-history-sections

# Changes in this PR

Removes offence codes across the service, after user feedback told us they are confusing.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
