### PR TITLE
Tweaks user journey to 'Find by prison number' page

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -1,12 +1,6 @@
 import { Page, expect } from '@playwright/test'
 
-import {
-  ApplicationsDashboardPage,
-  BeforeYouStartPage,
-  DashboardPage,
-  FindByPrisonNumberPage,
-  TaskListPage,
-} from '../pages/apply'
+import { BeforeYouStartPage, DashboardPage, FindByPrisonNumberPage, TaskListPage } from '../pages/apply'
 import {
   completeCheckInformationTask,
   completeConsentTask,
@@ -40,12 +34,6 @@ export const startAnApplication = async (page: Page) => {
   // // confirm that I'm ready to start
   const beforeYouStartPage = new BeforeYouStartPage(page)
   await beforeYouStartPage.startNow()
-
-  // Applications dashboard
-  // -----------------
-  // Follow link to 'Start a new application'
-  const applicationsDashboard = new ApplicationsDashboardPage(page)
-  await applicationsDashboard.startNewApplication()
 }
 
 export const enterPrisonerNumber = async (page: Page, prisonNumber: string) => {

--- a/integration_tests/tests/apply/find_by_prison_number.cy.ts
+++ b/integration_tests/tests/apply/find_by_prison_number.cy.ts
@@ -3,8 +3,8 @@
 //    As a referrer
 //    I want to enter the prison number of the applicant and see that the correct person is returned
 //
-//  Scenario: follow link from applications dashboard
-//    Given I'm on the applications dashboard
+//  Scenario: follow link from 'Before you start' page
+//    Given I'm on the 'Before you start' page
 //    And I click the link to start a new application
 //    Then I'm on the Enter prison number page
 //
@@ -33,7 +33,7 @@ import ConfirmApplicantPage from '../../pages/apply/confirmApplicantPage'
 import { personFactory, applicationFactory } from '../../../server/testutils/factories/index'
 import Page from '../../pages/page'
 import FindByPrisonNumberPage from '../../pages/apply/findByPrisonNumberPage'
-import ListPage from '../../pages/apply/list'
+import BeforeYouStartPage from '../../pages/apply/beforeYouStartPage'
 
 context('Find by prison number', () => {
   const person = personFactory.build({ name: 'Roger Smith', nomsNumber: '123' })
@@ -53,14 +53,14 @@ context('Find by prison number', () => {
     cy.task('stubApplications', applications)
   })
 
-  //  Scenario: follow link from applications dashboard
+  //  Scenario: follow link from 'Before you start' page
   // ----------------------------------------------
   it('start new application button takes me to the enter prison number page', () => {
-    // I'm on the applications dashboard
-    ListPage.visit([])
+    // I'm on the 'Before you start' page
+    BeforeYouStartPage.visit(person.name)
 
     // I click the link to start a new application
-    cy.get('a').contains('Start a new application').click()
+    cy.get('a').contains('Start now').click()
 
     // I'm on the Enter prison number page
     Page.verifyOnPage(FindByPrisonNumberPage)

--- a/server/views/applications/before-you-start.njk
+++ b/server/views/applications/before-you-start.njk
@@ -21,7 +21,7 @@
           text: "Start now",
           isStartButton: true,
           preventDoubleClick: true,
-          href: paths.applications.index()
+          href: paths.applications.new()
       }) }}
 
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -72,7 +72,7 @@
         })
       }}
 
-      <a class="govuk-button" href="{{ paths.applications.new() }}">Start a new application</a>
+      <a class="govuk-button" href="{{ paths.applications.beforeYouStart() }}">Start a new application</a>
     </div>
   </div>
 


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-144
E2E PR: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e/pull/67

# Changes in this PR

This fixes the start an application journey, ensuring that the links direct the user first to the 'Before you start' guidance page and then to the 'Find by prison number' page.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
