### PR TITLE
Tweak previous conviction question and answer for no

### DIFF
--- a/e2e-tests/steps/offenceAndLicenceInformationSection.ts
+++ b/e2e-tests/steps/offenceAndLicenceInformationSection.ts
@@ -37,7 +37,10 @@ export const completeOffenceHistoryTask = async (page: Page, name: string) => {
 }
 
 async function completeAnyPreviousConvictionsPage(page: Page, name: string) {
-  const anyPreviousConvictionsPage = await ApplyPage.initialize(page, `Does ${name} have any previous convictions?`)
+  const anyPreviousConvictionsPage = await ApplyPage.initialize(
+    page,
+    `Does ${name} have any previous unspent convictions?`,
+  )
   await anyPreviousConvictionsPage.checkRadio('No')
   await anyPreviousConvictionsPage.clickSave()
 }

--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -331,8 +331,8 @@
           "title": "Add offending history",
           "questionsAndAnswers": [
             {
-              "question": "Does Aadland Bertrand have any previous convictions?",
-              "answer": "No, this is their first offence"
+              "question": "Does Aadland Bertrand have any previous unspent convictions?",
+              "answer": "No"
             }
           ]
         }

--- a/integration_tests/pages/apply/offence_and_licence_information/offending-history/anyPreviousConvictionsPage.ts
+++ b/integration_tests/pages/apply/offence_and_licence_information/offending-history/anyPreviousConvictionsPage.ts
@@ -6,7 +6,7 @@ import paths from '../../../../../server/paths/apply'
 export default class AnyPreviousConvictionsPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(
-      `Does ${nameOrPlaceholderCopy(application.person)} have any previous convictions?`,
+      `Does ${nameOrPlaceholderCopy(application.person)} have any previous unspent convictions?`,
       application,
       'offending-history',
       'any-previous-convictions',

--- a/integration_tests/tests/apply/offence_and_licence_information/offending-history/any_previous_convictions.cy.ts
+++ b/integration_tests/tests/apply/offence_and_licence_information/offending-history/any_previous_convictions.cy.ts
@@ -1,18 +1,18 @@
-//  Feature: Referrer completes 'has any previous convictions' page
+//  Feature: Referrer completes 'has any previous unspent convictions' page
 //    So that I can complete the "Offending history" task
 //    As a referrer
-//    I want to complete the 'has any previous convictions' page
+//    I want to complete the 'has any previous unspent convictions' page
 //
 //  Background:
 //    Given an application exists
 //    And I am logged in
-//    And I visit the 'has any previous convictions' page
+//    And I visit the 'has any previous unspent convictions' page
 //
-//  Scenario: view 'has any previous convictions' page
-//    Then I see the "has any previous convictions" page
+//  Scenario: view 'has any previous unspent convictions' page
+//    Then I see the "has any previous unspent convictions" page
 //
 //  Scenario: navigate to task list on completion of task
-//    When I complete the "has any previous convictions" page
+//    When I complete the "has any previous unspent convictions" page
 //    And I continue to the next task / page
 //    Then I am taken to add an offence history
 
@@ -21,7 +21,7 @@ import { personFactory, applicationFactory } from '../../../../../server/testuti
 import AnyPreviousConvictionsPage from '../../../../pages/apply/offence_and_licence_information/offending-history/anyPreviousConvictionsPage'
 import OffenceHistoryDataPage from '../../../../pages/apply/offence_and_licence_information/offending-history/offenceHistoryDataPage'
 
-context('Visit "has any previous convictions" page', () => {
+context('Visit "has any previous unspent convictions" page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
 
   beforeEach(function test() {
@@ -50,23 +50,23 @@ context('Visit "has any previous convictions" page', () => {
     //---------------------
     cy.signIn()
 
-    // And I visit the 'has any previous convictions' page
+    // And I visit the 'has any previous unspent convictions' page
     // --------------------------------
     AnyPreviousConvictionsPage.visit(this.application)
   })
 
-  //  Scenario: view 'has any previous convictions' page
+  //  Scenario: view 'has any previous unspent convictions' page
   // ----------------------------------------------
 
-  it('presents has any previous convictions page', function test() {
-    //    Then I see the "has any previous convictions" page
+  it('presents has any previous unspent convictions page', function test() {
+    //    Then I see the "has any previous unspent convictions" page
     Page.verifyOnPage(AnyPreviousConvictionsPage, this.application)
   })
 
   //  Scenario: navigate to Offence History page
   // ----------------------------------------------
   it('navigates to the next page', function test() {
-    //    When I complete the "has any previous convictions" page
+    //    When I complete the "has any previous unspent convictions" page
     const page = Page.verifyOnPage(AnyPreviousConvictionsPage, this.application)
     page.checkRadioByNameAndValue('hasAnyPreviousConvictions', 'yes')
 

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/anyPreviousConvictions.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/anyPreviousConvictions.test.ts
@@ -27,7 +27,7 @@ describe('hasAnyPreviousConvictions', () => {
     it('personalises the page title', () => {
       const page = new AnyPreviousConvictions({}, application)
 
-      expect(page.title).toEqual('Does Roger Smith have any previous convictions?')
+      expect(page.title).toEqual('Does Roger Smith have any previous unspent convictions?')
     })
   })
 
@@ -68,7 +68,7 @@ describe('hasAnyPreviousConvictions', () => {
       it('returns an error', () => {
         const page = new AnyPreviousConvictions({}, application)
         expect(page.errors()).toEqual({
-          hasAnyPreviousConvictions: 'Confirm whether the applicant has any previous convictions',
+          hasAnyPreviousConvictions: 'Confirm whether the applicant has any previous unspent convictions',
         })
       })
     })
@@ -79,10 +79,7 @@ describe('hasAnyPreviousConvictions', () => {
       const page = new AnyPreviousConvictions({}, application)
 
       expect(page.items()).toEqual(yesNoRadios)
-      expect(convertKeyValuePairToRadioItems).toHaveBeenCalledWith(
-        { no: 'No, this is their first offence', yes: 'Yes' },
-        undefined,
-      )
+      expect(convertKeyValuePairToRadioItems).toHaveBeenCalledWith({ no: 'No', yes: 'Yes' }, undefined)
     })
   })
 })

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/anyPreviousConvictions.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/anyPreviousConvictions.ts
@@ -15,11 +15,11 @@ type AnyPreviousConvictionsBody = {
   bodyProperties: ['hasAnyPreviousConvictions'],
 })
 export default class AnyPreviousConvictions implements TaskListPage {
-  documentTitle = 'Does the person have any previous convictions?'
+  documentTitle = 'Does the person have any previous unspent convictions?'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 
-  title = `Does ${this.personName} have any previous convictions?`
+  title = `Does ${this.personName} have any previous unspent convictions?`
 
   questions = getQuestions(this.personName)['offending-history']['any-previous-convictions']
 
@@ -51,7 +51,7 @@ export default class AnyPreviousConvictions implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
     if (!this.body.hasAnyPreviousConvictions) {
-      errors.hasAnyPreviousConvictions = 'Confirm whether the applicant has any previous convictions'
+      errors.hasAnyPreviousConvictions = 'Confirm whether the applicant has any previous unspent convictions'
     }
     return errors
   }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -809,8 +809,8 @@ export const getQuestions = (name: string) => {
     'offending-history': {
       'any-previous-convictions': {
         hasAnyPreviousConvictions: {
-          question: `Does ${name} have any previous convictions?`,
-          answers: { yes: 'Yes', no: 'No, this is their first offence' },
+          question: `Does ${name} have any previous unspent convictions?`,
+          answers: { yes: 'Yes', no: 'No' },
         },
       },
       'offence-history-data': {

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -38,7 +38,7 @@ export const offenceDetailsFactory = Factory.define<OASysQuestion>(options => ({
     'Provide evidence of the motivation and triggers for the offending',
     'Provide details of the impact on the victim',
     'Victim Information',
-    'Is there a pattern of offending? Consider details of previous convictions',
+    'Is there a pattern of offending? Consider details of previous unspent convictions',
   ]),
   answer: faker.lorem.paragraph(),
 }))


### PR DESCRIPTION
Tweak to previous conviction question page to:
- specify that the question is about unspent convictions
- remove 'this is their first offence' from the 'No' answer, as the applicant may have previous convictions that are not unspent

[Jira ticket 261](https://dsdmoj.atlassian.net/browse/CAS2-261)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
