### PR TITLE
Maintenance page steers users to the old referral form

### DIFF
--- a/server/views/static/maintenance.njk
+++ b/server/views/static/maintenance.njk
@@ -9,6 +9,9 @@
       <p class="govuk-body">
         The service is currently down for maintenance, please try again later.
       </p>
+      <p class="govuk-body">
+        If you need to create a CAS-2 application urgently, follow the <a href="https://justiceuk.sharepoint.com/sites/HMPPSIntranet-Probation/SitePages/Community-Accommodation-Service.aspx" class="govuk-link">previous paper form process</a>.
+      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Changes in this PR

As part of our plan for being offline we proactively point users back to using the old form. This will hopefully avoid support requests and ensure minimal disruption to referrals.

[Conversation and where we find what link to use](https://mojdt.slack.com/archives/C04T6SC31HA/p1705577258492259).

We are planning to hold this pending confirmation that that link is definitely correct before releasing.

## Screenshots of UI changes

### Before

![Screenshot 2024-01-19 at 11-55-46 Maintenance page](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/18c2c979-2a8c-4372-b07a-3c8e327f691a)

### After

![Screenshot 2024-01-19 at 11-52-46 Maintenance page](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/07bbcf58-4bec-4df2-8942-19d5ab5dfe3d)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
