### PR TITLE
Fix bug where other disability data is not removed

### DIFF
--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
@@ -176,5 +176,22 @@ describe('Disability', () => {
         hasDisability: 'preferNotToSay',
       })
     })
+
+    it('removes other disability data when it is not listed as the type of disability', () => {
+      const body: Partial<DisabilityBody> = {
+        hasDisability: 'yes',
+        typeOfDisability: ['sensoryImpairment'],
+        otherDisability: 'Other disability',
+      }
+
+      const page = new Disability(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasDisability: 'yes',
+        typeOfDisability: ['sensoryImpairment'],
+      })
+    })
   })
 })

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
@@ -91,5 +91,9 @@ export default class Disability implements TaskListPage {
       delete this.body.typeOfDisability
       delete this.body.otherDisability
     }
+
+    if (this.body.hasDisability === 'yes' && !this.body.typeOfDisability?.includes('other')) {
+      delete this.body.otherDisability
+    }
   }
 }


### PR DESCRIPTION
# Context
We previously implemented an `onSave` method which we use to remove stale data when the answer to a question changes.

This change addresses a bug where the "other" disability data is not being deleted when the checkbox isn't selected.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
