### PR TITLE
Fix RoSH OASys import date bug

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -109,7 +109,7 @@ describe('Summary', () => {
 
     const expectedResponse = {
       'OASys created': '30 January 2023',
-      'OASys completed': 'Unknown',
+      'OASys completed': '31 January 2023',
       'OASys imported': '15 September 2023',
       'Overall risk rating': roshSummaryData.value.overallRisk,
       'Risk to children': roshSummaryData.value.riskToChildren,

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -82,7 +82,7 @@ export default class Summary implements TaskListPage {
       const oasysData = this.application.data['risk-of-serious-harm']['summary-data']
       response = {
         'OASys created': DateFormats.isoDateToUIDate(oasysData.oasysStartedDate, { format: 'medium' }),
-        'OASys completed': oasysData.dateCompleted
+        'OASys completed': oasysData.oasysCompletedDate
           ? DateFormats.isoDateToUIDate(oasysData.oasysCompletedDate, { format: 'medium' })
           : 'Unknown',
         'OASys imported': DateFormats.dateObjtoUIDate(oasysData.oasysImportedDate, { format: 'medium' }),


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=CAS2-319

# Changes in this PR

Fixes a bug which meant that the 'OASys completed' date wasn't rendering for RoSH data.

## Screenshots of UI changes

### Before

![Screenshot 2024-03-07 at 14 22 31](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/1e10106d-dd28-4201-8c6a-e23d5fda032e)

### After

![Screenshot 2024-03-07 at 14 22 17](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/74c6aaf7-fa22-4776-bc01-8b41b4e3f6e2)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
