### PR TITLE
Change ‘offence category’ text to ‘offence type’

### DIFF
--- a/e2e-tests/steps/offenceAndLicenceInformationSection.ts
+++ b/e2e-tests/steps/offenceAndLicenceInformationSection.ts
@@ -12,7 +12,7 @@ export const completeCurrentOffencesTask = async (page: Page, name: string) => {
 async function completeCurrentOffenceDetailsPage(page: Page, name: string) {
   const currentOffenceDetailsPage = await ApplyPage.initialize(page, `Add ${name}'s current offence details`)
   await currentOffenceDetailsPage.fillField('Offence title', 'Stalking')
-  await currentOffenceDetailsPage.chooseSelectItem('Offence category', 'Stalking or Harassment')
+  await currentOffenceDetailsPage.chooseSelectItem('Offence type', 'Stalking or Harassment')
   await currentOffenceDetailsPage.fillDateFieldInGroup('When did they commit the offence?', {
     year: '2022',
     month: '3',

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.test.ts
@@ -41,7 +41,7 @@ describe('CurrentOffenceData', () => {
     describe('when there are errors', () => {
       const requiredFields = [
         ['titleAndNumber', 'Enter the offence title'],
-        ['offenceCategory', 'Select the offence category'],
+        ['offenceCategory', 'Select the offence type'],
         ['offenceDate', 'Enter the date the offence was committed'],
         ['sentenceLength', 'Enter the sentence length'],
         ['summary', 'Enter a summary of the offence'],

--- a/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
+++ b/server/form-pages/apply/offence-and-licence-information/current-offences/custom-forms/currentOffenceData.ts
@@ -65,7 +65,7 @@ export default class CurrentOffenceData implements TaskListPage {
     const items = [
       {
         value: 'choose',
-        text: 'Choose category',
+        text: 'Choose type',
         selected: selectedItem === '',
       },
     ]
@@ -95,7 +95,7 @@ export default class CurrentOffenceData implements TaskListPage {
       errors.titleAndNumber = 'Enter the offence title'
     }
     if (this.body.offenceCategory === 'choose') {
-      errors.offenceCategory = 'Select the offence category'
+      errors.offenceCategory = 'Select the offence type'
     }
     if (!dateAndTimeInputsAreValidDates(this.body, 'offenceDate')) {
       errors.offenceDate = 'Enter the date the offence was committed'

--- a/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.ts
+++ b/server/form-pages/apply/offence-and-licence-information/offending-history/custom-forms/offenceHistoryData.ts
@@ -46,7 +46,7 @@ export default class OffenceHistoryData implements TaskListPage {
     const items = [
       {
         value: 'choose',
-        text: 'Choose category',
+        text: 'Choose type',
         selected: selectedItem === '',
       },
     ]

--- a/server/views/applications/pages/current-offences/current-offences.njk
+++ b/server/views/applications/pages/current-offences/current-offences.njk
@@ -43,7 +43,7 @@
           rows: [
             {
               key: {
-                text: 'Category:'
+                text: 'Type:'
               },
               value: {
                 html: offence.offenceCategoryTag


### PR DESCRIPTION
The discrepancy was causing E2E test failures, so I have corrected it in accordance with the up to date designs.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
