### PR TITLE
(308) Apply correct formatting for application notes

### DIFF
--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from '@approved-premises/api'
 import { getSections } from '../checkYourAnswersUtils'
 import { stringToKebabCase, formatCommaToLinebreak } from '../utils'
+import { formatLines } from '../viewUtils'
 import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
@@ -65,7 +66,7 @@ export const getTimelineEvents = (timelineEvents: Array<Cas2TimelineEvent>): Arr
         const description =
           sortedTimelineEvents.type === 'cas2_status_update' && sortedTimelineEvents.body
             ? formatCommaToLinebreak(sortedTimelineEvents.body)
-            : sortedTimelineEvents.body
+            : formatLines(sortedTimelineEvents.body)
 
         return {
           label: { text: sortedTimelineEvents.label },


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CAS2-308?atlOrigin=eyJpIjoiZTU1NDRkZWU4ZjlkNDA5YWE3YmY2MGQ0Mzg0MDJiYzUiLCJwIjoiaiJ9)

# Context
We want application notes that contain linebreaks to preserve this formatting.

## Screenshots of UI changes

### Before
![Screenshot 2024-03-12 at 17 04 47](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/846da645-1a6e-44d4-9b7b-9c8078ec9a64)

### After
![Screenshot 2024-03-12 at 17 03 41](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/6377078/4780291a-d562-494e-999f-963417a11cab)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
