### PR TITLE
Extend E2E tests to check notes added appear on application timeline

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker/locale/en_GB'
 
 import { BeforeYouStartPage, DashboardPage, FindByPrisonNumberPage, TaskListPage } from '../pages/apply'
 import {
@@ -97,7 +98,9 @@ export const viewSubmittedApplication = async (page: Page, name: string) => {
 }
 
 export const addNote = async (page: Page) => {
-  await page.getByLabel('Add a note for the assessor ', { exact: true }).fill('some notes for the assessor')
+  const note = faker.lorem.paragraph()
+  await page.getByLabel('Add a note for the assessor', { exact: true }).fill(note)
   await page.getByTestId('submit-button').click()
   await expect(page.locator('h2').first()).toContainText('Success')
+  await expect(page.locator('.moj-timeline__description').first()).toContainText(note)
 }

--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker/locale/en_GB'
 
 export const updateStatus = async (page: Page) => {
   await page.getByRole('button', { name: 'Update application status' }).click()
@@ -28,7 +29,9 @@ export const signInAsAssessor = async (
 }
 
 export const addNote = async (page: Page) => {
-  await page.getByLabel('Add a note for the referrer ', { exact: true }).fill('some notes for the referrer')
+  const note = faker.lorem.paragraph()
+  await page.getByLabel('Add a note for the referrer', { exact: true }).fill(note)
   await page.getByTestId('submit-button').click()
   await expect(page.locator('h2').first()).toContainText('Success')
+  await expect(page.locator('.moj-timeline__description').first()).toContainText(note)
 }


### PR DESCRIPTION
Because of the way the tests are written, we will likely end up adding notes to the same applications multiple times through the E2E tests. So, we have a double safeguard of checking that the note we have added is first in the list, and also that it is unique.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-231

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
