### PR TITLE
(644) Add onSave method to questions

### DIFF
--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
@@ -1,13 +1,12 @@
-import { YesOrNo } from '@approved-premises/ui'
 import { applicationFactory, personFactory } from '../../../../testutils/factories/index'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import PregnancyInformation from './pregnancyInformation'
+import PregnancyInformation, { PregnancyInformationBody } from './pregnancyInformation'
 
 describe('PregnancyInformation', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Sue Smith' }) })
 
-  const body = {
-    isPregnant: 'yes' as YesOrNo,
+  const body: PregnancyInformationBody = {
+    isPregnant: 'yes',
     dueDate: '2024-03-27',
     'dueDate-month': '10',
     'dueDate-year': '2023',
@@ -59,8 +58,8 @@ describe('PregnancyInformation', () => {
     })
 
     describe('and they are not pregnant', () => {
-      const bodyWithoutDueDate = {
-        isPregnant: 'no' as YesOrNo,
+      const bodyWithoutDueDate: PregnancyInformationBody = {
+        isPregnant: 'no',
         dueDate: '',
         'dueDate-month': '',
         'dueDate-year': '',
@@ -73,6 +72,26 @@ describe('PregnancyInformation', () => {
         expect(page.response()).toEqual({
           'Is Sue Smith pregnant?': 'No',
         })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    it('removes due date data if question is not set to "yes"', () => {
+      const pageBody: PregnancyInformationBody = {
+        isPregnant: 'dontKnow',
+        dueDate: '2024-03-27',
+        'dueDate-month': '10',
+        'dueDate-year': '2023',
+        'dueDate-day': '01',
+      }
+
+      const page = new PregnancyInformation(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        isPregnant: 'dontKnow',
       })
     })
   })

--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
@@ -6,7 +6,7 @@ import TaskListPage from '../../../taskListPage'
 import { Page } from '../../../utils/decorators'
 import { getQuestions } from '../../../utils/questions'
 
-type PregnancyInformationBody = {
+export type PregnancyInformationBody = {
   isPregnant: YesNoOrDontKnow
   dueDate: string
   'dueDate-month': string
@@ -68,5 +68,14 @@ export default class PregnancyInformation implements TaskListPage {
     }
 
     return response
+  }
+
+  onSave(): void {
+    if (this.body.isPregnant !== 'yes') {
+      delete this.body.dueDate
+      delete this.body['dueDate-day']
+      delete this.body['dueDate-month']
+      delete this.body['dueDate-year']
+    }
   }
 }

--- a/server/form-pages/apply/about-the-person/personal-information/supportWorkerPreference.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/supportWorkerPreference.test.ts
@@ -44,4 +44,21 @@ describe('SupportWorkerPreference', () => {
 
   itShouldHaveNextValue(new SupportWorkerPreference(body, application), '')
   itShouldHavePreviousValue(new SupportWorkerPreference(body, application), 'pregnancy-information')
+
+  describe('onSave', () => {
+    it('removes support worker data if question is not set to "yes"', () => {
+      const pageBody: SupportWorkerPreferenceBody = {
+        hasSupportWorkerPreference: 'dontKnow',
+        supportWorkerPreference: 'female',
+      }
+
+      const page = new SupportWorkerPreference(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasSupportWorkerPreference: 'dontKnow',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/about-the-person/personal-information/supportWorkerPreference.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/supportWorkerPreference.ts
@@ -53,4 +53,10 @@ export default class SupportWorkerPreference implements TaskListPage {
 
     return errors
   }
+
+  onSave(): void {
+    if (this.body.hasSupportWorkerPreference !== 'yes') {
+      delete this.body.supportWorkerPreference
+    }
+  }
 }

--- a/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.test.ts
@@ -1,4 +1,3 @@
-import { YesNoOrDontKnow } from '@approved-premises/ui'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import WorkingMobilePhone, { WorkingMobilePhoneBody } from './workingMobilePhone'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
@@ -7,7 +6,7 @@ describe('WorkingMobilePhone', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Sue Smith' }) })
 
   const body: WorkingMobilePhoneBody = {
-    hasWorkingMobilePhone: 'yes' as YesNoOrDontKnow,
+    hasWorkingMobilePhone: 'yes',
     mobilePhoneNumber: '11111111111',
     isSmartPhone: 'yes',
   }
@@ -46,4 +45,22 @@ describe('WorkingMobilePhone', () => {
 
   itShouldHaveNextValue(new WorkingMobilePhone(body, application), 'immigration-status')
   itShouldHavePreviousValue(new WorkingMobilePhone(body, application), 'taskList')
+
+  describe('onSave', () => {
+    it('removes mobile phone data if question is not set to "yes"', () => {
+      const pageBody: WorkingMobilePhoneBody = {
+        hasWorkingMobilePhone: 'dontKnow',
+        mobilePhoneNumber: '07111111111',
+        isSmartPhone: 'yes',
+      }
+
+      const page = new WorkingMobilePhone(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasWorkingMobilePhone: 'dontKnow',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.ts
@@ -54,4 +54,11 @@ export default class WorkingMobilePhone implements TaskListPage {
 
     return errors
   }
+
+  onSave(): void {
+    if (this.body.hasWorkingMobilePhone !== 'yes') {
+      delete this.body.mobilePhoneNumber
+      delete this.body.isSmartPhone
+    }
+  }
 }

--- a/server/form-pages/apply/area-and-funding/area-information/exclusionZones.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/exclusionZones.test.ts
@@ -1,6 +1,6 @@
 import { YesOrNo } from '@approved-premises/ui'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import ExclusionZones from './exclusionZones'
+import ExclusionZones, { ExclusionZonesBody } from './exclusionZones'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
 
 describe('ExclusionZones', () => {
@@ -44,4 +44,21 @@ describe('ExclusionZones', () => {
 
   itShouldHaveNextValue(new ExclusionZones(body, application), 'gang-affiliations')
   itShouldHavePreviousValue(new ExclusionZones(body, application), 'second-preferred-area')
+
+  describe('onSave', () => {
+    it('removes exclusion zones data if question is set to "no"', () => {
+      const pageBody: ExclusionZonesBody = {
+        hasExclusionZones: 'no',
+        exclusionZonesDetail: 'Exclusion zones detail',
+      }
+
+      const page = new ExclusionZones(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasExclusionZones: 'no',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/area-and-funding/area-information/exclusionZones.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/exclusionZones.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
-type ExclusionZonesBody = {
+export type ExclusionZonesBody = {
   hasExclusionZones: YesOrNo
   exclusionZonesDetail: string
 }
@@ -52,5 +52,11 @@ export default class ExclusionZones implements TaskListPage {
     }
 
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.hasExclusionZones !== 'yes') {
+      delete this.body.exclusionZonesDetail
+    }
   }
 }

--- a/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.test.ts
@@ -1,6 +1,6 @@
 import { YesOrNo } from '@approved-premises/ui'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import GangAffiliations from './gangAffiliations'
+import GangAffiliations, { GangAffiliationsBody } from './gangAffiliations'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
 
 describe('GangAffiliations', () => {
@@ -54,4 +54,23 @@ describe('GangAffiliations', () => {
 
   itShouldHaveNextValue(new GangAffiliations(body, application), 'family-accommodation')
   itShouldHavePreviousValue(new GangAffiliations(body, application), 'exclusion-zones')
+
+  describe('onSave', () => {
+    it('removes gang affiliation data if question is set to "no"', () => {
+      const pageBody: GangAffiliationsBody = {
+        hasGangAffiliations: 'no',
+        gangName: 'Gang name',
+        gangOperationArea: 'Gang operation area',
+        rivalGangDetail: 'Rival gang detail',
+      }
+
+      const page = new GangAffiliations(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasGangAffiliations: 'no',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
-type GangAffiliationsBody = {
+export type GangAffiliationsBody = {
   hasGangAffiliations: YesOrNo
   gangName: string
   gangOperationArea: string
@@ -58,5 +58,13 @@ export default class GangAffiliations implements TaskListPage {
     }
 
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.hasGangAffiliations !== 'yes') {
+      delete this.body.gangName
+      delete this.body.gangOperationArea
+      delete this.body.rivalGangDetail
+    }
   }
 }

--- a/server/form-pages/apply/offence-and-licence-information/hdc-licence-and-cpp-details/nonStandardLicenceConditions.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/hdc-licence-and-cpp-details/nonStandardLicenceConditions.test.ts
@@ -1,6 +1,6 @@
 import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import NonStandardLicenceConditions from './nonStandardLicenceConditions'
+import NonStandardLicenceConditions, { NonStandardLicenceConditionsBody } from './nonStandardLicenceConditions'
 
 describe('NonStandardLicenceConditions', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -64,6 +64,23 @@ describe('NonStandardLicenceConditions', () => {
         expect(page.errors()).toEqual({
           nonStandardLicenceConditionsDetail: 'Describe their non-standard licence conditions',
         })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    it('removes non-standard license conditions data when the question is not set to "yes"', () => {
+      const body: NonStandardLicenceConditionsBody = {
+        nonStandardLicenceConditions: 'dontKnow',
+        nonStandardLicenceConditionsDetail: 'Non-standard license condition detail',
+      }
+
+      const page = new NonStandardLicenceConditions(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        nonStandardLicenceConditions: 'dontKnow',
       })
     })
   })

--- a/server/form-pages/apply/offence-and-licence-information/hdc-licence-and-cpp-details/nonStandardLicenceConditions.ts
+++ b/server/form-pages/apply/offence-and-licence-information/hdc-licence-and-cpp-details/nonStandardLicenceConditions.ts
@@ -6,7 +6,7 @@ import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 
-type NonStandardLicenceConditionsBody = {
+export type NonStandardLicenceConditionsBody = {
   nonStandardLicenceConditions: YesNoOrDontKnow
   nonStandardLicenceConditionsDetail: string
 }
@@ -68,5 +68,11 @@ export default class NonStandardLicenceConditions implements TaskListPage {
       errors.nonStandardLicenceConditionsDetail = 'Describe their non-standard licence conditions'
     }
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.nonStandardLicenceConditions !== 'yes') {
+      delete this.body.nonStandardLicenceConditionsDetail
+    }
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/additionalRiskInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/additionalRiskInformation.test.ts
@@ -1,6 +1,6 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import AdditionalRiskInformation from './additionalRiskInformation'
+import AdditionalRiskInformation, { AdditionalRiskInformationBody } from './additionalRiskInformation'
 
 describe('AdditionalRiskInformation', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -39,6 +39,23 @@ describe('AdditionalRiskInformation', () => {
         expect(page.errors()).toEqual({
           additionalInformationDetail: 'Enter additional information for risk to others',
         })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    it('removes additional information data when the question is set to "no"', () => {
+      const body: AdditionalRiskInformationBody = {
+        hasAdditionalInformation: 'no',
+        additionalInformationDetail: 'Additional information',
+      }
+
+      const page = new AdditionalRiskInformation(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasAdditionalInformation: 'no',
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/additionalRiskInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/additionalRiskInformation.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 
-type AdditionalRiskInformationBody = { hasAdditionalInformation: YesOrNo; additionalInformationDetail: string }
+export type AdditionalRiskInformationBody = { hasAdditionalInformation: YesOrNo; additionalInformationDetail: string }
 
 @Page({
   name: 'additional-risk-information',
@@ -50,5 +50,11 @@ export default class AdditionalRiskInformation implements TaskListPage {
     }
 
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.hasAdditionalInformation !== 'yes') {
+      delete this.body.additionalInformationDetail
+    }
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/cellShareInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/cellShareInformation.test.ts
@@ -1,6 +1,6 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import CellShareInformation from './cellShareInformation'
+import CellShareInformation, { CellShareInformationBody } from './cellShareInformation'
 
 describe('CellShareInformation', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -39,6 +39,23 @@ describe('CellShareInformation', () => {
         expect(page.errors()).toEqual({
           cellShareInformationDetail: 'Enter cell sharing information',
         })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    it('removes cell share data when the question is set to "no"', () => {
+      const body: CellShareInformationBody = {
+        hasCellShareComments: 'no',
+        cellShareInformationDetail: 'Cell share information',
+      }
+
+      const page = new CellShareInformation(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasCellShareComments: 'no',
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/cellShareInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/cellShareInformation.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 
-type CellShareInformationBody = { hasCellShareComments: YesOrNo; cellShareInformationDetail: string }
+export type CellShareInformationBody = { hasCellShareComments: YesOrNo; cellShareInformationDetail: string }
 
 @Page({
   name: 'cell-share-information',
@@ -48,5 +48,11 @@ export default class CellShareInformation implements TaskListPage {
     }
 
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.hasCellShareComments !== 'yes') {
+      delete this.body.cellShareInformationDetail
+    }
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/riskManagementArrangements.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/riskManagementArrangements.test.ts
@@ -128,4 +128,51 @@ describe('RiskManagementArrangements', () => {
       expect(page.errors()).toEqual({ iomDetails: 'Provide IOM details' })
     })
   })
+
+  describe('onSave', () => {
+    it('removes MAPPA data if option is not selected', () => {
+      const body: RiskManagementArrangementsBody = {
+        arrangements: ['no'],
+        mappaDetails: 'MAPPA details',
+      }
+
+      const page = new RiskManagementArrangements(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        arrangements: ['no'],
+      })
+    })
+
+    it('removes IOM data if option is not selected', () => {
+      const body: RiskManagementArrangementsBody = {
+        arrangements: ['no'],
+        iomDetails: 'IOM details',
+      }
+
+      const page = new RiskManagementArrangements(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        arrangements: ['no'],
+      })
+    })
+
+    it('removes MARAC data if option is not selected', () => {
+      const body: RiskManagementArrangementsBody = {
+        arrangements: ['no'],
+        maracDetails: 'MARAC details',
+      }
+
+      const page = new RiskManagementArrangements(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        arrangements: ['no'],
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/riskManagementArrangements.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/riskManagementArrangements.ts
@@ -13,7 +13,7 @@ const arrangementOptions = {
   no: 'No, this person does not have risk management arrangements',
 }
 
-type RiskManagementArrangementsOptions = keyof typeof arrangementOptions
+export type RiskManagementArrangementsOptions = keyof typeof arrangementOptions
 
 export type RiskManagementArrangementsBody = {
   arrangements: Array<RiskManagementArrangementsOptions>
@@ -91,5 +91,19 @@ export default class RiskManagementArrangements implements TaskListPage {
     const noCheckbox = items.pop()
 
     return [...items, { divider: 'or' }, { ...noCheckbox }]
+  }
+
+  onSave(): void {
+    if (!this.body.arrangements.includes('mappa')) {
+      delete this.body.mappaDetails
+    }
+
+    if (!this.body.arrangements.includes('iom')) {
+      delete this.body.iomDetails
+    }
+
+    if (!this.body.arrangements.includes('marac')) {
+      delete this.body.maracDetails
+    }
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.test.ts
@@ -1,6 +1,6 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import AdditionalInformation from './additionalInformation'
+import AdditionalInformation, { AdditionalInformationBody } from './additionalInformation'
 
 describe('AdditionalInformation', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -47,6 +47,23 @@ describe('AdditionalInformation', () => {
         expect(page.errors()).toEqual({
           additionalInformationDetail: 'Provide additional information about their risk to self',
         })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    it('removes additional information data if question is set to "no"', () => {
+      const body: AdditionalInformationBody = {
+        hasAdditionalInformation: 'no',
+        additionalInformationDetail: 'Additional information detail',
+      }
+
+      const page = new AdditionalInformation(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasAdditionalInformation: 'no',
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/additionalInformation.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
-type AdditionalInformationBody = { hasAdditionalInformation: YesOrNo; additionalInformationDetail: string }
+export type AdditionalInformationBody = { hasAdditionalInformation: YesOrNo; additionalInformationDetail: string }
 
 @Page({
   name: 'additional-information',
@@ -46,5 +46,11 @@ export default class AdditionalInformation implements TaskListPage {
     }
 
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.hasAdditionalInformation !== 'yes') {
+      delete this.body.additionalInformationDetail
+    }
   }
 }


### PR DESCRIPTION
# Context
We [previously added an `onSave` method to pages](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/388) that would remove stale data whenever the page is updated. In this PR we expand this pattern to other parts of the application.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
