### PR TITLE
Add hero banner copy to e2e tests

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -77,8 +77,8 @@ export const completeOffenceAndLicenceInformationSection = async (page: Page, na
   await completeHDCLicenceAndCPPDetailsTask(page, name)
 }
 
-export const completeCheckAnswersSection = async (page: Page) => {
-  await completeCheckAnswersTask(page)
+export const completeCheckAnswersSection = async (page: Page, name: string) => {
+  await completeCheckAnswersTask(page, name)
 }
 
 export const submitApplication = async (page: Page) => {

--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -15,7 +15,7 @@ export const viewSubmittedApplication = async (
   await expect(page.locator('h1')).toContainText('Short-Term Accommodation (CAS-2) applications')
   await page.getByRole('link', { name: person.name }).first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
-  await expect(page.locator('h1')).toContainText('Application answers')
+  await expect(page.locator('h1')).toContainText(`${person.name}'s application`)
 }
 
 export const signInAsAssessor = async (

--- a/e2e-tests/steps/checkAnswersSection.ts
+++ b/e2e-tests/steps/checkAnswersSection.ts
@@ -1,10 +1,10 @@
 import { Page } from '@playwright/test'
 import { ApplyPage, TaskListPage } from '../pages/apply'
 
-export const completeCheckAnswersTask = async (page: Page) => {
+export const completeCheckAnswersTask = async (page: Page, name: string) => {
   const taskListPage = new TaskListPage(page)
   await taskListPage.clickTask('Check application answers')
-  const checkAnswersPage = await ApplyPage.initialize(page, `Check your answers`)
+  const checkAnswersPage = await ApplyPage.initialize(page, `Check ${name}'s application`)
   await checkAnswersPage.checkCheckboxes([
     'I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments.',
   ])

--- a/e2e-tests/tests/01_apply.spec.ts
+++ b/e2e-tests/tests/01_apply.spec.ts
@@ -22,7 +22,7 @@ test('create a CAS-2 application', async ({ page, person }) => {
   await completeAboutThePersonSection(page, person.name)
   await completeRisksAndNeedsSection(page, person.name)
   await completeOffenceAndLicenceInformationSection(page, person.name)
-  await completeCheckAnswersSection(page)
+  await completeCheckAnswersSection(page, person.name)
   await expect(page.getByText('You have completed 16 of 16 tasks')).toBeVisible()
   await submitApplication(page)
 })

--- a/e2e-tests/tests/02_admin.spec.ts
+++ b/e2e-tests/tests/02_admin.spec.ts
@@ -6,7 +6,7 @@ test('view a submitted application as an admin', async ({ page, adminUser, perso
   await signOut(page)
   await signInAsAdmin(page, adminUser)
   await viewSubmittedApplication(page, person.name)
-  await expect(page.locator('h1')).toContainText('Application answers')
+  await expect(page.locator('h1')).toContainText(`${person.name}'s application`)
 })
 
 const signOut = async (page: Page) => {


### PR DESCRIPTION
The h1 for a submitted application/CYA view has changed, this corrects expected copy to reflect that.
