### PR TITLE
(CAS2-290) Validate the referer header used in backlinks and redirects

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -9,3 +9,4 @@ SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
 APPROVED_PREMISES_API_URL=http://localhost:9999
 REDIS_PORT=6380
+INGRESS_URL=http://localhost:3007

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -24,12 +24,14 @@ import paths from '../../paths/apply'
 import { buildDocument } from '../../utils/applications/documentUtils'
 import config from '../../config'
 import { showMissingRequiredTasksOrTaskList, generateSuccessMessage } from '../../utils/applications/utils'
+import { validateReferer } from '../../utils/viewUtils'
 
 jest.mock('../../utils/validation')
 jest.mock('../../services/taskListService')
 jest.mock('../../utils/applications/getPage')
 jest.mock('../../utils/applications/documentUtils')
 jest.mock('../../utils/applications/utils')
+jest.mock('../../utils/viewUtils')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -62,7 +64,7 @@ describe('applicationsController', () => {
     request = createMock<Request>({
       user: { token },
       headers: {
-        referer: 'some-referrer/',
+        referer: 'some-referer/',
       },
     })
     response = createMock<Response>({})
@@ -195,6 +197,7 @@ describe('applicationsController', () => {
 
   describe('consentRefused', () => {
     it('renders the consent refused page', async () => {
+      ;(validateReferer as jest.MockedFunction<typeof validateReferer>).mockReturnValue('some-validated-referer')
       const application = applicationFactory.build({
         person: personFactory.build({ name: 'Roger Smith' }),
       })
@@ -217,8 +220,9 @@ describe('applicationsController', () => {
         panelText,
         changeAnswerPath,
         newApplicationPath,
-        backLink: 'some-referrer/',
+        backLink: 'some-validated-referer',
       })
+      expect(validateReferer).toHaveBeenCalledWith('some-referer/')
     })
   })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -14,6 +14,7 @@ import paths from '../../paths/apply'
 import { getPage } from '../../utils/applications/getPage'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
 import { buildDocument } from '../../utils/applications/documentUtils'
+import { validateReferer } from '../../utils/viewUtils'
 
 export default class ApplicationsController {
   constructor(
@@ -114,7 +115,7 @@ export default class ApplicationsController {
       page: 'confirm-consent',
     })
     const newApplicationPath = paths.applications.new({})
-    const backLink = req.headers.referer
+    const backLink = validateReferer(req.headers.referer)
     return { application, panelText, changeAnswerPath, newApplicationPath, backLink }
   }
 

--- a/server/controllers/assess/statusUpdateController.test.ts
+++ b/server/controllers/assess/statusUpdateController.test.ts
@@ -8,8 +8,10 @@ import { SubmittedApplicationService } from '../../services'
 import paths from '../../paths/assess'
 import applicationStatuses from '../../../wiremock/stubs/application-statuses.json'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import { validateReferer } from '../../utils/viewUtils'
 
 jest.mock('../../utils/validation')
+jest.mock('../../utils/viewUtils')
 
 describe('statusUpdateController', () => {
   const token = 'SOME_TOKEN'
@@ -32,10 +34,14 @@ describe('statusUpdateController', () => {
   })
 
   describe('new', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
     it('renders the status update _new_ template', async () => {
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
+      ;(validateReferer as jest.MockedFunction<typeof validateReferer>).mockReturnValue('some-validated-referer')
 
       submittedApplicationService.findApplication.mockResolvedValue(submittedApplication)
       submittedApplicationService.getApplicationStatuses.mockResolvedValue(applicationStatuses)
@@ -58,7 +64,7 @@ describe('statusUpdateController', () => {
         errors: {},
         pageHeading: 'What is the latest status of the application?',
         questionText: `What is the latest status of ${person.name}'s application?`,
-        previousPath: 'referer',
+        previousPath: 'some-validated-referer',
       })
     })
 
@@ -98,6 +104,7 @@ describe('statusUpdateController', () => {
           questionText: `What is the latest status of ${person.name}'s application?`,
           previousPath: paths.submittedApplications.overview({ id: submittedApplication.id }),
         })
+        expect(validateReferer).not.toHaveBeenCalled()
       })
     })
   })

--- a/server/controllers/assess/statusUpdateController.ts
+++ b/server/controllers/assess/statusUpdateController.ts
@@ -4,6 +4,7 @@ import SubmittedApplicationService from '../../services/submittedApplicationServ
 import paths from '../../paths/assess'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import { camelToKebabCase } from '../../utils/utils'
+import { validateReferer } from '../../utils/viewUtils'
 
 export default class StatusUpdateController {
   constructor(private readonly submittedApplicationService: SubmittedApplicationService) {}
@@ -39,7 +40,7 @@ export default class StatusUpdateController {
       return paths.submittedApplications.overview({ id: application.id })
     }
 
-    return referer
+    return validateReferer(referer)
   }
 
   create(): RequestHandler {

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -4,6 +4,7 @@ import { errorMessage, errorSummary } from '../utils/validation'
 import PersonService from '../services/personService'
 import ApplicationService from '../services/applicationService'
 import { DateFormats } from '../utils/dateUtils'
+import { validateReferer } from '../utils/viewUtils'
 
 export default class PeopleController {
   constructor(
@@ -40,11 +41,11 @@ export default class PeopleController {
             throw err
           }
 
-          return res.redirect(req.headers.referer)
+          return res.redirect(validateReferer(req.headers.referer))
         }
       } else {
         this.addErrorMessagesToFlash(req, 'Enter a prison number')
-        return res.redirect(req.headers.referer)
+        return res.redirect(validateReferer(req.headers.referer))
       }
     }
   }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -15,10 +15,12 @@ import { getSections } from '../checkYourAnswersUtils'
 import config from '../../config'
 import paths from '../../paths/apply'
 import { TaskListService } from '../../services'
+import { formatLines, validateReferer } from '../viewUtils'
 
 jest.mock('../../services/taskListService')
 jest.mock('../checkYourAnswersUtils')
 jest.mock('../../utils/validation')
+jest.mock('../../utils/viewUtils')
 
 const mockSections = [
   {
@@ -139,6 +141,11 @@ describe('utils', () => {
             }),
           ],
         })
+
+        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockReturnValue(
+          'The application was received by an assessor.',
+        )
+
         expect(getApplicationTimelineEvents(application)).toEqual([
           {
             byline: {
@@ -390,6 +397,7 @@ describe('utils', () => {
         ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
           return { errors: {}, errorSummary: [], userInput: {} }
         })
+        ;(validateReferer as jest.MockedFunction<typeof validateReferer>).mockReturnValue('some-validated-referer')
 
         const actual = showMissingRequiredTasksOrTaskList(request, response, application)
 
@@ -399,7 +407,7 @@ describe('utils', () => {
             taskList: stubTaskList,
             errors: {},
             errorSummary: [],
-            referrer: 'some-referrer/',
+            referrer: 'some-validated-referer',
           }),
         )
       })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -132,9 +132,9 @@ export const showMissingRequiredTasksOrTaskList = (req: Request, res: Response, 
       if (hdcDatesHaveBeenEntered(application)) {
         const { errors, errorSummary } = fetchErrorsAndUserInput(req)
 
-        const referrer = validateReferer(req.headers.referer)
+        const referer = validateReferer(req.headers.referer)
         const taskList = new TaskListService(application)
-        return res.render('applications/taskList', { application, taskList, errors, errorSummary, referrer })
+        return res.render('applications/taskList', { application, taskList, errors, errorSummary, referer })
       }
       return res.redirect(
         paths.applications.pages.show({

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -8,7 +8,7 @@ import type {
 } from '@approved-premises/api'
 import { getSections } from '../checkYourAnswersUtils'
 import { stringToKebabCase, formatCommaToLinebreak } from '../utils'
-import { formatLines } from '../viewUtils'
+import { formatLines, validateReferer } from '../viewUtils'
 import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
@@ -132,7 +132,7 @@ export const showMissingRequiredTasksOrTaskList = (req: Request, res: Response, 
       if (hdcDatesHaveBeenEntered(application)) {
         const { errors, errorSummary } = fetchErrorsAndUserInput(req)
 
-        const referrer = req.headers.referer
+        const referrer = validateReferer(req.headers.referer)
         const taskList = new TaskListService(application)
         return res.render('applications/taskList', { application, taskList, errors, errorSummary, referrer })
       }

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -11,6 +11,9 @@ import {
 } from './validation'
 import { TaskListAPIError, ValidationError } from './errors'
 import errorLookups from '../i18n/en/errors.json'
+import { validateReferer } from './viewUtils'
+
+jest.mock('./viewUtils')
 
 jest.mock('../i18n/en/errors.json', () => {
   return {
@@ -148,6 +151,7 @@ describe('catchAPIErrorOrPropogate', () => {
 
   it('populates the error and redirects to the previous page if the API finds an error', () => {
     const error = new TaskListAPIError('some message', 'field')
+    ;(validateReferer as jest.MockedFunction<typeof validateReferer>).mockReturnValue('some-validated-referer')
 
     catchAPIErrorOrPropogate(request, response, error)
 
@@ -161,7 +165,8 @@ describe('catchAPIErrorOrPropogate', () => {
       },
     ])
 
-    expect(response.redirect).toHaveBeenCalledWith(request.headers.referer)
+    expect(validateReferer).toHaveBeenCalledWith(request.headers.referer)
+    expect(response.redirect).toHaveBeenCalledWith('some-validated-referer')
   })
 
   it('throws the error if not of type TaskListAPIError', () => {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -5,6 +5,7 @@ import type { ErrorMessage, ErrorMessages, ErrorSummary, ErrorsAndUserInput } fr
 import { SanitisedError } from '../sanitisedError'
 import errorLookup from '../i18n/en/errors.json'
 import { TaskListAPIError, ValidationError } from './errors'
+import { validateReferer } from './viewUtils'
 
 interface InvalidParams {
   propertyName: string
@@ -32,7 +33,7 @@ export const catchAPIErrorOrPropogate = (request: Request, response: Response, e
     })
     request.flash('errorSummary', [errorSummary(error.field, error.message)])
 
-    response.redirect(request.headers.referer)
+    response.redirect(validateReferer(request.headers.referer))
   } else {
     throw error
   }

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -1,7 +1,11 @@
 import * as viewUtilsModule from './viewUtils'
 import * as formUtilsModule from './formUtils'
 
-const { formatLines } = viewUtilsModule
+const { formatLines, validateReferer } = viewUtilsModule
+
+jest.mock('../config', () => ({
+  domain: 'https://test-domain.com',
+}))
 
 describe('formatLines', () => {
   let escapeSpy: jest.SpyInstance<string, [text: string]>
@@ -39,5 +43,25 @@ describe('formatLines', () => {
 
   it('returns the empty string when given null', () => {
     expect(formatLines(null)).toEqual('')
+  })
+})
+
+describe('validateReferer', () => {
+  describe('when the referer is from our own domain', () => {
+    it('returns the referer path', () => {
+      expect(validateReferer('https://test-domain.com/some-referer')).toEqual('https://test-domain.com/some-referer')
+    })
+  })
+
+  describe('when the referer is from outside our domain', () => {
+    it('returns the root path', () => {
+      expect(validateReferer('https://example.com/some-external-referer')).toEqual('/')
+    })
+  })
+
+  describe('when the referer is undefined, for any reason', () => {
+    it('returns the root path', () => {
+      expect(validateReferer(undefined)).toEqual('/')
+    })
   })
 })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -1,3 +1,4 @@
+import config from '../config'
 import { escape } from './formUtils'
 
 export const formatLines = (text: string): string => {
@@ -18,6 +19,14 @@ export const formatLines = (text: string): string => {
     return paragraphs[0]
   }
   return `<p>${paragraphs.join('</p><p>')}</p>`
+}
+
+export const validateReferer = (referer?: string): string => {
+  if (!referer || !referer.startsWith(config.domain)) {
+    return '/'
+  }
+
+  return referer
 }
 
 function normalizeText(text: string): string {

--- a/server/views/applications/taskList.njk
+++ b/server/views/applications/taskList.njk
@@ -9,10 +9,10 @@
 {% endblock %}
 
 {% block beforeContent%}
-  {% if referrer %}
+  {% if referer %}
     {{ govukBackLink({
         text: "Back",
-        href: referrer
+        href: referer
     }) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
[Jira ticket 290](https://dsdmoj.atlassian.net/browse/CAS2-290)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

We're currently not validating the `referer` header, which theoretically allows for "Reflected XSS attacks", as a `referer` could be passed in the header of a GET request. Although this is currently blocked by our CSP settings, we've been recommended to fix this by the pen test report.

This introduces a `validateReferer` function that checks the `referer` comes from our own URL, read from the ingress in the config. We've opted to revert to the root URL (`/`) for the back link otherwise.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
