### PR TITLE
store test artifacts for e2e's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,12 @@ jobs:
       - run:
           name: Run E2E tests
           command: npm run test:e2e
+      - store_artifacts:
+          path: playwright-report
+          destination: playwright-report
+      - store_artifacts:
+          path: test-results
+          destination: test-results
 
 workflows:
   build-test-and-deploy:


### PR DESCRIPTION
This follow's CAS1's implementation (and the recommended CircleCI way), and should allow us to see videos of failing tests in CircleCI UI (e.g. [here[1]](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-api/10433/workflows/6da2f46d-345b-43b9-9963-6f9b3981b01f/jobs/32937/artifacts)) helping us debug failures quicker.

