### PR TITLE
fix assessor e2e tests to be person-agnostic

### DIFF
--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -1,21 +1,19 @@
 import { Page, expect } from '@playwright/test'
 
-export const updateStatus = async (page: Page, person: { crn: string; name: string; nomsNumber: string }) => {
+export const updateStatus = async (page: Page) => {
   await page.getByRole('button', { name: 'Update application status' }).click()
-  await expect(page.locator('h1')).toContainText(`What is the latest status of ${person.name}'s application?`)
+  await expect(page.locator('h1')).toContainText(`What is the latest status`)
   await page.getByLabel('More information requested').check()
   await page.getByRole('button', { name: 'Save and continue' }).click()
 }
 
-export const viewSubmittedApplication = async (
-  page: Page,
-  person: { crn: string; name: string; nomsNumber: string },
-) => {
+export const viewSubmittedApplication = async (page: Page) => {
   await page.goto('/assess/applications')
   await expect(page.locator('h1')).toContainText('Short-Term Accommodation (CAS-2) applications')
   await page.getByTestId('submitted-applications').getByRole('link').first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
-  await expect(page.locator('h1')).toContainText(`${person.name}'s application`)
+  await expect(page.locator('h1')).toContainText(`application`)
+  await expect(page.locator('h2').first()).toContainText('Applicant details')
 }
 
 export const signInAsAssessor = async (

--- a/e2e-tests/tests/03_assess.spec.ts
+++ b/e2e-tests/tests/03_assess.spec.ts
@@ -2,12 +2,12 @@ import { Page, expect } from '@playwright/test'
 import { signInAsAssessor, updateStatus, viewSubmittedApplication } from '../steps/assess'
 import { test } from '../test'
 
-test('view a submitted application as an admin', async ({ page, assessorUser, person }) => {
+test('view a submitted application as an admin', async ({ page, assessorUser }) => {
   await signOut(page)
   await signInAsAssessor(page, assessorUser)
-  await viewSubmittedApplication(page, person)
-  await updateStatus(page, person)
-  await expect(page.locator('h1')).toContainText(person.name)
+  await viewSubmittedApplication(page)
+  await updateStatus(page)
+  await expect(page.locator('.moj-timeline__title').first()).toContainText('More information requested')
 })
 
 const signOut = async (page: Page) => {


### PR DESCRIPTION
As the dev environment has seeded data with test
names, the test has to be neutral on the personal
details of the application it picks, and just
check for known elements.

