### PR TITLE
Remove NOTES_DISABLED feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ COMMUNITY_ACCOMMODATION_API_SERVICE_NAME=approved-premises
 ENVIRONMENT=local
 APPROVED_PREMISES_ROOT_PATH=approved-premises
 IN_MAINTENANCE_MODE=false
-NOTES_DISABLED=false
 
 # E2E tests
 # Allow tests to be run locally against the real dev environment

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,6 @@ generic-service:
     AUDIT_LOG_ERRORS: 'true'
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    NOTES_DISABLED: 'false'
 
   namespace_secrets:
     hmpps-community-accommodation-tier-2-ui:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,7 +17,6 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
-    NOTES_DISABLED: 'false'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,7 +17,6 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
-    NOTES_DISABLED: 'false'
 
   namespace_secrets:
     hmpps-community-accommodation-tier-2-ui:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -18,7 +18,6 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    NOTES_DISABLED: 'false'
 
   allowlist: null
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -100,7 +100,6 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   flags: {
-    notesDisabled: get('NOTES_DISABLED', 'false'),
     maintenanceMode: get('IN_MAINTENANCE_MODE', false),
   },
   analytics: {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -128,8 +128,7 @@ describe('applicationsController', () => {
       submittedAt: '2024-02-05',
     })
 
-    it('renders the overview page with the feature flag set to false', async () => {
-      config.flags.notesDisabled = 'false'
+    it('renders the overview page', async () => {
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
@@ -140,28 +139,6 @@ describe('applicationsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('applications/overview', {
-        notesDisabled: 'false',
-        application: submittedApplication,
-        status: 'Received',
-        pageHeading: 'Overview of application',
-        errors: {},
-        errorSummary: [],
-      })
-    })
-
-    it('renders the overview page with the feature flag set to true', async () => {
-      config.flags.notesDisabled = 'true'
-      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
-        return { errors: {}, errorSummary: [], userInput: {} }
-      })
-
-      applicationService.findApplication.mockResolvedValue(submittedApplication)
-
-      const requestHandler = applicationsController.overview()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('applications/overview', {
-        notesDisabled: 'true',
         application: submittedApplication,
         status: 'Received',
         pageHeading: 'Overview of application',

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -14,7 +14,6 @@ import paths from '../../paths/apply'
 import { getPage } from '../../utils/applications/getPage'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
 import { buildDocument } from '../../utils/applications/documentUtils'
-import config from '../../config'
 
 export default class ApplicationsController {
   constructor(
@@ -65,7 +64,6 @@ export default class ApplicationsController {
       const status = application.statusUpdates?.length ? application.statusUpdates[0].label : 'Received'
 
       return res.render('applications/overview', {
-        notesDisabled: config.flags.notesDisabled,
         application,
         status,
         errors,

--- a/server/controllers/assess/submittedApplicationsController.test.ts
+++ b/server/controllers/assess/submittedApplicationsController.test.ts
@@ -115,8 +115,6 @@ describe('submittedApplicationsController', () => {
       it('renders the submitted application overview template', async () => {
         submittedApplicationService.findApplication.mockResolvedValue(submittedApplication)
 
-        config.flags.notesDisabled = 'false'
-
         const requestHandler = submittedApplicationsController.overview()
         await requestHandler(request, response, next)
 
@@ -125,7 +123,6 @@ describe('submittedApplicationsController', () => {
         )
 
         expect(response.render).toHaveBeenCalledWith('assess/applications/overview', {
-          notesDisabled: 'false',
           application: submittedApplication,
           status: statusUpdate.label,
           errors: {},
@@ -145,8 +142,6 @@ describe('submittedApplicationsController', () => {
         })
         submittedApplicationService.findApplication.mockResolvedValue(submittedApplicationWithoutStatus)
 
-        config.flags.notesDisabled = 'true'
-
         const requestHandler = submittedApplicationsController.overview()
         await requestHandler(request, response, next)
 
@@ -155,7 +150,6 @@ describe('submittedApplicationsController', () => {
         )
 
         expect(response.render).toHaveBeenCalledWith('assess/applications/overview', {
-          notesDisabled: 'true',
           application: submittedApplicationWithoutStatus,
           status: 'Received',
           errors: {},

--- a/server/controllers/assess/submittedApplicationsController.ts
+++ b/server/controllers/assess/submittedApplicationsController.ts
@@ -3,7 +3,6 @@ import { FullPerson } from '@approved-premises/api'
 import SubmittedApplicationService from '../../services/submittedApplicationService'
 import assessPaths from '../../paths/assess'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
-import config from '../../config'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import { assessmentHasExistingData } from '../../utils/assessmentUtils'
 
@@ -47,7 +46,6 @@ export default class SubmittedApplicationsController {
       const status = application.statusUpdates.length ? application.statusUpdates[0].label : 'Received'
 
       return res.render('assess/applications/overview', {
-        notesDisabled: config.flags.notesDisabled,
         application,
         status,
         errors,

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -121,7 +121,6 @@ describe('utils', () => {
     })
 
     describe('when there are timeline events', () => {
-      config.flags.notesDisabled = 'false'
       it('returns them in the timeline events', () => {
         const application = submittedApplicationFactory.build({
           timelineEvents: [
@@ -242,28 +241,6 @@ describe('utils', () => {
             'the status description<br>and another<br>and another',
           )
         })
-      })
-    })
-
-    describe('when the feature flag is disabled', () => {
-      it('does not include events with the type "cas2_note"', () => {
-        config.flags.notesDisabled = 'true'
-
-        const application = submittedApplicationFactory.build({
-          timelineEvents: [
-            timelineEventsFactory.build({
-              type: 'cas2_status_update',
-              label: 'cas2_status_update',
-            }),
-            timelineEventsFactory.build({
-              type: 'cas2_note',
-              label: 'cas2_note',
-            }),
-          ],
-        })
-
-        expect(getApplicationTimelineEvents(application).length).toEqual(1)
-        expect(getApplicationTimelineEvents(application)[0].label.text).toEqual('cas2_status_update')
       })
     })
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -12,7 +12,6 @@ import { formatLines } from '../viewUtils'
 import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
-import config from '../../config'
 import { fetchErrorsAndUserInput } from '../validation'
 import { TaskListService } from '../../services'
 
@@ -88,14 +87,7 @@ export const getTimelineEvents = (timelineEvents: Array<Cas2TimelineEvent>): Arr
 
 export const getApplicationTimelineEvents = (
   application: Cas2Application | Cas2SubmittedApplication,
-): Array<UiTimelineEvent> => {
-  const timelineEvents =
-    config.flags.notesDisabled === 'false'
-      ? application.timelineEvents
-      : application.timelineEvents.filter(event => event.type !== 'cas2_note')
-
-  return [...getTimelineEvents(timelineEvents)]
-}
+): Array<UiTimelineEvent> => getTimelineEvents(application.timelineEvents)
 
 export const generateSuccessMessage = (pageName: string): string => {
   switch (pageName) {

--- a/server/views/applications/overview.njk
+++ b/server/views/applications/overview.njk
@@ -54,12 +54,10 @@
         Application history
       </h2>
 
-      {% if notesDisabled == 'false' %}
+      <form action="{{ paths.applications.addNote({ id: application.id }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        <form action="{{ paths.applications.addNote({ id: application.id }) }}" method="post">
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-          {{ govukTextarea({
+        {{ govukTextarea({
         name: "note",
         id: "note",
         label: {
@@ -72,13 +70,11 @@
         errorMessage: errors.note
       }) }}
 
-          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-testid="submit-button">
+        <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-testid="submit-button">
           Submit
         </button>
 
-        </form>
-
-      {% endif %}
+      </form>
 
       {{ timeline(getApplicationTimelineEvents(application)) }}
     </div>

--- a/server/views/assess/applications/overview.njk
+++ b/server/views/assess/applications/overview.njk
@@ -112,12 +112,10 @@ printButtonScript %}
         Application history
       </h2>
 
-      {% if notesDisabled == 'false' %}
+      <form action="{{ paths.submittedApplications.addNote({ id: application.id }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        <form action="{{ paths.submittedApplications.addNote({ id: application.id }) }}" method="post">
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-          {{ govukTextarea({
+        {{ govukTextarea({
         name: "note",
         id: "note",
         label: {
@@ -130,13 +128,11 @@ printButtonScript %}
         errorMessage: errors.note
       }) }}
 
-          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-testid="submit-button">
+        <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-testid="submit-button">
           Submit
         </button>
 
-        </form>
-
-      {% endif %}
+      </form>
 
       {{ timeline(getApplicationTimelineEvents(application)) }}
     </div>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-322

The NOTES_DISABLED flag was put in in order to
incrementally release the Notes/Further Info work.
As we have now released the feature to production,
and we do not plan to hide it again, we can remove
this feature flag.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
