### PR TITLE
Use `personName`, `crn` and `nomsNumber` on assessments dashboard view

### DIFF
--- a/integration_tests/mockApis/submissions.ts
+++ b/integration_tests/mockApis/submissions.ts
@@ -1,6 +1,7 @@
 import type {
   Cas2SubmittedApplication as SubmittedApplication,
   Cas2ApplicationStatusUpdate as ApplicationStatusUpdate,
+  Cas2SubmittedApplicationSummary,
 } from '@approved-premises/api'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from '../../wiremock'
@@ -20,7 +21,7 @@ export default {
       },
     }),
   stubSubmittedApplicationsGet: (args: {
-    applications: Array<SubmittedApplication>
+    applications: Array<Cas2SubmittedApplicationSummary>
     page: number
   }): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/pages/submissions/submissionListPage.ts
+++ b/integration_tests/pages/submissions/submissionListPage.ts
@@ -1,7 +1,6 @@
 import Page from '../page'
 import paths from '../../../server/paths/assess'
-import { Cas2SubmittedApplication, FullPerson } from '../../../server/@types/shared'
-import { nameOrPlaceholderCopy } from '../../../server/utils/utils'
+import { Cas2SubmittedApplication, Cas2SubmittedApplicationSummary, FullPerson } from '../../../server/@types/shared'
 
 export default class SubmissionListPage extends Page {
   constructor(
@@ -19,13 +18,9 @@ export default class SubmissionListPage extends Page {
     return new SubmissionListPage(applications, person?.name)
   }
 
-  shouldShowSubmittedApplications(applications: Array<Cas2SubmittedApplication>): void {
-    this.shouldShowApplications(applications)
-  }
-
-  private shouldShowApplications(applications: Array<Cas2SubmittedApplication>): void {
+  shouldShowSubmittedApplications(applications: Array<Cas2SubmittedApplicationSummary>): void {
     applications.forEach(application => {
-      const personName = nameOrPlaceholderCopy(application.person)
+      const { personName } = application
       cy.contains(personName)
         .should('have.attr', 'href', paths.submittedApplications.overview({ id: application.id }))
         .parent()

--- a/integration_tests/tests/assess/view_all_submitted_applications.cy.ts
+++ b/integration_tests/tests/assess/view_all_submitted_applications.cy.ts
@@ -9,24 +9,22 @@
 //      Then I see a list of all submitted applications
 //
 import SubmissionListPage from '../../pages/submissions/submissionListPage'
-import { submittedApplicationFactory } from '../../../server/testutils/factories'
-import { fullPersonFactory } from '../../../server/testutils/factories/person'
+import submittedApplicationSummary from '../../../server/testutils/factories/submittedApplicationSummary'
 import Page from '../../pages/page'
 
 context('Submitted applications', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    cy.fixture('applicationDocument.json').then(applicationDocument => {
-      const submittedApplication = submittedApplicationFactory.build({
-        id: 'abc123',
-        document: applicationDocument,
-        submittedAt: '2022-12-10T21:47:28Z',
-        person: fullPersonFactory.build({ name: 'Robert Smith' }),
-      })
-      cy.wrap(submittedApplication).as('submittedApplication')
-      cy.task('stubSubmittedApplicationsGet', { applications: [submittedApplication], page: 1 })
+    const submittedApplication = submittedApplicationSummary.build({
+      id: 'abc123',
+      submittedAt: '2022-12-10T21:47:28Z',
+      personName: 'Robert Smith',
+      crn: 'CRN123',
+      nomsNumber: 'NOMS456',
     })
+    cy.wrap(submittedApplication).as('submittedApplication')
+    cy.task('stubSubmittedApplicationsGet', { applications: [submittedApplication], page: 1 })
   })
 
   //  Scenario: viewing the dashboard page as an admin

--- a/server/@types/shared/models/Cas2SubmittedApplicationSummary.ts
+++ b/server/@types/shared/models/Cas2SubmittedApplicationSummary.ts
@@ -7,6 +7,9 @@ export type Cas2SubmittedApplicationSummary = {
     id: string;
     createdByUserId: string;
     person: Person;
+    crn: string;
+    nomsNumber: string;
+    personName: string;
     createdAt: string;
     submittedAt?: string;
 };

--- a/server/testutils/factories/submittedApplicationSummary.ts
+++ b/server/testutils/factories/submittedApplicationSummary.ts
@@ -13,4 +13,7 @@ export default Factory.define<Cas2SubmittedApplicationSummary>(() => ({
   submittedAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   createdByUserId: faker.string.uuid(),
   status: 'submitted',
+  crn: faker.string.alphanumeric(5),
+  nomsNumber: faker.string.alphanumeric(5),
+  personName: faker.person.fullName(),
 }))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -4,8 +4,10 @@ import {
   documentSummaryListRows,
   inProgressApplicationTableRows,
   submittedApplicationTableRows,
+  assessmentsTableRows,
 } from './applicationUtils'
 import { fullPersonFactory } from '../testutils/factories/person'
+import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
 
 describe('inProgressApplicationTableRows', () => {
   it('returns an array of applications as table rows', async () => {
@@ -96,6 +98,52 @@ describe('submittedApplicationTableRows', () => {
         },
         {
           text: personB.crn,
+        },
+        {
+          text: '11 December 2022',
+        },
+      ],
+    ])
+  })
+})
+
+describe('assessmentsTableRows', () => {
+  it('returns an array of applications as table rows', async () => {
+    const applicationA = submittedApplicationSummary.build({
+      submittedAt: '2022-12-10T21:47:28Z',
+      personName: 'A',
+    })
+    const applicationB = submittedApplicationSummary.build({
+      submittedAt: '2022-12-11T21:47:28Z',
+      personName: 'B',
+    })
+
+    const result = assessmentsTableRows([applicationA, applicationB])
+
+    expect(result).toEqual([
+      [
+        {
+          html: `<a href=/assess/applications/${applicationA.id}/overview data-cy-id="${applicationA.id}">A</a>`,
+        },
+        {
+          text: applicationA.nomsNumber,
+        },
+        {
+          text: applicationA.crn,
+        },
+        {
+          text: '10 December 2022',
+        },
+      ],
+      [
+        {
+          html: `<a href=/assess/applications/${applicationB.id}/overview data-cy-id="${applicationB.id}">B</a>`,
+        },
+        {
+          text: applicationB.nomsNumber,
+        },
+        {
+          text: applicationB.crn,
         },
         {
           text: '11 December 2022',

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,4 +1,8 @@
-import type { Cas2Application as Application, FullPerson } from '@approved-premises/api'
+import type {
+  Cas2Application as Application,
+  Cas2SubmittedApplicationSummary,
+  FullPerson,
+} from '@approved-premises/api'
 import type { QuestionAndAnswer, TableRow } from '@approved-premises/ui'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
@@ -28,6 +32,17 @@ export const submittedApplicationTableRows = (
       nameAnchorElement(nameOrPlaceholderCopy(person), application.id, isAssessPath),
       textValue(person.nomsNumber),
       textValue(person.crn),
+      textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'medium' })),
+    ]
+  })
+}
+
+export const assessmentsTableRows = (applications: Array<Cas2SubmittedApplicationSummary>): Array<TableRow> => {
+  return applications.map(application => {
+    return [
+      nameAnchorElement(application.personName, application.id, true),
+      textValue(application.nomsNumber),
+      textValue(application.crn),
       textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'medium' })),
     ]
   })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,7 @@ import {
   documentSummaryListRows,
   inProgressApplicationTableRows,
   submittedApplicationTableRows,
+  assessmentsTableRows,
 } from './applicationUtils'
 import {
   getApplicationTimelineEvents,
@@ -84,6 +85,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('inProgressApplicationTableRows', inProgressApplicationTableRows)
   njkEnv.addGlobal('submittedApplicationTableRows', submittedApplicationTableRows)
+  njkEnv.addGlobal('assessmentsTableRows', assessmentsTableRows)
   njkEnv.addGlobal('documentSummaryListRows', documentSummaryListRows)
 
   const {

--- a/server/views/assess/applications/index.njk
+++ b/server/views/assess/applications/index.njk
@@ -39,13 +39,13 @@
                 text: "Date submitted"
               }
             ],
-            submittedApplicationTableRows(applications, true)
+            assessmentsTableRows(applications)
           )
 
       }}
       </div>
 
-    {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
     </div>
   </div>


### PR DESCRIPTION
# Context

DO NOT MERGE UNTIL THIS API PR MERGED: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1621, and the first commit pointing to the types branch is deleted.

See above PR for context of this work - TLDR, reading person data on the top level fields of an Application to avoid extra integration API calls.

# Changes in this PR

This changes how we construct the table on the assessors dashboard at `assess/applications`
![Screenshot 2024-03-18 at 16 17 27](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/327f2b9f-08ff-4c98-996f-da7deac7de99)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
