### PR TITLE
Remove "Back to task list" link from HDC dates page

### DIFF
--- a/server/views/applications/pages/hdc-licence-dates/hdc-licence-dates.njk
+++ b/server/views/applications/pages/hdc-licence-dates/hdc-licence-dates.njk
@@ -41,3 +41,9 @@
       fetchContext()) 
   }}
 {% endblock %}
+
+{% block button %}
+  {{ govukButton({
+      text: "Save and continue"
+    }) }}
+{% endblock %}


### PR DESCRIPTION
# Context

Now that this page is part of the pre task list flow, it should not have a back to task list link.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
