### PR TITLE
Remove jquery-ui as no longer required

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -8,11 +8,6 @@
 {% block head %}
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
   <script src="/assets/js/jquery.min.js"></script>
-  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
-          integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
-          nonce="{{ cspNonce }}"
-          crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
   {% if tagManagerId %}
     <!-- Google Tag Manager -->


### PR DESCRIPTION


# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

https://dsdmoj.atlassian.net/browse/CAS2-120?atlOrigin=eyJpIjoiNTBjMGY3MjJiNGZhNGE4YmFiMDk0OTdjZDRlNDhjZmMiLCJwIjoiaiJ9

- The version 1.12.1 of jquery-ui has security vulnerabilities so we need to take some action. We could bump it but on review of the typescript template this has now been removed [2]. This suggests it’s no longer needed so we take the approach of removing it instead
- As I understand it jquery-ui is a superset of jquery
- The MOJ Frontend (which itself builds on the GOV.UK Frontend) requires jquery to be provisioned by the consumer[1] (us). It does not mention jquery-ui explicitly

[1] https://github.com/ministryofjustice/moj-frontend/blob/main/package/package.json#L34
[2] https://github.com/ministryofjustice/hmpps-template-typescript/commit/14f2b43344ae2ee771e7c70c508b744a89e51605

## Screenshots of UI changes

### Before

![Screenshot 2024-02-26 at 15-52-30 Home - Short-Term Accommodation (CAS-2)](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/4fa536f5-a0c3-42f7-9e95-1a94526c7547)


### After

![Screenshot 2024-02-26 at 16-13-29 Home - Short-Term Accommodation (CAS-2)](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/537ce55f-d1c0-4328-89ff-b852fa7b7253)

(If I recall, jquery is used to help attach error messages to the right element so is a test of sorts)

![Screenshot 2024-02-26 at 16-14-38 Short-Term Accommodation (CAS-2) - Enter the person's prison number](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/912473/5420caea-fa4a-45c4-8ae1-249a391173e8)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
