### PR TITLE
add google tag manager to prod environment

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,6 +19,8 @@ generic-service:
     IN_MAINTENANCE_MODE: true
 
   namespace_secrets:
+    hmpps-community-accommodation-tier-2-ui:
+      TAG_MANAGER_ID: "TAG_MANAGER_ID"
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
       AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'


### PR DESCRIPTION
Now we are about to release to private beta, we want to enable GTM. Providing a value for the the TAG_MANAGER_ID variable will allow the script in `server/views/partials/layout.njk` to run.

https://dsdmoj.atlassian.net/browse/CAS2-171

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
