### PR TITLE
Add side navigation to CYA and submitted application views

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -14,7 +14,8 @@ $govuk-page-width: $moj-page-width;
 @import './components/tag';
 @import './components/checkboxes';
 @import './components/timeline';
-@import './components//status-box';
+@import './components/status-box';
+@import './components/side-nav';
 
 @import './pages//oasys-import';
 @import './pages/dashboard-index';

--- a/assets/scss/components/_side-nav.scss
+++ b/assets/scss/components/_side-nav.scss
@@ -1,0 +1,4 @@
+.side-nav {
+  position: sticky;
+  top: 0.5rem;
+}

--- a/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
@@ -1,9 +1,9 @@
 import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
 import { FullPerson } from '../../../../../server/@types/shared/models/FullPerson'
 import ApplyPage from '../../applyPage'
-import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import { nameOrPlaceholderCopy, stringToKebabCase } from '../../../../../server/utils/utils'
 import { getQuestions } from '../../../../../server/form-pages/utils/questions'
-import { getPage, hasResponseMethod } from '../../../../../server/utils/checkYourAnswersUtils'
+import { getPage, getSections, hasResponseMethod } from '../../../../../server/utils/checkYourAnswersUtils'
 
 export default class CheckYourAnswersPage extends ApplyPage {
   constructor(private readonly application: Application) {
@@ -110,6 +110,16 @@ export default class CheckYourAnswersPage extends ApplyPage {
           })
         })
       }
+    })
+  }
+
+  shouldShowSideNavBar() {
+    const sections = getSections()
+
+    sections.forEach(section => {
+      section.tasks.forEach(task => {
+        cy.get(`a[href="#${stringToKebabCase(task.title)}"]`)
+      })
     })
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -4,6 +4,7 @@ import { DateFormats } from '../../server/utils/dateUtils'
 import { Cas2Application } from '../../server/@types/shared/models/Cas2Application'
 import { Cas2SubmittedApplication } from '../../server/@types/shared/models/Cas2SubmittedApplication'
 import { FullPerson } from '../../server/@types/shared/models/FullPerson'
+import { stringToKebabCase } from '../../server/utils/utils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -158,6 +159,18 @@ export default abstract class Page {
         })
       this.checkTermAndDescription('PNC number', person.pncNumber)
       this.checkTermAndDescription('CRN from nDelius', person.crn)
+    })
+  }
+
+  hasSideNavBar(application: Cas2SubmittedApplication) {
+    const document = application.document as ApplicationDocument
+
+    cy.get('.side-nav').within(() => {
+      document.sections.forEach(section => {
+        section.tasks.forEach(task => {
+          cy.get(`a[href="#${stringToKebabCase(task.title)}"]`)
+        })
+      })
     })
   }
 }

--- a/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
+++ b/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
@@ -54,6 +54,7 @@ context('Check your answers page', () => {
     //  And I see a list of questions and answers for the application
     page.hasExpectedSummaryData()
     page.hasApplicantDetails(this.application)
+    page.shouldShowSideNavBar()
     page.shouldShowConfirmEligibilityAnswers()
     page.shouldShowFundingInformationAnswers()
     page.shouldShowEqualityAndDiversityAnswers()

--- a/integration_tests/tests/apply/view_submitted_application_as_referrer.cy.ts
+++ b/integration_tests/tests/apply/view_submitted_application_as_referrer.cy.ts
@@ -46,6 +46,7 @@ context('View submitted application', () => {
     //  Then I should see the read-only version of the answers submitted
     submittedApplicationPage.hasExpectedSummaryData()
     submittedApplicationPage.hasApplicantDetails(this.application)
+    submittedApplicationPage.hasSideNavBar(this.application)
     submittedApplicationPage.hasQuestionsAndAnswersFromDocument(this.application.document)
 
     //  And I see a print button

--- a/integration_tests/tests/assess/update_application_status.cy.ts
+++ b/integration_tests/tests/assess/update_application_status.cy.ts
@@ -34,7 +34,40 @@ import Page from '../../pages/page'
 import SubmittedApplicationPage from '../../pages/assess/submittedApplicationPage'
 
 context("Assessor updates a submitted application's status", () => {
-  const submittedApplication = submittedApplicationFactory.build()
+  const submittedApplication = submittedApplicationFactory.build({
+    document: {
+      sections: [
+        {
+          title: 'Section 1',
+          tasks: [
+            {
+              title: 'Task 1',
+              questionsAndAnswers: [
+                {
+                  question: 'a question',
+                  answer: 'an answer',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Section 2',
+          tasks: [
+            {
+              title: 'Task 2',
+              questionsAndAnswers: [
+                {
+                  question: 'a question',
+                  answer: 'an answer',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  })
 
   beforeEach(() => {
     cy.task('reset')

--- a/integration_tests/tests/assess/view_submitted_application.cy.ts
+++ b/integration_tests/tests/assess/view_submitted_application.cy.ts
@@ -60,6 +60,7 @@ context('Assessor views submitted application', () => {
     const page = new SubmittedApplicationPage(this.submittedApplication)
     page.hasExpectedSummaryData()
     page.hasApplicantDetails(this.submittedApplication)
+    page.hasSideNavBar(this.submittedApplication)
     page.hasQuestionsAndAnswersFromDocument(this.submittedApplication.document)
 
     //  And I see a print button

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -189,3 +189,8 @@ export type ServiceSection = {
   shortTitle: string
   href: string
 }
+
+export type SideNavItem = {
+  text: string
+  href: string
+}

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -6,9 +6,47 @@ import {
   statusUpdateFactory,
   submittedApplicationFactory,
 } from '../../testutils/factories'
-
-import { eligibilityQuestionIsAnswered, getApplicationTimelineEvents } from './utils'
+import {
+  eligibilityQuestionIsAnswered,
+  getApplicationTimelineEvents,
+  getSideNavLinksForDocument,
+  getSideNavLinksForApplication,
+} from './utils'
 import { DateFormats } from '../dateUtils'
+import { getSections } from '../checkYourAnswersUtils'
+
+jest.mock('../checkYourAnswersUtils')
+
+const mockSections = [
+  {
+    title: 'Section 1',
+    tasks: [
+      {
+        title: 'Task 1',
+        questionsAndAnswers: [
+          {
+            question: 'a question',
+            answer: 'an answer',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Section 2',
+    tasks: [
+      {
+        title: 'Task 2',
+        questionsAndAnswers: [
+          {
+            question: 'a question',
+            answer: 'an answer',
+          },
+        ],
+      },
+    ],
+  },
+]
 
 describe('utils', () => {
   describe('eligibilityQuestionIsAnswered', () => {
@@ -197,6 +235,29 @@ describe('utils', () => {
           },
         ])
       })
+    })
+  })
+  describe('getSideNavLinksForDocument', () => {
+    it('returns an array with a side nav item for each task', () => {
+      const document = {
+        sections: mockSections,
+      }
+
+      expect(getSideNavLinksForDocument(document)).toEqual([
+        { text: 'Task 1', href: '#task-1' },
+        { text: 'Task 2', href: '#task-2' },
+      ])
+    })
+  })
+
+  describe('getSideNavLinksForApplication', () => {
+    it('returns an array with a side nav item for each task', () => {
+      ;(getSections as jest.Mock).mockReturnValue(mockSections)
+
+      expect(getSideNavLinksForApplication()).toEqual([
+        { text: 'Task 1', href: '#task-1' },
+        { text: 'Task 2', href: '#task-2' },
+      ])
     })
   })
 })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -1,8 +1,10 @@
-import type { FormPages, JourneyType, UiTimelineEvent } from '@approved-premises/ui'
+import type { ApplicationDocument, FormPages, JourneyType, SideNavItem, UiTimelineEvent } from '@approved-premises/ui'
 import type { Cas2Application as Application, Cas2StatusUpdate, Cas2SubmittedApplication } from '@approved-premises/api'
 import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
+import { getSections } from '../checkYourAnswersUtils'
+import { stringToKebabCase } from '../utils'
 
 export const journeyPages = (_journeyType: JourneyType): FormPages => {
   return Apply.pages
@@ -101,4 +103,26 @@ export const generateSuccessMessage = (pageName: string): string => {
     default:
       return ''
   }
+}
+
+export const getSideNavLinksForDocument = (document: ApplicationDocument) => {
+  const tasks: Array<SideNavItem> = []
+
+  document.sections.forEach(section => {
+    section.tasks.forEach(task => tasks.push({ href: `#${stringToKebabCase(task.title)}`, text: task.title }))
+  })
+
+  return tasks
+}
+
+export const getSideNavLinksForApplication = () => {
+  const sections = getSections()
+
+  const tasks: Array<SideNavItem> = []
+
+  sections.forEach(section => {
+    section.tasks.forEach(task => tasks.push({ href: `#${stringToKebabCase(task.title)}`, text: task.title }))
+  })
+
+  return tasks
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -16,7 +16,11 @@ import {
   inProgressApplicationTableRows,
   submittedApplicationTableRows,
 } from './applicationUtils'
-import { getApplicationTimelineEvents } from './applications/utils'
+import {
+  getApplicationTimelineEvents,
+  getSideNavLinksForApplication,
+  getSideNavLinksForDocument,
+} from './applications/utils'
 import { applicationStatusRadios } from './assessUtils'
 import { checkYourAnswersSections, getApplicantDetails } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
@@ -24,7 +28,7 @@ import { dateFieldValues } from './formUtils'
 import * as OasysImportUtils from './oasysImportUtils'
 import { statusTag } from './personUtils'
 import * as TaskListUtils from './taskListUtils'
-import { initialiseName, removeBlankSummaryListItems } from './utils'
+import { initialiseName, removeBlankSummaryListItems, stringToKebabCase } from './utils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -107,4 +111,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   }
 
   njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
+  njkEnv.addGlobal('getSideNavLinksForDocument', getSideNavLinksForDocument)
+  njkEnv.addGlobal('getSideNavLinksForApplication', getSideNavLinksForApplication)
+  njkEnv.addGlobal('stringToKebabCase', stringToKebabCase)
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -62,3 +62,7 @@ export const removeBlankSummaryListItems = (items: Array<SummaryListItem>): Arra
     return false
   })
 }
+
+export const stringToKebabCase = (stringToTransform: string) => {
+  return stringToTransform.replace(/\s+/g, '-').toLowerCase()
+}

--- a/server/views/applications/pages/check-your-answers/check-your-answers.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers.njk
@@ -2,8 +2,10 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
-{% from "../../../components/printButton/macro.njk" import printButtonScript, printButton %}
+{% from "../../../components/printButton/macro.njk" import printButtonScript,
+printButton %}
 {% from "../../../components/applicationSummary/macro.njk" import applicationSummary %}
+{% from "../../../components/sideNav/macro.njk" import sideNav %}
 
 {% from "../../../partials/applicantDetails.njk" import applicantDetails %}
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
@@ -38,70 +40,85 @@
         </div>
       </div>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
 
       {{ applicationSummary(page.applicationSummary()) }}
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
 
       {{ applicantDetails(page.application) }}
 
-      {% for section in checkYourAnswersSections(page.application) %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
-        {% for task in section.tasks %}
-          <div class="main-box" data-cy-check-your-answers-section="{{ task.id }}">
-            <div class="box-content">
+      <div class="govuk-grid-row">
+
+        <div class="govuk-grid-column-one-quarter side-nav">
+          {{ sideNav(getSideNavLinksForApplication()) }}
+        </div>
+
+        <div class="govuk-grid-column-three-quarters">
+
+          {% for section in checkYourAnswersSections(page.application) %}
+            <h2 class="govuk-heading-l">{{ section.title }}</h2>
+            {% for task in section.tasks %}
+              <div class="main-box" data-cy-check-your-answers-section="{{ task.id }}">
+                <div class="box-content">
+                  {{
+                    govukSummaryList({
+                          card: {
+                            attributes: { id: stringToKebabCase(task.title)},
+                            title: {
+                              text: task.title
+                            }
+                        },
+                      rows: task.rows
+                    })
+                  }}
+                </div>
+              </div>
+            {% endfor %}
+          {% endfor %}
+
+          <div class="govuk-grid-row">
+            <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post" class="govuk-!-margin-top-8 print__hidden">
+              <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
               {{
-                govukSummaryList({
-                      card: {
-                        title: {
-                          text: task.title
-                        }
-                    },
-                  rows: task.rows
-                })
-              }}
+            formPageCheckboxes(
+              {
+                fieldName: "checkYourAnswers",
+                fieldset: {
+                  legend: {
+                    text: "Confirm your answers",
+                    classes: "govuk-fieldset__legend--l"
+                  }
+                },
+                items: [
+                  {
+                    value: "confirmed",
+                    text: "I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments."
+                  }
+                ]
+              },
+              fetchContext()
+            )
+          }}
+
+              <div class="govuk-button-group">
+                {{ govukButton({
+            text: "Save and continue",
+            preventDoubleClick: true
+            }) }}
+
+                <a href="{{ paths.applications.show({ id: applicationId }) }}">Back to task list</a>
+              </div>
+            </form>
+
+            <div class="print__show govuk-!-margin-top-6">
+              <p>I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments.</p>
             </div>
           </div>
-        {% endfor %}
-      {% endfor %}
 
-      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post" class="govuk-!-margin-top-8 print__hidden">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{
-          formPageCheckboxes(
-            {
-              fieldName: "checkYourAnswers",
-              fieldset: {
-                legend: {
-                  text: "Confirm your answers",
-                  classes: "govuk-fieldset__legend--l"
-                }
-              },
-              items: [
-                {
-                  value: "confirmed",
-                  text: "I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments."
-                }
-              ]
-            },
-            fetchContext()
-          )
-        }}
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-          text: "Save and continue",
-          preventDoubleClick: true
-          }) }}
-
-          <a href="{{ paths.applications.show({ id: applicationId }) }}">Back to task list</a>
         </div>
-      </form>
 
-      <div class="print__show govuk-!-margin-top-6">
-        <p>I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments.</p>
       </div>
 
     </div>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -6,6 +6,7 @@
 {% from "../components/printButton/macro.njk" import printButtonScript,
 printButton %}
 {% from "../components/applicationSummary/macro.njk" import applicationSummary %}
+{% from "../components/sideNav/macro.njk" import sideNav %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -40,10 +41,17 @@ printButton %}
 
       {{ applicantDetails(application) }}
 
-      {% if application.document.sections | length %}
-        {{ documentSummaryList(application) }}
-      {% endif %}
+      <div class="govuk-grid-column-one-quarter side-nav">
 
+        {{sideNav(getSideNavLinksForDocument(application.document))}}
+
+      </div>
+
+      <div class="govuk-grid-column-three-quarters">
+        {% if application.document.sections | length %}
+          {{ documentSummaryList(application) }}
+        {% endif %}
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/server/views/assess/applications/show.njk
+++ b/server/views/assess/applications/show.njk
@@ -8,6 +8,7 @@
 {% from "../../components/printButton/macro.njk" import printButtonScript,
 printButton %}
 {% from "../../components/applicationSummary/macro.njk" import applicationSummary %}
+{% from "../../components/sideNav/macro.njk" import sideNav %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -54,9 +55,17 @@ printButton %}
 
       {{ applicantDetails(application) }}
 
-      {% if application.document.sections | length %}
-        {{ documentSummaryList(application) }}
-      {% endif %}
+      <div class="govuk-grid-column-one-quarter side-nav">
+
+        {{ sideNav(getSideNavLinksForDocument(application.document)) }}
+
+      </div>
+
+      <div class="govuk-grid-column-three-quarters">
+        {% if application.document.sections | length %}
+          {{ documentSummaryList(application) }}
+        {% endif %}
+      </div>
     </div>
   </div>
 

--- a/server/views/components/sideNav/macro.njk
+++ b/server/views/components/sideNav/macro.njk
@@ -1,0 +1,21 @@
+{% macro sideNav(navItems) %}
+
+  <h3 class="govuk-body-s ">Contents</h3>
+
+  <ul class="govuk-list govuk-list--spaced">
+    {% for item in navItems %}
+      <li class="govuk-!-font-size-16">
+        <a href="{{ item.href }}" class="govuk-link govuk-link--no-visited-state">{{ item.text }}</a>
+      </li>
+    {% endfor %}
+    <li class="govuk-!-font-size-16">
+      <div>
+        <a class="govuk-link govuk-link--no-visited-state" href="#top">
+          <svg role="presentation" focusable="false" class="govuk-!-margin-right-2" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+            <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+          </svg>Back to top
+            </a>
+      </div>
+    </li>
+  </ul>
+{% endmacro %}

--- a/server/views/partials/documentSummaryList.njk
+++ b/server/views/partials/documentSummaryList.njk
@@ -10,7 +10,8 @@
                     card: {
                             title: {
                               text: task.title
-                            }
+                            },
+                            attributes: { id: stringToKebabCase(task.title) }
                     },
                     rows: documentSummaryListRows(task.questionsAndAnswers)
                   })


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-68

# Changes in this PR

This PR adds a side navigation component for use on the Check your answers page and submitted application views.

## Screenshots of UI changes

### Before

![Screenshot 2024-01-24 at 15 10 10](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/0722dc65-f1ba-474f-a63d-e972814f3d67)

### After

![Screenshot 2024-01-24 at 15 09 09](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/07650c9f-0987-415d-815c-2076dfe1aafa)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
