### PR TITLE
Use a label instead of hint for immigration status question

### DIFF
--- a/server/views/applications/pages/personal-information/immigration-status.njk
+++ b/server/views/applications/pages/personal-information/immigration-status.njk
@@ -4,29 +4,24 @@
 
 {% block questions %}
 
-  {% call govukFieldset({
-    legend: {
-      text: page.questions.immigrationStatus.question,
-      classes: "govuk-fieldset__legend--l",
-      isPageHeading: true
-    }
-  })%}
-
-    {{
-      govukSelect({
-        hint: {
-          text: page.questions.immigrationStatus.hint
-        },
-        attributes: {
-          'data-testid': 'immigrationStatus'
-        },
-        id: "immigrationStatus",
-        name: "immigrationStatus",
-        items: page.immigrationStatusSelectItems,
-        errorMessage: errors.immigrationStatus
-      })
-    }}
-
-  {% endcall %}
+  {{
+    govukSelect({
+      label: {
+        text: page.questions.immigrationStatus.question,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+      hint: {
+        text: page.questions.immigrationStatus.hint
+      },
+      attributes: {
+        'data-testid': 'immigrationStatus'
+      },
+      id: "immigrationStatus",
+      name: "immigrationStatus",
+      items: page.immigrationStatusSelectItems,
+      errorMessage: errors.immigrationStatus
+    })
+  }}
 
 {% endblock %}


### PR DESCRIPTION
JIRA ticket: https://dsdmoj.atlassian.net/browse/CAS2-141?atlOrigin=eyJpIjoiNDA0ZTUyN2MwZGE1NDQyZjgzMWM3OWViNDRlODRkMzIiLCJwIjoiaiJ9

# Context
An accessibility report flagged this page for not having a label
associated with the select field. This commit changes the legend to an
explicit label.

## Screenshots of UI changes

### Before
![Screenshot 2024-01-25 at 09 59 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/8a35ced6-3e8a-43c4-bbc5-d6ec59c3b705)

### After (no visible change)
![Screenshot 2024-01-25 at 09 59 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/8a35ced6-3e8a-43c4-bbc5-d6ec59c3b705)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
