### PR TITLE
Revert "Remove code used to submit incomplete applications"

### DIFF
--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -170,6 +170,12 @@ export const getPages = (application: Application, task: string) => {
   const pagesWithoutQuestions = ['summary-data', 'oasys-import']
   const pages = application.data[task]
 
+  // TODO: Remove the early return before we go live (or feature flag for testing)
+  // Allow for incomplete applications to be submitted
+  if (!pages) {
+    return []
+  }
+
   const pagesKeys = Object.keys(pages)
 
   return pagesKeys.filter(pageKey => !pagesWithoutQuestions.includes(pageKey))


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-community-accommodation-tier-2-ui#472

This change allowed for the viewing of the check your answers page without having to have started all of the tasks. We'll keep it in until we guard against viewing the CYA page without having completed the rest of the tasks.