### PR TITLE
Ensure that CYA cannot be started until all prior tasks are complete

### DIFF
--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -25,7 +25,11 @@ export default class TaskListPage extends Page {
 
         // And I see each expected TASK
         section.tasks.forEach(task => {
-          cy.get('[data-cy-task-name]').contains(task.title)
+          if (task.id === 'check-your-answers') {
+            cy.get('div').contains('Check application answers')
+          } else {
+            cy.get('[data-cy-task-name]').contains(task.title)
+          }
         })
       })
     })

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -35,6 +35,15 @@ jest.mock('../form-pages/apply', () => {
           },
         ],
       },
+      {
+        title: 'Check your answers',
+        tasks: [
+          {
+            id: 'check-your-answers',
+            title: 'Check your answers',
+          },
+        ],
+      },
     ],
   }
 })
@@ -49,7 +58,7 @@ describe('taskListService', () => {
   })
 
   describe('taskStatuses', () => {
-    it('returns status of task', () => {
+    it('returns task statuses and sets the statuses of check your answers to be cannot_start when other tasks have not been completed', () => {
       ;(getTaskStatus as jest.Mock).mockReturnValue('in_progress')
 
       const taskListService = new TaskListService(application)
@@ -60,9 +69,25 @@ describe('taskListService', () => {
         'third-task': 'in_progress',
         'fourth-task': 'in_progress',
         'fifth-task': 'in_progress',
+        'check-your-answers': 'cannot_start',
       })
 
       expect(getTaskStatus).toHaveBeenCalledTimes(5)
+    })
+
+    it('allows check your answers to be complete when other tasks have been completed', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('complete')
+
+      const taskListService = new TaskListService(application)
+
+      expect(taskListService.taskStatuses).toEqual({
+        'first-task': 'complete',
+        'second-task': 'complete',
+        'third-task': 'complete',
+        'fourth-task': 'complete',
+        'fifth-task': 'complete',
+        'check-your-answers': 'complete',
+      })
     })
   })
 
@@ -90,7 +115,7 @@ describe('taskListService', () => {
 
       const taskListService = new TaskListService(application)
 
-      expect(taskListService.completeTaskCount).toEqual(5)
+      expect(taskListService.completeTaskCount).toEqual(6)
     })
   })
 
@@ -136,6 +161,11 @@ describe('taskListService', () => {
             { id: 'fifth-task', title: 'Fifth task', status: 'not_started' },
           ],
         },
+        {
+          sectionNumber: 3,
+          title: 'Check your answers',
+          tasks: [{ id: 'check-your-answers', title: 'Check your answers', status: 'cannot_start' }],
+        },
       ])
     })
   })
@@ -144,7 +174,7 @@ describe('taskListService', () => {
     it('returns the number of total tasks', () => {
       const taskListService = new TaskListService(application)
 
-      expect(taskListService.taskCount).toEqual(5)
+      expect(taskListService.taskCount).toEqual(6)
     })
   })
 })

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -14,7 +14,15 @@ export default class TaskListService {
 
     this.formSections.forEach(section => {
       section.tasks.forEach(task => {
-        this.taskStatuses[task.id] = getTaskStatus(task, application)
+        if (
+          task.id === 'check-your-answers' &&
+          (Object.values(this.taskStatuses).includes('not_started') ||
+            Object.values(this.taskStatuses).includes('in_progress'))
+        ) {
+          this.taskStatuses[task.id] = 'cannot_start'
+        } else {
+          this.taskStatuses[task.id] = getTaskStatus(task, application)
+        }
       })
     })
   }

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -17,7 +17,6 @@ export const statusTag = (task: TaskWithStatus): string => {
 
 export const taskLink = (task: TaskWithStatus, application: Application): string => {
   if (task.status !== 'cannot_start') {
-    // there is no such status, so this is always true
     const firstPage = Object.keys(task.pages)[0]
     const link = applyPaths.applications.pages.show({
       id: application.id,

--- a/server/views/partials/taskListItems.njk
+++ b/server/views/partials/taskListItems.njk
@@ -8,12 +8,17 @@
         <li class="govuk-task-list__item govuk-task-list__item--with-link">
           <div class="govuk-task-list__name-and-hint">
             {{ TaskListUtils.taskLink(task, application) | safe   }}
-          </div>
-          <div class="govuk-task-list__status" id="{{ task.id }}-status">
-            {{ TaskListUtils.statusTag(task) | safe  }}
-          </div>
-        </li>
-      {% endfor %}
-    </ul>
-  </li>
-{% endfor %}
+            {% if task.id == 'check-your-answers' %}
+              <div class="govuk-task-list__hint">
+                All questions must be answered first
+              </div>
+              {%endif%}
+            </div>
+            <div class="govuk-task-list__status" id="{{ task.id }}-status">
+              {{ TaskListUtils.statusTag(task) | safe  }}
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </li>
+  {% endfor %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-170
I currently cannot run E2E tests locally due to issues with Playwright and mobile internet so I would appreciate if the reviewer could check that the tests pass on their machine.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
