### PR TITLE
Update eligibility to remove reference to not serviing a sentence 4 y…

### DIFF
--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -11,9 +11,6 @@
         be 18 years old or older
       </li>
       <li>
-        not be currently serving a sentence of 4 years or more for any offence
-      </li>
-      <li>
         not be currently charged with, or have any past convictions of cautions, or current allegations of any sexual offences in Schedule 3 of the Sexual Offences Act 2003
       </li>
       <li>


### PR DESCRIPTION
…ears or more

As per Suzie's request:

It’s the second bullet point in the eligibility criteria that needs to be removed.

Not currently be serving a sentence of 4 years or more

# Context

Jira - https://dsdmoj.atlassian.net/browse/CAS2-264
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [x] Are any changes required to the e2e tests?
- [x] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [x] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [x] Are there any data migrations required. Automatic or manual?
- [x] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
