### PR TITLE
CAS2-392: add e2e test for viewing application within user's prison

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -97,10 +97,17 @@ export const viewSubmittedApplication = async (page: Page, name: string) => {
   await expect(page.locator('h2').first()).toContainText('Application history')
 }
 
+export const viewSubmittedApplicationOverview = async (applicationId: string, page: Page, name: string) => {
+  await page.goto(`/applications/${applicationId}/overview`)
+  await expect(page.locator('h1')).toContainText(name)
+  await expect(page.locator('h2').first()).toContainText('Application history')
+}
+
 export const addNote = async (page: Page) => {
   const note = faker.lorem.paragraph()
   await page.getByLabel('Add a note for the assessor', { exact: true }).fill(note)
   await page.getByTestId('submit-button').click()
   await expect(page.locator('h2').first()).toContainText('Success')
   await expect(page.locator('.moj-timeline__description').first()).toContainText(note)
+  await expect(page.locator('.moj-timeline__title').first()).toContainText('Note')
 }

--- a/e2e-tests/tests/01_apply.spec.ts
+++ b/e2e-tests/tests/01_apply.spec.ts
@@ -13,6 +13,7 @@ import {
   submitApplication,
   viewSubmittedApplication,
   addNote,
+  viewSubmittedApplicationOverview,
 } from '../steps/apply'
 
 test('create a CAS-2 application', async ({ page, person }) => {
@@ -32,5 +33,11 @@ test('create a CAS-2 application', async ({ page, person }) => {
 test('add a note to a submitted application', async ({ page, person }) => {
   await viewSubmittedApplication(page, person.name)
   await addNote(page)
-  await expect(page.locator('.moj-timeline__title').first()).toContainText('Note')
+})
+
+test(`add a note to a submitted application created by another user within user's prison`, async ({ page, person }) => {
+  const { name } = person
+  const SEEDED_APPLICATION_ID = 'edd787eb-31a3-4fad-a473-9cf8969f1487'
+  await viewSubmittedApplicationOverview(SEEDED_APPLICATION_ID, page, name)
+  await addNote(page)
 })


### PR DESCRIPTION
This [depends on work in the API to introduce](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1735) permissions for users to view any submitted applications within their own prison. 

We are using a hardcoded seeded UUID for the application, but we will shortly be expanding the test to start from viewing a 'prison dashboard', from which the user will click through to the application.

I think currently this step still sits within a referrer's 'apply' journey so I haven't created a new spec for it, but I think 
as the dashboard requirements grow it may make sense to split out. 


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
