### PR TITLE
Feature flagged: allow an assessor to add a note to an application

### DIFF
--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -26,3 +26,9 @@ export const signInAsAssessor = async (
   await page.getByLabel('Password').fill(assessorUser.password)
   await page.getByRole('button', { name: 'Sign in' }).click()
 }
+
+export const addNote = async (page: Page) => {
+  await page.getByLabel('Add a note for the referrer ', { exact: true }).fill('some notes for the referrer')
+  await page.getByTestId('submit-button').click()
+  await expect(page.locator('h2').first()).toContainText('Success')
+}

--- a/e2e-tests/tests/03_assess.spec.ts
+++ b/e2e-tests/tests/03_assess.spec.ts
@@ -1,5 +1,5 @@
 import { Page, expect } from '@playwright/test'
-import { signInAsAssessor, updateStatus, viewSubmittedApplication } from '../steps/assess'
+import { signInAsAssessor, updateStatus, viewSubmittedApplication, addNote } from '../steps/assess'
 import { test } from '../test'
 
 test('view a submitted application as an assessor', async ({ page, assessorUser }) => {
@@ -8,6 +8,7 @@ test('view a submitted application as an assessor', async ({ page, assessorUser 
   await viewSubmittedApplication(page)
   await updateStatus(page)
   await expect(page.locator('.moj-timeline__title').first()).toContainText('More information requested')
+  await addNote(page)
 })
 
 const signOut = async (page: Page) => {

--- a/integration_tests/pages/apply/submittedApplicationOverviewPage.ts
+++ b/integration_tests/pages/apply/submittedApplicationOverviewPage.ts
@@ -16,4 +16,9 @@ export default class SubmittedApplicationOverviewPage extends Page {
     this.getTextInputByIdAndEnterDetails('note', 'some notes')
     cy.get('button').click()
   }
+
+  shouldShowErrorMessage(): void {
+    cy.get('.govuk-error-summary').should('contain', 'Enter a note for the assessor')
+    cy.get('form').should('contain', 'Enter a note for the assessor')
+  }
 }

--- a/integration_tests/pages/assess/submittedApplicationOverviewPage.ts
+++ b/integration_tests/pages/assess/submittedApplicationOverviewPage.ts
@@ -11,4 +11,14 @@ export default class SubmittedApplicationOverviewPage extends Page {
     cy.visit(`/assess/applications/${application.id}/overview`)
     return new SubmittedApplicationOverviewPage(application)
   }
+
+  addANote = (): void => {
+    this.getTextInputByIdAndEnterDetails('note', 'some notes')
+    cy.get('button').click()
+  }
+
+  shouldShowErrorMessage(): void {
+    cy.get('.govuk-error-summary').should('contain', 'Enter a note for the referrer')
+    cy.get('form').should('contain', 'Enter a note for the referrer')
+  }
 }

--- a/integration_tests/tests/apply/submitted_applications/add_an_application_note.cy.ts
+++ b/integration_tests/tests/apply/submitted_applications/add_an_application_note.cy.ts
@@ -74,6 +74,6 @@ context('Referrer adds a note to a submitted application', () => {
     page.addANote()
 
     //   Then I see an error message
-    page.shouldShowErrorMessagesForFields(['note'])
+    page.shouldShowErrorMessage()
   })
 })

--- a/integration_tests/tests/assess/add_an_application_note.cy.ts
+++ b/integration_tests/tests/assess/add_an_application_note.cy.ts
@@ -1,0 +1,65 @@
+//  Feature: Assessor adds a note to a submitted application
+//    So that I can communicate with referrers about a submitted application
+//    As an assessor
+//    I want to add a note to the application
+//
+//  Background:
+//    Given a submitted application exists
+//    And I am logged in as a assessor
+//    When I visit the application overview for that application
+//
+//  Scenario: successfully add a note to an application
+//    And I add a note
+//    Then I see a success message
+//
+//  Scenario: fail to add a note to an application
+//    And I add a note
+//    Then I see an error message
+
+import SubmittedApplicationOverviewPage from '../../pages/assess/submittedApplicationOverviewPage'
+import { applicationNoteFactory, submittedApplicationFactory } from '../../../server/testutils/factories'
+import Page from '../../pages/page'
+
+context('Assessor adds a note to a submitted application', () => {
+  const submittedApplication = submittedApplicationFactory.build({})
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAssessorUser')
+  })
+
+  beforeEach(() => {
+    // Given a submitted application exists
+    cy.task('stubSubmittedApplicationGet', { application: submittedApplication })
+
+    // And I am logged in as a NACRO assessor
+    cy.signIn()
+
+    // When I visit the application overview for that application
+    SubmittedApplicationOverviewPage.visit(submittedApplication)
+  })
+
+  //  Scenario: successfully add a note to an application
+  it('shows a success message', function test() {
+    //  And I add a note
+    const note = applicationNoteFactory.build()
+    const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, submittedApplication)
+    cy.task('stubAddNote', { applicationId: submittedApplication.id, note })
+    page.addANote()
+
+    //  Then I see a success message
+    page.shouldShowSuccessMessage('Your note was saved.')
+  })
+
+  //  Scenario: fail to add a note to an application
+  it('shows an error message', function test() {
+    //  And I add a note
+    const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, submittedApplication)
+    cy.task('stubAddNoteBadRequest', { applicationId: submittedApplication.id })
+    page.addANote()
+
+    //   Then I see an error message
+    page.shouldShowErrorMessage()
+  })
+})

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -19,7 +19,7 @@ import {
   errorSummary as errorSummaryMock,
 } from '../../utils/validation'
 import ApplicationsController from './applicationsController'
-import { PersonService, ApplicationService, TaskListService } from '../../services'
+import { PersonService, ApplicationService, TaskListService, SubmittedApplicationService } from '../../services'
 import paths from '../../paths/apply'
 import { buildDocument } from '../../utils/applications/documentUtils'
 import config from '../../config'
@@ -38,6 +38,7 @@ describe('applicationsController', () => {
 
   const personService = createMock<PersonService>({})
   const applicationService = createMock<ApplicationService>({})
+  const submittedApplicationService = createMock<SubmittedApplicationService>({})
 
   let applicationsController: ApplicationsController
 
@@ -46,10 +47,15 @@ describe('applicationsController', () => {
   applicationService.getAllForLoggedInUser.mockResolvedValue(applications)
 
   beforeEach(() => {
-    applicationsController = new ApplicationsController(personService, applicationService, {
+    applicationsController = new ApplicationsController(
       personService,
       applicationService,
-    })
+      submittedApplicationService,
+      {
+        personService,
+        applicationService,
+      },
+    )
 
     request = createMock<Request>({
       user: { token },
@@ -791,7 +797,7 @@ describe('applicationsController', () => {
 
         const note = applicationNoteFactory.build()
 
-        applicationService.addApplicationNote.mockImplementation(async () => note)
+        submittedApplicationService.addApplicationNote.mockImplementation(async () => note)
 
         const requestHandler = applicationsController.addNote()
         await requestHandler(request, response)
@@ -809,7 +815,7 @@ describe('applicationsController', () => {
         request.body = { note: 'some notes' }
 
         const err = new Error()
-        applicationService.addApplicationNote.mockImplementation(() => {
+        submittedApplicationService.addApplicationNote.mockImplementation(() => {
           throw err
         })
 

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -6,11 +6,16 @@ import PagesController from './applications/pagesController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { applicationService, personService } = services
-  const applicationsController = new ApplicationsController(personService, applicationService, {
+  const { applicationService, personService, submittedApplicationService } = services
+  const applicationsController = new ApplicationsController(
     personService,
     applicationService,
-  })
+    submittedApplicationService,
+    {
+      personService,
+      applicationService,
+    },
+  )
   const pagesController = new PagesController(applicationService, { personService, applicationService })
 
   return {

--- a/server/controllers/assess/submittedApplicationsController.test.ts
+++ b/server/controllers/assess/submittedApplicationsController.test.ts
@@ -97,12 +97,20 @@ describe('submittedApplicationsController', () => {
   })
 
   describe('overview', () => {
+    const priorConfigFlags = config.flags
+
+    afterAll(() => {
+      config.flags = priorConfigFlags
+    })
+
     describe('when there is a status update', () => {
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
       it('renders the submitted application overview template', async () => {
         submittedApplicationService.findApplication.mockResolvedValue(submittedApplication)
+
+        config.flags.notesDisabled = 'false'
 
         const requestHandler = submittedApplicationsController.overview()
         await requestHandler(request, response, next)
@@ -112,6 +120,7 @@ describe('submittedApplicationsController', () => {
         )
 
         expect(response.render).toHaveBeenCalledWith('assess/applications/overview', {
+          notesDisabled: 'false',
           application: submittedApplication,
           status: statusUpdate.label,
           errors: {},
@@ -130,6 +139,8 @@ describe('submittedApplicationsController', () => {
         })
         submittedApplicationService.findApplication.mockResolvedValue(submittedApplicationWithoutStatus)
 
+        config.flags.notesDisabled = 'true'
+
         const requestHandler = submittedApplicationsController.overview()
         await requestHandler(request, response, next)
 
@@ -138,6 +149,7 @@ describe('submittedApplicationsController', () => {
         )
 
         expect(response.render).toHaveBeenCalledWith('assess/applications/overview', {
+          notesDisabled: 'true',
           application: submittedApplicationWithoutStatus,
           status: 'Received',
           errors: {},

--- a/server/controllers/assess/submittedApplicationsController.ts
+++ b/server/controllers/assess/submittedApplicationsController.ts
@@ -3,6 +3,7 @@ import { FullPerson } from '@approved-premises/api'
 import SubmittedApplicationService from '../../services/submittedApplicationService'
 import assessPaths from '../../paths/assess'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
+import config from '../../config'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 
 export default class SubmittedApplicationsController {
@@ -45,6 +46,7 @@ export default class SubmittedApplicationsController {
       const status = application.statusUpdates.length ? application.statusUpdates[0].label : 'Received'
 
       return res.render('assess/applications/overview', {
+        notesDisabled: config.flags.notesDisabled,
         application,
         status,
         errors,

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,6 +1,6 @@
 import { SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
 import ApplicationClient from './applicationClient'
-import { applicationFactory, applicationNoteFactory } from '../testutils/factories'
+import { applicationFactory } from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 
@@ -151,38 +151,6 @@ describeClient('ApplicationClient', provider => {
       })
 
       await applicationClient.submit(application.id, data)
-    })
-  })
-
-  describe('addNote', () => {
-    it('should create a note', async () => {
-      const application = applicationFactory.build()
-      const body = {
-        note: 'some note',
-      }
-
-      const applicationNote = applicationNoteFactory.build({ body: body.note })
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to add a note to an application',
-        withRequest: {
-          method: 'POST',
-          path: paths.submissions.applicationNotes.create({ id: application.id }),
-          body,
-          headers: {
-            authorization: `Bearer ${token}`,
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: applicationNote,
-        },
-      })
-
-      const result = await applicationClient.addNote(application.id, body.note)
-
-      expect(result).toEqual(applicationNote)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,6 +1,5 @@
 import {
   Cas2Application as Application,
-  Cas2ApplicationNote,
   Cas2ApplicationSummary,
   SubmitCas2Application,
   UpdateApplication,
@@ -46,12 +45,5 @@ export default class ApplicationClient {
       path: paths.submissions.create.pattern,
       data: { ...submissionData, applicationId },
     })
-  }
-
-  async addNote(applicationId: string, newNote: string): Promise<Cas2ApplicationNote> {
-    return (await this.restClient.post({
-      path: paths.submissions.applicationNotes.create({ id: applicationId }),
-      data: { note: newNote },
-    })) as Cas2ApplicationNote
   }
 }

--- a/server/data/submittedApplicationClient.test.ts
+++ b/server/data/submittedApplicationClient.test.ts
@@ -1,5 +1,5 @@
 import SubmittedApplicationClient from './submittedApplicationClient'
-import { submittedApplicationFactory } from '../testutils/factories'
+import { applicationFactory, applicationNoteFactory, submittedApplicationFactory } from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 
@@ -100,6 +100,38 @@ describeClient('SubmittedApplicationClient', provider => {
       })
 
       await submittedApplicationClient.updateStatus(application.id, data)
+    })
+  })
+
+  describe('addNote', () => {
+    it('should create a note', async () => {
+      const application = applicationFactory.build()
+      const body = {
+        note: 'some note',
+      }
+
+      const applicationNote = applicationNoteFactory.build({ body: body.note })
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to add a note to an application',
+        withRequest: {
+          method: 'POST',
+          path: paths.submissions.applicationNotes.create({ id: application.id }),
+          body,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: applicationNote,
+        },
+      })
+
+      const result = await submittedApplicationClient.addNote(application.id, body.note)
+
+      expect(result).toEqual(applicationNote)
     })
   })
 })

--- a/server/data/submittedApplicationClient.ts
+++ b/server/data/submittedApplicationClient.ts
@@ -2,6 +2,7 @@ import {
   Cas2SubmittedApplication as SubmittedApplication,
   Cas2ApplicationStatusUpdate as ApplicationStatusUpdate,
   Cas2SubmittedApplicationSummary,
+  Cas2ApplicationNote,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 import RestClient from './restClient'
@@ -34,5 +35,12 @@ export default class SubmittedApplicationClient {
       path: paths.applicationStatusUpdates.create({ id: applicationId }),
       data: newStatus,
     })
+  }
+
+  async addNote(applicationId: string, newNote: string): Promise<Cas2ApplicationNote> {
+    return (await this.restClient.post({
+      path: paths.submissions.applicationNotes.create({ id: applicationId }),
+      data: { note: newNote },
+    })) as Cas2ApplicationNote
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -91,8 +91,5 @@
     "cancelled": {
       "empty": "Select why the referral was cancelled"
     }
-  },
-  "note": {
-    "empty": "Enter a note for the assessor"
   }
 }

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -10,6 +10,7 @@ export default {
     index: assessApplicationsPath,
     show: singleApplicationPath,
     overview: singleApplicationPath.path('overview'),
+    addNote: singleApplicationPath.path('add-note'),
   },
   statusUpdate: {
     new: updateStatusPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -76,7 +76,9 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
     })
   })
 
-  post(paths.applications.addNote.pattern, applicationsController.addNote(), { auditEvent: 'CREATE_APPLICATION_NOTE' })
+  post(paths.applications.addNote.pattern, applicationsController.addNote(), {
+    auditEvent: 'CREATE_APPLICATION_NOTE_AS_REFERRER',
+  })
 
   return router
 }

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -40,5 +40,9 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
     auditEvent: 'CREATE_SUBMITTED_APPLICATION_FURTHER_INFORMATION_STATUS_UPDATE',
   })
 
+  post(paths.submittedApplications.addNote.pattern, submittedApplicationsController.addNote(), {
+    auditEvent: 'CREATE_APPLICATION_NOTE_AS_ASSESSOR',
+  })
+
   return router
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -11,7 +11,7 @@ import { ValidationError } from '../utils/errors'
 import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
 import CheckYourAnswers from '../form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers'
 
-import { applicationFactory, applicationNoteFactory, applicationSummaryFactory } from '../testutils/factories'
+import { applicationFactory, applicationSummaryFactory } from '../testutils/factories'
 
 jest.mock('../data/applicationClient.ts')
 jest.mock('../data/personClient.ts')
@@ -687,26 +687,6 @@ describe('ApplicationService', () => {
         data: newApplicationData,
       })
       expect(applicationClient.update).toHaveBeenCalledWith(application.id, applicationData)
-    })
-  })
-
-  describe('addApplicationNote', () => {
-    it('calls the correct client method and returns the created application note', async () => {
-      const application = applicationFactory.build()
-      const body = {
-        note: 'some note',
-      }
-      const token = 'some-token'
-
-      const applicationNote = applicationNoteFactory.build({ body: body.note })
-
-      applicationClient.addNote.mockImplementation(() => Promise.resolve(applicationNote))
-
-      const result = await service.addApplicationNote(token, application.id, body.note)
-
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.addNote).toHaveBeenCalledWith(application.id, body.note)
-      expect(result).toEqual(applicationNote)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express'
-import { AnyValue, Cas2Application as Application, Cas2Application, Cas2ApplicationNote } from '@approved-premises/api'
+import { AnyValue, Cas2Application as Application, Cas2Application } from '@approved-premises/api'
 import type { DataServices, GroupedApplications } from '@approved-premises/ui'
 import { getBody, getPageName, getTaskName, pageBodyShallowEquals } from '../form-pages/utils'
 import type { ApplicationClient, RestClientBuilder } from '../data'
@@ -183,11 +183,5 @@ export default class ApplicationService {
     const client = this.applicationClientFactory(token)
 
     await client.submit(application.id, getApplicationSubmissionData(application))
-  }
-
-  async addApplicationNote(token: string, applicationId: string, newNote: string): Promise<Cas2ApplicationNote> {
-    const applicationClient = this.applicationClientFactory(token)
-
-    return applicationClient.addNote(applicationId, newNote)
   }
 }

--- a/server/services/submittedApplicationService.test.ts
+++ b/server/services/submittedApplicationService.test.ts
@@ -2,7 +2,12 @@ import { Cas2SubmittedApplicationSummary } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 
 import SubmittedApplicationService from './submittedApplicationService'
-import { submittedApplicationFactory, applicationStatusFactory, paginatedResponseFactory } from '../testutils/factories'
+import {
+  submittedApplicationFactory,
+  applicationStatusFactory,
+  paginatedResponseFactory,
+  applicationNoteFactory,
+} from '../testutils/factories'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
 import { ReferenceDataClient, SubmittedApplicationClient } from '../data'
 
@@ -90,6 +95,24 @@ describe('SubmittedApplicationService', () => {
 
       expect(submittedApplicationClientFactory).toHaveBeenCalledWith(token)
       expect(submittedApplicationClient.updateStatus).toHaveBeenCalledWith(submittedApplication.id, data)
+    })
+  })
+
+  describe('addApplicationNote', () => {
+    it('calls the correct client method and returns the created application note', async () => {
+      const body = {
+        note: 'some note',
+      }
+
+      const applicationNote = applicationNoteFactory.build({ body: body.note })
+
+      submittedApplicationClient.addNote.mockImplementation(() => Promise.resolve(applicationNote))
+
+      const result = await service.addApplicationNote(token, submittedApplication.id, body.note)
+
+      expect(submittedApplicationClientFactory).toHaveBeenCalledWith(token)
+      expect(submittedApplicationClient.addNote).toHaveBeenCalledWith(submittedApplication.id, body.note)
+      expect(result).toEqual(applicationNote)
     })
   })
 })

--- a/server/services/submittedApplicationService.ts
+++ b/server/services/submittedApplicationService.ts
@@ -3,6 +3,7 @@ import {
   Cas2ApplicationStatus as ApplicationStatus,
   Cas2ApplicationStatusUpdate as ApplicationStatusUpdate,
   Cas2SubmittedApplicationSummary,
+  Cas2ApplicationNote,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 
@@ -46,5 +47,11 @@ export default class SubmittedApplicationService {
     const applicationClient = this.submittedApplicationClientFactory(token)
 
     await applicationClient.updateStatus(applicationId, newStatus)
+  }
+
+  async addApplicationNote(token: string, applicationId: string, newNote: string): Promise<Cas2ApplicationNote> {
+    const applicationClient = this.submittedApplicationClientFactory(token)
+
+    return applicationClient.addNote(applicationId, newNote)
   }
 }

--- a/server/views/applications/overview.njk
+++ b/server/views/applications/overview.njk
@@ -81,5 +81,7 @@
       {% endif %}
 
       {{ timeline(getApplicationTimelineEvents(application)) }}
+    </div>
+  </div>
 
-    {% endblock %}
+{% endblock %}

--- a/server/views/assess/applications/overview.njk
+++ b/server/views/assess/applications/overview.njk
@@ -4,6 +4,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/_timeline.njk" import timeline %}
@@ -22,29 +25,66 @@
 {% endblock %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ showErrorSummary(errorSummary) }}
 
-  {{submittedApplicationDetails(application, status)}}
+      {% if successMessages %}
+        {% for message in successMessages %}
+          {{ govukNotificationBanner({
+                html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+                type: 'success',
+                titleId: 'success-title'
+              }) }}
+        {% endfor %}
+      {% endif %}
 
-  <div class="govuk-button-group govuk-!-margin-top-5">
-    {{ govukButton({
+      {{submittedApplicationDetails(application, status)}}
+
+      <div class="govuk-button-group govuk-!-margin-top-5">
+        {{ govukButton({
       text: "View submitted application",
       href: paths.submittedApplications.show({id: application.id})
     }) }}
 
-    {{ govukButton({
+        {{ govukButton({
       text: "Update application status",
       href: paths.statusUpdate.new({id: application.id}),
       classes: "govuk-button--secondary"
     })
   }}
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-2">
+
+      <h2 class="govuk-heading-l">
+        Application history
+      </h2>
+
+
+        <form action="{{ paths.submittedApplications.addNote({ id: application.id }) }}" method="post">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+          {{ govukTextarea({
+        name: "note",
+        id: "note",
+        label: {
+          text: "Add a note for the referrer",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: 'Use this text box to ask for or provide more information. Anything you add and save will appear on the application history.'
+        },
+        errorMessage: errors.note
+      }) }}
+
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-testid="submit-button">
+          Submit
+        </button>
+
+        </form>
+
+      {{ timeline(getApplicationTimelineEvents(application)) }}
+    </div>
   </div>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-2">
-
-  <h2 class="govuk-heading-l">
-        Status history
-  </h2>
-
-  {{ timeline(getApplicationTimelineEvents(application)) }}
-
 {% endblock %}

--- a/server/views/assess/applications/overview.njk
+++ b/server/views/assess/applications/overview.njk
@@ -61,6 +61,7 @@
         Application history
       </h2>
 
+      {% if notesDisabled == 'false' %}
 
         <form action="{{ paths.submittedApplications.addNote({ id: application.id }) }}" method="post">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
@@ -83,6 +84,8 @@
         </button>
 
         </form>
+
+      {% endif %}
 
       {{ timeline(getApplicationTimelineEvents(application)) }}
     </div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-211

# Changes in this PR

Allows an assessor to add a note to a submitted application, provided the NOTES_DISABLED env variable is set to 'false'.

## Screenshots of UI changes

### Before

![Screenshot 2024-02-23 at 11 53 53](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/fbbcbad7-eb51-4ada-84f3-91910c6c1b19)

### After

![Screenshot 2024-02-23 at 11 54 14](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/57bd39e5-cfac-4ea7-89b6-2a3dbe1d5874)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
