### PR TITLE
Allow full error trace in Nunjucks

### DIFF
--- a/server/@types/nunjucks/index.d.ts
+++ b/server/@types/nunjucks/index.d.ts
@@ -1,0 +1,7 @@
+export default {}
+
+declare module 'nunjucks' {
+  export interface ConfigureOptions {
+    dev?: boolean | undefined
+  }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -57,6 +57,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     {
       autoescape: true,
       express: app,
+      dev: true, // This is set to true to allow us to see the full stacktrace from errors in global functions, otherwise it gets swallowed and tricky to see in logs
     },
   )
 


### PR DESCRIPTION
When a global function in a template throws an error, we don’t see the full trace of the error, which makes diagnosing issues really hard.

This makes use of the [undocumented dev argument](mozilla/nunjucks#1430) which allows us to see the cause of the error in our logs and in Sentry.

[Copied from CAS1.](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/490/commits/8eed08b4e8698b0ad16bc285f731bc8b8f0cd3b2)

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2024-01-17 at 08 49 24](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/22ad5220-f5d1-4db4-b7f2-58d8faf975cd)

### After

![Screenshot 2024-01-17 at 08 48 57](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/3477c1c8-82f1-4462-b04a-c6ab497f1ec5)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
