### PR TITLE
Document our approach to removing old answers on the application

### DIFF
--- a/doc/how-to/removing_old_answers_on_an_application.md
+++ b/doc/how-to/removing_old_answers_on_an_application.md
@@ -1,0 +1,42 @@
+
+# Removing old answers on an Application
+
+- The application form is built using the inherited [task list
+system](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/main/doc/task_list_system.md)
+- [Matrix for making changes to the questions of an application form](<https://docs.google.com/spreadsheets/d/1gI-iPUCUrPRm7xPWyodWG1WnMZCC3-h3Fc6T6VtEeWU/edit?pli=1#gid=0>)
+
+## Removing old answers
+
+When a user answers a question in such a way that presents them with additional
+sub-questions:
+
+```
+Do you have a primary address?
+- [X] Yes
+  - Sub-question: How long have you lived here?:
+  - Sub-answer: '1 year'
+- [ ] No
+```
+
+When the user answers those sub-questions and continues they will be saved inside
+the `application`'s `data` blob as normal.
+
+**Should the user come back to this question and wish to change the parent answer, we
+need to take extra steps to make sure any sub-answers are removed from the `data` blob
+so that they aren't presented back**:
+
+```
+Do you have a primary address?
+- [ ] Yes
+  - Sub-question: How long have you lived here?:
+  - Sub-answer: '1 year'
+- [X] No
+```
+
+We do this in two ways:
+
+1. We extend the `onSave` method on each question page
+   ([example](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/b92daed3d1298cb014cd53db8e35ef60b8a4c792/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts#L90))
+   to remove the old data
+1. If the change in answer needs to change data in other questions we can extend [our 'delete
+   orphaned' logic here](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/main/server/utils/applications/deleteOrphanedData.ts)


### PR DESCRIPTION
This came up today as we discussed implementing another type of this change. We don't have a good way to automate this so it requires a human to remember which risks it being forgotten.

- We could write this in a checklist but it probably doesn't happen enough so we'd likely not notice it on the rare occasion it would be relevant. A similar thing could happen with Jira card checklist
- We could try and automate this somehow by redesigning how the question framework so it requires us to be more explicit about the relationship around dependencies. Such that the adding of the question and it's sub-questions is expressed explicitly so it could be automatically torn down. We're not sure how this would work, it would likely require more time than the couple of months we have left


# Changes in this PR

- document the problem within the repo so we have a easy thing to link to and improve the probability that a new developer reads through when joining

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
