### PR TITLE
Turn off maintenance mode in prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,7 +16,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    IN_MAINTENANCE_MODE: true
+    IN_MAINTENANCE_MODE: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:


### PR DESCRIPTION
To enable a testing session today.

I will be watching [for any prod domain events](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz3LMQ6AIAwAwN1XdGPiCYyuDn7AEGjAhLaEgi4%252BXlnc78LQLrReyF2XB%252B6MDSEUGfHYpeDmCcE5MJlqVRuF%252FMkWJ7dFUsJm%252FsXTBuH%252BEQUTvJoX9nLsVl4AAAA%253D/timespan/PT12H) to ensure nobody uses the service to create a referral in the short window we're out of maintenance. We are currently obscured by the fact nobody knows how to find the service. If we find something we'll get in touch and tell them to continue using the old way.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
