### PR TITLE
Update 'details' info of 'Submitted applications' MI report

### DIFF
--- a/server/views/reports/new.njk
+++ b/server/views/reports/new.njk
@@ -51,7 +51,7 @@
             <code>conditionalReleaseDate: 2023-04-29</code>
           </li>
           <li>
-            <code>submittedOn: 2024-01-03</code>
+            <code>submittedAt: 2024-01-03T13:23:45</code>
           </li>
           <li>
             <code>submittedBy: NOMIS_USER_NAME</code>


### PR DESCRIPTION
See [Trello 781](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1360)

# Changes in this PR

We've tweaked this report to provide the submission timestamp rather than just the date.

See https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1360 for change at the API

## Screenshots of UI changes

<img width="773" alt="submitted_at_timestamp" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/20245/e49da00c-0326-4329-a1d3-171919e272db">


