### PR TITLE
Change URL path for ineligible application page

### DIFF
--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -153,9 +153,8 @@ describe('applicationsController', () => {
       })
 
       describe('and the person is confirmed INELIGIBLE', () => {
-        it('renders the _ineligible_ page', async () => {
+        it('redirects to the _ineligible_ page', async () => {
           const application = applicationFactory.build({
-            person: personFactory.build({ name: 'Roger Smith' }),
             data: {
               'confirm-eligibility': {
                 'confirm-eligibility': { isEligible: 'no' },
@@ -163,25 +162,12 @@ describe('applicationsController', () => {
             },
           })
 
-          const panelText = `Roger Smith is not eligible for CAS-2 accommodation`
-          const changeAnswerPath = paths.applications.pages.show({
-            id: application.id,
-            task: 'confirm-eligibility',
-            page: 'confirm-eligibility',
-          })
-          const newApplicationPath = paths.applications.new({})
-
           applicationService.findApplication.mockResolvedValue(application)
 
           const requestHandler = applicationsController.show()
           await requestHandler(request, response, next)
 
-          expect(response.render).toHaveBeenCalledWith('applications/ineligible', {
-            application,
-            panelText,
-            changeAnswerPath,
-            newApplicationPath,
-          })
+          expect(response.redirect).toHaveBeenCalledWith(paths.applications.ineligible({ id: application.id }))
         })
       })
     })
@@ -267,6 +253,34 @@ describe('applicationsController', () => {
             page: 'confirm-consent',
           }),
         )
+      })
+    })
+
+    describe('ineligible', () => {
+      it('renders the ineligible page', async () => {
+        const application = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+        })
+
+        const panelText = `Roger Smith is not eligible for CAS-2 accommodation`
+        const changeAnswerPath = paths.applications.pages.show({
+          id: application.id,
+          task: 'confirm-eligibility',
+          page: 'confirm-eligibility',
+        })
+        const newApplicationPath = paths.applications.new({})
+
+        applicationService.findApplication.mockResolvedValue(application)
+
+        const requestHandler = applicationsController.ineligible()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/ineligible', {
+          application,
+          panelText,
+          changeAnswerPath,
+          newApplicationPath,
+        })
       })
     })
 

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -191,9 +191,8 @@ describe('applicationsController', () => {
     })
 
     describe('when the person is confirmed ELIGIBLE but consent has been DENIED', () => {
-      it('renders the _consent refused_ page', async () => {
+      it('redirects to the _consent refused_ page', async () => {
         const application = applicationFactory.build({
-          person: personFactory.build({ name: 'Roger Smith' }),
           data: {
             'confirm-eligibility': {
               'confirm-eligibility': { isEligible: 'yes' },
@@ -207,26 +206,12 @@ describe('applicationsController', () => {
           },
         })
 
-        const panelText = `Roger Smith has not given their consent`
-        const changeAnswerPath = paths.applications.pages.show({
-          id: application.id,
-          task: 'confirm-consent',
-          page: 'confirm-consent',
-        })
-        const newApplicationPath = paths.applications.new({})
-
         applicationService.findApplication.mockResolvedValue(application)
 
         const requestHandler = applicationsController.show()
         await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('applications/consent-refused', {
-          application,
-          panelText,
-          changeAnswerPath,
-          newApplicationPath,
-          backLink: 'some-referrer/',
-        })
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.consentRefused({ id: application.id }))
       })
     })
 
@@ -280,6 +265,35 @@ describe('applicationsController', () => {
           panelText,
           changeAnswerPath,
           newApplicationPath,
+        })
+      })
+    })
+
+    describe('consentRefused', () => {
+      it('renders the consent refused page', async () => {
+        const application = applicationFactory.build({
+          person: personFactory.build({ name: 'Roger Smith' }),
+        })
+
+        const panelText = `Roger Smith has not given their consent`
+        const changeAnswerPath = paths.applications.pages.show({
+          id: application.id,
+          task: 'confirm-consent',
+          page: 'confirm-consent',
+        })
+        const newApplicationPath = paths.applications.new({})
+
+        applicationService.findApplication.mockResolvedValue(application)
+
+        const requestHandler = applicationsController.consentRefused()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/consent-refused', {
+          application,
+          panelText,
+          changeAnswerPath,
+          newApplicationPath,
+          backLink: 'some-referrer/',
         })
       })
     })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -70,10 +70,18 @@ export default class ApplicationsController {
       }
 
       if (eligibilityIsDenied(application)) {
-        return res.render('applications/ineligible', this.ineligibleViewParams(application))
+        return res.redirect(paths.applications.ineligible({ id: application.id }))
       }
 
       return res.redirect(firstPageOfBeforeYouStartSection(application))
+    }
+  }
+
+  ineligible(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+
+      return res.render('applications/ineligible', this.ineligibleViewParams(application))
     }
   }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -64,7 +64,7 @@ export default class ApplicationsController {
           return res.render('applications/taskList', { application, taskList, errors, errorSummary, referrer })
         }
         if (consentIsDenied(application)) {
-          return res.render('applications/consent-refused', this.consentRefusedViewParams(application, req))
+          return res.redirect(paths.applications.consentRefused({ id: application.id }))
         }
         return res.redirect(firstPageOfConsentTask(application))
       }
@@ -82,6 +82,14 @@ export default class ApplicationsController {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
 
       return res.render('applications/ineligible', this.ineligibleViewParams(application))
+    }
+  }
+
+  consentRefused(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+
+      return res.render('applications/consent-refused', this.consentRefusedViewParams(application, req))
     }
   }
 

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -28,6 +28,7 @@ const paths = {
     appendToList: appendToListPath,
     removeFromList: removeFromListPath,
     ineligible: singleApplicationPath.path('not-eligible'),
+    consentRefused: singleApplicationPath.path('no-consent-given'),
   },
 }
 

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -27,6 +27,7 @@ const paths = {
     update: singleApplicationPath,
     appendToList: appendToListPath,
     removeFromList: removeFromListPath,
+    ineligible: singleApplicationPath.path('not-eligible'),
   },
 }
 

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -37,6 +37,9 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
   get(paths.applications.ineligible.pattern, applicationsController.ineligible(), {
     auditEvent: 'VIEW_APPLICATION_INELIGIBLE',
   })
+  get(paths.applications.consentRefused.pattern, applicationsController.consentRefused(), {
+    auditEvent: 'VIEW_APPLICATION_CONSENT_REFUSED',
+  })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -34,6 +34,9 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
   get(paths.applications.removeFromList.pattern, applicationsController.removeFromList(), {
     auditEvent: 'UPDATE_APPLICATION_LIST_REMOVE',
   })
+  get(paths.applications.ineligible.pattern, applicationsController.ineligible(), {
+    auditEvent: 'VIEW_APPLICATION_INELIGIBLE',
+  })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {


### PR DESCRIPTION
JIRA tickets
[Consent](https://dsdmoj.atlassian.net/browse/CAS2-134?atlOrigin=eyJpIjoiNDQ3ODE2NmY4MDY2NGEyZmEyODQ5N2U5YTg2N2Y5MDEiLCJwIjoiaiJ9)
[Eligibility](https://dsdmoj.atlassian.net/browse/CAS2-135?atlOrigin=eyJpIjoiMDU0MGNiMDVmZDNkNDhmMzg1ZWFiOTIyNjViM2ZjNWEiLCJwIjoiaiJ9)

# Context
We want to use Google Analytics to get better insights into when the
ineligible & consent refused application page is being shown to referrers.

Previously, these page URLs were the same as viewing a single application
(`applications/{applicationId}`). Now they render with unique paths:

* `applications/{applicationId}/not-eligible`
* `applications/{applicationId}/no-consent-given`

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
