### PR TITLE
137 paginate submitted applications

### DIFF
--- a/e2e-tests/steps/admin.ts
+++ b/e2e-tests/steps/admin.ts
@@ -1,10 +1,10 @@
 import { Page, expect } from '@playwright/test'
 
-export const viewSubmittedApplication = async (page: Page, name: string) => {
+export const viewSubmittedApplication = async (page: Page) => {
   await expect(page.locator('h1')).toContainText('CAS2: Short-term accommodation')
   await page.getByRole('link', { name: 'Submitted applications' }).click()
   await expect(page.locator('h1')).toContainText('Short-Term Accommodation (CAS-2) applications')
-  await page.getByRole('link', { name }).first().click()
+  await page.getByTestId('submitted-applications').getByRole('link').first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
 }
 

--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -13,7 +13,7 @@ export const viewSubmittedApplication = async (
 ) => {
   await page.goto('/assess/applications')
   await expect(page.locator('h1')).toContainText('Short-Term Accommodation (CAS-2) applications')
-  await page.getByRole('link', { name: person.name }).first().click()
+  await page.getByTestId('submitted-applications').getByRole('link').first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
   await expect(page.locator('h1')).toContainText(`${person.name}'s application`)
 }

--- a/e2e-tests/tests/02_admin.spec.ts
+++ b/e2e-tests/tests/02_admin.spec.ts
@@ -2,11 +2,12 @@ import { Page, expect } from '@playwright/test'
 import { signInAsAdmin, viewSubmittedApplication } from '../steps/admin'
 import { test } from '../test'
 
-test('view a submitted application as an admin', async ({ page, adminUser, person }) => {
+test('view a submitted application as an admin', async ({ page, adminUser }) => {
   await signOut(page)
   await signInAsAdmin(page, adminUser)
-  await viewSubmittedApplication(page, person.name)
-  await expect(page.locator('h1')).toContainText(`${person.name}'s application`)
+  await viewSubmittedApplication(page)
+  await expect(page.locator('h1')).toContainText('application')
+  await expect(page.locator('h2').first()).toContainText('Applicant details')
 })
 
 const signOut = async (page: Page) => {

--- a/integration_tests/mockApis/submissions.ts
+++ b/integration_tests/mockApis/submissions.ts
@@ -19,15 +19,23 @@ export default {
         jsonBody: args.application,
       },
     }),
-  stubSubmittedApplicationsGet: (args: { applications: Array<SubmittedApplication> }): SuperAgentRequest =>
+  stubSubmittedApplicationsGet: (args: {
+    applications: Array<SubmittedApplication>
+    page: number
+  }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/submissions`,
+        url: `/cas2/submissions?page=${args.page}`,
       },
       response: {
         status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '2',
+          'X-Pagination-TotalResults': '20',
+          'X-Pagination-PageSize': '10',
+        },
         jsonBody: args.applications,
       },
     }),

--- a/integration_tests/pages/submissions/submissionListPage.ts
+++ b/integration_tests/pages/submissions/submissionListPage.ts
@@ -35,4 +35,9 @@ export default class SubmissionListPage extends Page {
         })
     })
   }
+
+  clickPageNumber(pageNumber: string): void {
+    const linkText = new RegExp(`^\\s+${pageNumber}\\s+$`)
+    cy.get('a').contains(linkText).click()
+  }
 }

--- a/integration_tests/tests/assess/view_all_submitted_applications.cy.ts
+++ b/integration_tests/tests/assess/view_all_submitted_applications.cy.ts
@@ -25,7 +25,7 @@ context('Submitted applications', () => {
         person: fullPersonFactory.build({ name: 'Robert Smith' }),
       })
       cy.wrap(submittedApplication).as('submittedApplication')
-      cy.task('stubSubmittedApplicationsGet', { applications: [submittedApplication] })
+      cy.task('stubSubmittedApplicationsGet', { applications: [submittedApplication], page: 1 })
     })
   })
 
@@ -41,6 +41,9 @@ context('Submitted applications', () => {
     const page = Page.verifyOnPage(SubmissionListPage)
 
     //  Then see the submitted applications
+    page.shouldShowSubmittedApplications([this.submittedApplication])
+    cy.task('stubSubmittedApplicationsGet', { applications: [this.submittedApplication], page: 2 })
+    page.clickPageNumber('2')
     page.shouldShowSubmittedApplications([this.submittedApplication])
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -194,3 +194,11 @@ export type SideNavItem = {
   text: string
   href: string
 }
+
+export type PaginatedResponse<T> = {
+  data: Array<T>
+  pageNumber: string
+  totalPages: string
+  totalResults: string
+  pageSize: string
+}

--- a/server/controllers/assess/submittedApplicationsController.test.ts
+++ b/server/controllers/assess/submittedApplicationsController.test.ts
@@ -1,11 +1,15 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
-import { FullPerson } from '@approved-premises/api'
+import { Cas2SubmittedApplicationSummary, FullPerson } from '@approved-premises/api'
 
-import { statusUpdateFactory, submittedApplicationFactory } from '../../testutils/factories'
+import { PaginatedResponse } from '@approved-premises/ui'
+import { paginatedResponseFactory, statusUpdateFactory, submittedApplicationFactory } from '../../testutils/factories'
 import SubmittedApplicationsController from './submittedApplicationsController'
 import { SubmittedApplicationService } from '../../services'
 import paths from '../../paths/assess'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
+
+jest.mock('../../utils/getPaginationDetails')
 
 describe('submittedApplicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -36,12 +40,30 @@ describe('submittedApplicationsController', () => {
   describe('index', () => {
     it('renders existing applications', async () => {
       const applications = [submittedApplication]
+
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: applications,
+        totalPages: '50',
+        totalResults: '500',
+      }) as PaginatedResponse<Cas2SubmittedApplicationSummary>
+
+      const paginationDetails = {
+        hrefPrefix: paths.submittedApplications.index({}),
+        pageNumber: 1,
+      }
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+      submittedApplicationService.getAll.mockResolvedValue(paginatedResponse)
+
       const requestHandler = submittedApplicationsController.index()
 
       await requestHandler(request, response, next)
 
+      expect(submittedApplicationService.getAll).toHaveBeenCalledWith(token, 1)
       expect(response.render).toHaveBeenCalledWith('assess/applications/index', {
         applications,
+        pageNumber: 1,
+        totalPages: 50,
+        hrefPrefix: paths.submittedApplications.index({}),
         pageHeading: 'Submitted Applications',
       })
     })

--- a/server/controllers/assess/submittedApplicationsController.ts
+++ b/server/controllers/assess/submittedApplicationsController.ts
@@ -1,16 +1,23 @@
 import { Request, RequestHandler, Response } from 'express'
 import { FullPerson } from '@approved-premises/api'
 import SubmittedApplicationService from '../../services/submittedApplicationService'
+import assessPaths from '../../paths/assess'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export default class SubmittedApplicationsController {
   constructor(private readonly submittedApplicationService: SubmittedApplicationService) {}
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const applications = await this.submittedApplicationService.getAll(req.user.token)
+      const { pageNumber, hrefPrefix } = getPaginationDetails(req, assessPaths.submittedApplications.index({}))
+
+      const result = await this.submittedApplicationService.getAll(req.user.token, pageNumber)
 
       return res.render('assess/applications/index', {
-        applications,
+        applications: result.data,
+        pageNumber: Number(result.pageNumber),
+        totalPages: Number(result.totalPages),
+        hrefPrefix,
         pageHeading: 'Submitted Applications',
       })
     }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -5,11 +5,13 @@ import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import type { Response } from 'express'
 
+import { PaginatedResponse } from '@approved-premises/ui'
 import logger from '../../logger'
 import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
 import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
+import { createQueryString } from '../utils/utils'
 
 interface GetRequest {
   path?: string
@@ -121,6 +123,30 @@ export default class RestClient {
       const sanitisedError = sanitiseError(error)
       logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
+    }
+  }
+
+  async getPaginatedResponse<T>({
+    path = '',
+    page = '',
+    query = {},
+  }: {
+    path: string
+    page: string
+    query: Record<string, unknown>
+  }): Promise<PaginatedResponse<T>> {
+    const response = (await this.get({
+      path,
+      query: createQueryString({ page, ...query }),
+      raw: true,
+    })) as superagent.Response
+
+    return {
+      data: response.body,
+      pageNumber: page,
+      totalPages: response.headers['x-pagination-totalpages'],
+      totalResults: response.headers['x-pagination-totalresults'],
+      pageSize: response.headers['x-pagination-pagesize'],
     }
   }
 

--- a/server/data/submittedApplicationClient.test.ts
+++ b/server/data/submittedApplicationClient.test.ts
@@ -22,6 +22,7 @@ describeClient('SubmittedApplicationClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.submissions.index.pattern,
+          query: { page: '1' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -29,12 +30,23 @@ describeClient('SubmittedApplicationClient', provider => {
         willRespondWith: {
           status: 200,
           body: submittedApplications,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
-      const result = await submittedApplicationClient.all()
+      const result = await submittedApplicationClient.all(1)
 
-      expect(result).toEqual(submittedApplications)
+      expect(result).toEqual({
+        data: submittedApplications,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/submittedApplicationClient.ts
+++ b/server/data/submittedApplicationClient.ts
@@ -3,6 +3,7 @@ import {
   Cas2ApplicationStatusUpdate as ApplicationStatusUpdate,
   Cas2SubmittedApplicationSummary,
 } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -14,10 +15,12 @@ export default class SubmittedApplicationClient {
     this.restClient = new RestClient('submittedApplicationClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<Cas2SubmittedApplicationSummary>> {
-    return (await this.restClient.get({
+  async all(pageNumber: number): Promise<PaginatedResponse<Cas2SubmittedApplicationSummary>> {
+    return this.restClient.getPaginatedResponse<Cas2SubmittedApplicationSummary>({
       path: paths.submissions.index.pattern,
-    })) as Array<Cas2SubmittedApplicationSummary>
+      page: pageNumber.toString(),
+      query: {},
+    })
   }
 
   async find(applicationId: string): Promise<SubmittedApplication> {

--- a/server/services/submittedApplicationService.test.ts
+++ b/server/services/submittedApplicationService.test.ts
@@ -1,6 +1,8 @@
-import SubmittedApplicationService from './submittedApplicationService'
+import { Cas2SubmittedApplicationSummary } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 
-import { submittedApplicationFactory, applicationStatusFactory } from '../testutils/factories'
+import SubmittedApplicationService from './submittedApplicationService'
+import { submittedApplicationFactory, applicationStatusFactory, paginatedResponseFactory } from '../testutils/factories'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
 import { ReferenceDataClient, SubmittedApplicationClient } from '../data'
 
@@ -29,14 +31,24 @@ describe('SubmittedApplicationService', () => {
   describe('getAll', () => {
     it('calls APIs index method and returns all submitted applications', async () => {
       const submittedApplicationSummaries = submittedApplicationSummary.buildList(2)
-      submittedApplicationClient.all.mockResolvedValue(submittedApplicationSummaries)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: submittedApplicationSummaries,
+        totalPages: '50',
+        totalResults: '500',
+        pageNumber: '2',
+      }) as PaginatedResponse<Cas2SubmittedApplicationSummary>
+      submittedApplicationClient.all.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getAll(token)
+      const result = await service.getAll(token, 2)
 
-      expect(result).toEqual(submittedApplicationSummaries)
+      expect(result.data).toEqual(submittedApplicationSummaries)
+      expect(result.pageNumber).toEqual('2')
+      expect(result.pageSize).toEqual('10')
+      expect(result.totalPages).toEqual('50')
+      expect(result.totalResults).toEqual('500')
 
       expect(submittedApplicationClientFactory).toHaveBeenCalledWith(token)
-      expect(submittedApplicationClient.all).toHaveBeenCalled()
+      expect(submittedApplicationClient.all).toHaveBeenCalledWith(2)
     })
   })
 

--- a/server/services/submittedApplicationService.ts
+++ b/server/services/submittedApplicationService.ts
@@ -4,6 +4,7 @@ import {
   Cas2ApplicationStatusUpdate as ApplicationStatusUpdate,
   Cas2SubmittedApplicationSummary,
 } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 
 import type { SubmittedApplicationClient, ReferenceDataClient, RestClientBuilder } from '../data'
 
@@ -13,10 +14,10 @@ export default class SubmittedApplicationService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getAll(token: string): Promise<Array<Cas2SubmittedApplicationSummary>> {
+  async getAll(token: string, pageNumber: number = 1): Promise<PaginatedResponse<Cas2SubmittedApplicationSummary>> {
     const applicationClient = this.submittedApplicationClientFactory(token)
 
-    const applications = await applicationClient.all()
+    const applications = await applicationClient.all(pageNumber)
 
     return applications
   }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -11,6 +11,7 @@ import nomisUserFactory from './nomisUser'
 import statusUpdateFactory from './statusUpdate'
 import externalUserFactory from './externalUser'
 import applicationStatusFactory from './applicationStatusFactory'
+import paginatedResponseFactory from './paginatedResponse'
 
 export {
   applicationSummaryFactory,
@@ -29,4 +30,5 @@ export {
   statusUpdateFactory,
   externalUserFactory,
   applicationStatusFactory,
+  paginatedResponseFactory,
 }

--- a/server/testutils/factories/paginatedResponse.ts
+++ b/server/testutils/factories/paginatedResponse.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+import { PaginatedResponse } from '../../@types/ui'
+
+export default Factory.define<PaginatedResponse<unknown>>(() => ({
+  data: [] as Array<unknown>,
+  pageNumber: '1',
+  totalPages: '10',
+  totalResults: '100',
+  pageSize: '10',
+}))

--- a/server/utils/getPaginationDetails.ts
+++ b/server/utils/getPaginationDetails.ts
@@ -1,0 +1,16 @@
+import type { Request } from 'express'
+import { createQueryString } from './utils'
+
+export const getPaginationDetails = (
+  request: Request,
+  basePath: string,
+  additionalParams: Record<string, unknown> = {},
+) => {
+  const pageNumber = request.query.page ? Number(request.query.page) : undefined
+
+  const queryString = createQueryString({ ...additionalParams }, { addQueryPrefix: true })
+  const queryStringSuffix = queryString.length > 0 ? '&' : '?'
+  const hrefPrefix = `${basePath}${queryString}${queryStringSuffix}`
+
+  return { pageNumber, hrefPrefix }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -29,6 +29,7 @@ import * as OasysImportUtils from './oasysImportUtils'
 import { statusTag } from './personUtils'
 import * as TaskListUtils from './taskListUtils'
 import { initialiseName, removeBlankSummaryListItems, stringToKebabCase } from './utils'
+import { pagination } from './pagination'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -114,4 +115,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('getSideNavLinksForDocument', getSideNavLinksForDocument)
   njkEnv.addGlobal('getSideNavLinksForApplication', getSideNavLinksForApplication)
   njkEnv.addGlobal('stringToKebabCase', stringToKebabCase)
+
+  njkEnv.addGlobal('pagination', pagination)
 }

--- a/server/utils/pagination.test.ts
+++ b/server/utils/pagination.test.ts
@@ -1,0 +1,121 @@
+import { type Pagination, pagination } from './pagination'
+
+describe('pagination', () => {
+  it('should be empty when there are no pages', () => {
+    expect(pagination(1, 0, '?a=b&')).toEqual<Pagination>({})
+  })
+
+  it('should be empty when there’s only 1 page', () => {
+    expect(pagination(1, 1, '?a=b&')).toEqual<Pagination>({})
+  })
+
+  it('should work on page 1 of 2', () => {
+    expect(pagination(1, 2, '?a=b&')).toEqual<Pagination>({
+      next: { href: '?a=b&page=2' },
+      items: [
+        { number: 1, href: '?a=b&page=1', current: true },
+        { number: 2, href: '?a=b&page=2' },
+      ],
+    })
+  })
+
+  it('should work on page 2 of 2', () => {
+    expect(pagination(2, 2, '?a=b&')).toEqual<Pagination>({
+      previous: { href: '?a=b&page=1' },
+      items: [
+        { number: 1, href: '?a=b&page=1' },
+        { number: 2, href: '?a=b&page=2', current: true },
+      ],
+    })
+  })
+
+  it('should work on page 2 of 3', () => {
+    expect(pagination(2, 3, '?a=b&')).toEqual<Pagination>({
+      previous: { href: '?a=b&page=1' },
+      next: { href: '?a=b&page=3' },
+      items: [
+        { number: 1, href: '?a=b&page=1' },
+        { number: 2, href: '?a=b&page=2', current: true },
+        { number: 3, href: '?a=b&page=3' },
+      ],
+    })
+  })
+
+  it('should work on page 1 of 7', () => {
+    expect(pagination(1, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1', current: true },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 2 of 7', () => {
+    expect(pagination(2, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2', current: true },
+      { number: 3, href: '?a=b&page=3' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 3 of 7', () => {
+    expect(pagination(3, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { number: 3, href: '?a=b&page=3', current: true },
+      { number: 4, href: '?a=b&page=4' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 4 of 7', () => {
+    expect(pagination(4, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { number: 3, href: '?a=b&page=3' },
+      { number: 4, href: '?a=b&page=4', current: true },
+      { number: 5, href: '?a=b&page=5' },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 5 of 7', () => {
+    expect(pagination(5, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 4, href: '?a=b&page=4' },
+      { number: 5, href: '?a=b&page=5', current: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 6 of 7', () => {
+    expect(pagination(6, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 5, href: '?a=b&page=5' },
+      { number: 6, href: '?a=b&page=6', current: true },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 7 of 7', () => {
+    expect(pagination(7, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7', current: true },
+    ])
+  })
+})

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -1,0 +1,82 @@
+export type PaginationPreviousOrNext = {
+  href: string
+  text?: string
+  attributes?: Record<string, string>
+}
+
+export type PaginationItem =
+  | {
+      number: number
+      href: string
+      current?: boolean
+    }
+  | {
+      ellipsis: true
+    }
+
+export type Pagination = {
+  previous?: PaginationPreviousOrNext
+  items?: Array<PaginationItem>
+  next?: PaginationPreviousOrNext
+  landmarkLabel?: string
+}
+
+/**
+ * Produces parameters for GOV.UK Pagination component macro
+ * NB: `page` starts at 1
+ *
+ * Accessibility notes:
+ * - set `landmarkLabel` on the returned object otherwise the navigation box is announced as "results"
+ * - set `previous.attributes.aria-label` and `next.attributes.aria-label` on the returned object if "Previous" and "Next" are not clear enough
+ */
+export function pagination(currentPage: number, pageCount: number, hrefPrefix: string): Pagination {
+  const params: Pagination = {}
+
+  if (!pageCount || pageCount <= 1) {
+    return params
+  }
+
+  if (currentPage !== 1) {
+    params.previous = {
+      href: `${hrefPrefix}page=${currentPage - 1}`,
+    }
+  }
+  if (currentPage < pageCount) {
+    params.next = {
+      href: `${hrefPrefix}page=${currentPage + 1}`,
+    }
+  }
+
+  let pages: Array<number | null>
+  if (currentPage >= 5) {
+    pages = [1, 2, null, currentPage - 1, currentPage]
+  } else {
+    pages = [1, 2, 3, 4].slice(0, currentPage)
+  }
+  const maxPage = Math.max(currentPage, pages.at(-1))
+  if (maxPage === pageCount - 1) {
+    pages.push(pageCount)
+  } else if (maxPage === pageCount - 2) {
+    pages.push(pageCount - 1, pageCount)
+  } else if (maxPage === pageCount - 3) {
+    pages.push(maxPage + 1, pageCount - 1, pageCount)
+  } else if (maxPage <= pageCount - 4) {
+    pages.push(maxPage + 1, null, pageCount - 1, pageCount)
+  }
+
+  params.items = pages.map((somePage: number | null): PaginationItem => {
+    if (somePage) {
+      const item: PaginationItem = {
+        number: somePage,
+        href: `${hrefPrefix}page=${somePage}`,
+      }
+      if (somePage === currentPage) {
+        item.current = true
+      }
+      return item
+    }
+    return { ellipsis: true }
+  })
+
+  return params
+}

--- a/server/views/assess/applications/index.njk
+++ b/server/views/assess/applications/index.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/table.njk" import applicationsTable %}
 {% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
@@ -38,8 +40,11 @@
               }
             ],
             submittedApplicationTableRows(applications, true)
-          )      
+          )
+
       }}
+
+    {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
     </div>
   </div>

--- a/server/views/assess/applications/index.njk
+++ b/server/views/assess/applications/index.njk
@@ -20,9 +20,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Short-Term Accommodation (CAS-2) applications</h1>
       {{ showErrorSummary(errorSummary) }}
-
-      {{  
-      
+      <div data-testid="submitted-applications">
+        {{  
+    
         applicationsTable(
             "Submitted", 
             [
@@ -43,6 +43,7 @@
           )
 
       }}
+      </div>
 
     {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-137

# Changes in this PR

Re-introducing pagination to the submitted applications list page, with added e2e tests.
For more context on pagination see this PR https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/498 

Interested in any feedback on what the e2e test for the admin journey should be, and whether just clicking the first link to an application is enough. I would say that we should have confidence our integration test is already checking the content of the application page in detail, so the e2e just needs to check that the page has loaded successfully, but maybe we want to be more specific?

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
