### PR TITLE
CAS2-405: Add skeleton prison dashboard tab behind feature flag

### DIFF
--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -28,6 +28,10 @@ export default class ListPage extends Page {
     this.shouldShowApplications(this.applications)
   }
 
+  shouldShowPrisonTab(): void {
+    cy.contains(`Your prison's applications`).should('have.attr', 'href', paths.applications.prison.pattern)
+  }
+
   clickApplication(application: Application) {
     cy.get(`a[data-cy-id="${application.id}"]`).click()
   }

--- a/integration_tests/pages/apply/prisonDashboard.ts
+++ b/integration_tests/pages/apply/prisonDashboard.ts
@@ -1,0 +1,18 @@
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+
+export default class PrisonDashboardPage extends Page {
+  constructor() {
+    super('Short-Term Accommodation (CAS-2) applications', undefined)
+  }
+
+  static visit(): PrisonDashboardPage {
+    cy.visit(paths.applications.prison.pattern)
+
+    return new PrisonDashboardPage()
+  }
+
+  shouldShowMyApplicationsTab(): void {
+    cy.contains(`Your applications`).should('have.attr', 'href', paths.applications.index.pattern)
+  }
+}

--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -1,16 +1,16 @@
 import Page, { PageElement } from './page'
 
-export default class DashboardPage extends Page {
+export default class HomePage extends Page {
   constructor() {
     const name = undefined
     super('CAS-2: Short-Term Accommodation', name)
     this.checkPhaseBanner()
   }
 
-  static visit(): DashboardPage {
+  static visit(): HomePage {
     cy.visit('/')
 
-    return new DashboardPage()
+    return new HomePage()
   }
 
   shouldShowSignOutButton(): void {

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -14,6 +14,10 @@
 //    And there are submitted applications in the database
 //    When I visit the Submitted Applications tab
 //    Then I should see all of my submitted applications
+//
+//  Scenario: see prison dashboad
+//    Given I am logged in
+//    Then I see a tab for my prison's applications
 
 import ListPage from '../../pages/apply/list'
 import { applicationSummaryFactory } from '../../../server/testutils/factories'
@@ -58,5 +62,19 @@ context('Applications dashboard', () => {
 
     // I should see all of the in progress applications
     page.shouldShowSubmittedApplications()
+  })
+
+  //
+  //  Scenario: see prison dashboad
+  it('shows prison dashboard tab', () => {
+    // There are applications in the database
+    const submittedApplications = applicationSummaryFactory.buildList(1, {
+      status: 'submitted',
+    })
+
+    cy.task('stubApplications', submittedApplications)
+    //    Then I see a tab for my prison's applications
+    const page = ListPage.visit(submittedApplications)
+    page.shouldShowPrisonTab()
   })
 })

--- a/integration_tests/tests/apply/prison_dashboard.cy.ts
+++ b/integration_tests/tests/apply/prison_dashboard.cy.ts
@@ -1,0 +1,24 @@
+//  Feature: user views prison dashboard
+//    So that I can see recent submitted applications
+//    for my Prison
+//    So that I can manage applications
+//
+//  Scenario: viewing the prison dashboard as a referrer
+//      Given I am logged in as a referrer
+//      When I visit the prison dashboard
+//      Then I can tab back to my applications
+import PrisonDashboardPage from '../../pages/apply/prisonDashboard'
+
+context('PrisonDashboard', () => {
+  //  Scenario: viewing the prison dashboard as a referrer
+  it('sees tab for my applications', () => {
+    // Given I am logged in as a referrer
+    cy.task('stubSignIn', ['ROLE_POM'])
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    //      When I visit the prison dashboard
+    const page = PrisonDashboardPage.visit()
+    page.shouldShowMyApplicationsTab()
+  })
+})

--- a/integration_tests/tests/home_page.cy.ts
+++ b/integration_tests/tests/home_page.cy.ts
@@ -44,7 +44,7 @@ context('Home', () => {
     const page = Page.verifyOnPage(HomePage)
 
     //  Then see the correct cards
-    page.shouldShowCards(['referrals', 'new-referral'])
+    page.shouldShowCards(['referrals', 'new-referral', 'prison-dashboard'])
 
     //  And I see the sign out button
     page.shouldShowSignOutButton()

--- a/integration_tests/tests/home_page.cy.ts
+++ b/integration_tests/tests/home_page.cy.ts
@@ -1,47 +1,47 @@
-//  Feature: user views dashboard page
+//  Feature: user views home page
 //    So that I can navigate to the parts of the service that I need
 //    As a user
-//    I want to view the correct cards on the dashboard page
+//    I want to view the correct cards on the home page
 //
-//  Scenario: viewing the dashboard page as a referrer
+//  Scenario: viewing the home page as a referrer
 //      Given I am logged in as a referrer
-//      When I visit the dashboard page
+//      When I visit the home page
 //      Then see the correct cards
 //      And I see the sign out button
 //
-//  Scenario: viewing the dashboard page as an admin
+//  Scenario: viewing the home page as an admin
 //      Given I am logged in as an admin
-//      When I visit the dashboard page
+//      When I visit the home page
 //      Then I see the correct cards
 //
-//  Scenario: viewing the dashboard page as an assessor
+//  Scenario: viewing the home page as an assessor
 //      Given I am logged in as an assessor
-//      When I visit the dashboard page
+//      When I visit the home page
 //      Then I see no cards
 //
-//  Scenario: viewing the dashboard page as an Management Info user
+//  Scenario: viewing the home page as an Management Info user
 //      Given I am logged in as an MI user
-//      When I visit the dashboard page
+//      When I visit the home page
 //      Then I see the management info report downloads card
 
-import DashboardPage from '../pages/dashboardPage'
+import HomePage from '../pages/homePage'
 import Page from '../pages/page'
 
-context('Dashboard', () => {
+context('Home', () => {
   beforeEach(() => {
     cy.task('reset')
   })
 
-  //  Scenario: viewing the dashboard page as a referrer
+  //  Scenario: viewing the home page as a referrer
   it('shows the referrer cards', () => {
     // Given I am logged in as a referrer
     cy.task('stubSignIn', ['ROLE_POM'])
     cy.task('stubAuthUser')
     cy.signIn()
 
-    //  When I visit the dashboard page
-    DashboardPage.visit()
-    const page = Page.verifyOnPage(DashboardPage)
+    //  When I visit the home page
+    HomePage.visit()
+    const page = Page.verifyOnPage(HomePage)
 
     //  Then see the correct cards
     page.shouldShowCards(['referrals', 'new-referral'])
@@ -50,46 +50,46 @@ context('Dashboard', () => {
     page.shouldShowSignOutButton()
   })
 
-  //  Scenario: viewing the dashboard page as an admin
+  //  Scenario: viewing the home page as an admin
   it('shows the admin cards', () => {
     // Given I am logged in as an admin
     cy.task('stubSignIn', ['ROLE_CAS2_ADMIN'])
     cy.task('stubAuthUser')
     cy.signIn()
 
-    //  When I visit the dashboard page
-    DashboardPage.visit()
-    const page = Page.verifyOnPage(DashboardPage)
+    //  When I visit the home page
+    HomePage.visit()
+    const page = Page.verifyOnPage(HomePage)
 
     //  Then see the correct cards
     page.shouldShowCards(['submitted-applications'])
   })
 
-  //  Scenario: viewing the dashboard page as an assessor
+  //  Scenario: viewing the home page as an assessor
   it('shows the assessor cards', () => {
     // Given I am logged in as an assessor
     cy.task('stubSignIn', ['ROLE_CAS2_ASSESSOR'])
     cy.task('stubAuthUser')
     cy.signIn()
 
-    //  When I visit the dashboard page
-    DashboardPage.visit()
-    const page = Page.verifyOnPage(DashboardPage)
+    //  When I visit the home page
+    HomePage.visit()
+    const page = Page.verifyOnPage(HomePage)
 
     //  Then I see no cards
     page.shouldNotShowCards(['referrals', 'new-referral'])
   })
 
-  //  Scenario: viewing the dashboard page as an Management Info user
+  //  Scenario: viewing the home page as an Management Info user
   it('Management info user sees reports download tile', () => {
     // Given I am logged in as an MI user
     cy.task('stubSignIn', ['ROLE_CAS2_MI'])
     cy.task('stubAuthUser')
     cy.signIn()
 
-    // When I visit the dashboard page
-    DashboardPage.visit()
-    const page = Page.verifyOnPage(DashboardPage)
+    // When I visit the home page
+    HomePage.visit()
+    const page = Page.verifyOnPage(HomePage)
 
     // Then I see the management info report downloads card
     page.shouldShowCards(['management-information-reports'])

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -1,4 +1,4 @@
-import IndexPage from '../pages/dashboardPage'
+import IndexPage from '../pages/homePage'
 import AuthSignInPage from '../pages/authSignIn'
 import Page from '../pages/page'
 import AuthManageDetailsPage from '../pages/authManageDetails'

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -71,20 +71,44 @@ describe('applicationsController', () => {
   })
 
   describe('index', () => {
-    it('renders existing applications', async () => {
-      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
-        return { errors: {}, errorSummary: [], userInput: {} }
+    describe('when the prison dashboard is enabled', () => {
+      it('renders existing applications with dashboard flag', async () => {
+        config.flags.isPrisonDashboardEnabled = true
+        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+          return { errors: {}, errorSummary: [], userInput: {} }
+        })
+
+        const requestHandler = applicationsController.index()
+
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/index', {
+          errors: {},
+          errorSummary: [],
+          applications,
+          pageHeading: 'Applications',
+          isPrisonDashboardEnabled: true,
+        })
       })
+    })
+    describe('when the prison dashboard is disabled', () => {
+      it('renders existing applications with dashboard flag set to false', async () => {
+        config.flags.isPrisonDashboardEnabled = false
+        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+          return { errors: {}, errorSummary: [], userInput: {} }
+        })
 
-      const requestHandler = applicationsController.index()
+        const requestHandler = applicationsController.index()
 
-      await requestHandler(request, response, next)
+        await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/index', {
-        errors: {},
-        errorSummary: [],
-        applications,
-        pageHeading: 'Applications',
+        expect(response.render).toHaveBeenCalledWith('applications/index', {
+          errors: {},
+          errorSummary: [],
+          applications,
+          pageHeading: 'Applications',
+          isPrisonDashboardEnabled: false,
+        })
       })
     })
   })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -698,4 +698,14 @@ describe('applicationsController', () => {
       })
     })
   })
+
+  describe('prisonDashboard', () => {
+    it('renders the prison dashboard page', async () => {
+      const requestHandler = applicationsController.prisonDashboard()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/prison-dashboard')
+    })
+  })
 })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -15,6 +15,7 @@ import { getPage } from '../../utils/applications/getPage'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
 import { buildDocument } from '../../utils/applications/documentUtils'
 import { validateReferer } from '../../utils/viewUtils'
+import config from '../../config'
 
 export default class ApplicationsController {
   constructor(
@@ -36,6 +37,7 @@ export default class ApplicationsController {
         ...userInput,
         applications,
         pageHeading: 'Applications',
+        isPrisonDashboardEnabled: config.flags.isPrisonDashboardEnabled,
       })
     }
   }

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -282,4 +282,10 @@ export default class ApplicationsController {
       }
     }
   }
+
+  prisonDashboard(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      return res.render('applications/prison-dashboard')
+    }
+  }
 }

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -9,10 +9,13 @@ const appendToListPath = pagesPath.path('/appendToList')
 
 const removeFromListPath = pagesPath.path(':index/removeFromList')
 
+const prisonDashboardPath = applicationsPath.path('/prison')
+
 const paths = {
   applications: {
     create: applicationsPath.path('create'),
     index: applicationsPath,
+    prison: prisonDashboardPath,
     new: applicationsPath.path('new'),
     beforeYouStart: applicationsPath.path('before-you-start'),
     people: {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -23,6 +23,9 @@ export default function applyRoutes(controllers: Controllers, router: Router, se
   )
   get(paths.applications.new.pattern, applicationsController.new(), { auditEvent: 'VIEW_APPLICATION_NEW' })
   get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'VIEW_APPLICATIONS_LIST' })
+  get(paths.applications.prison.pattern, applicationsController.prisonDashboard(), {
+    auditEvent: 'VIEW_PRISON_DASHBOARD',
+  })
   get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION_START' })
   post(paths.applications.submission.pattern, applicationsController.submit(), { auditEvent: 'SUBMIT_APPLICATION' })
   post(paths.applications.create.pattern, applicationsController.create(), { auditEvent: 'CREATE_APPLICATION' })

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -1,3 +1,4 @@
+import config from '../config'
 import { sectionsForUser, sections } from './userUtils'
 
 describe('userUtils', () => {
@@ -6,9 +7,20 @@ describe('userUtils', () => {
       expect(sectionsForUser([])).toEqual([])
     })
 
-    it('should return correct sections for a POM', () => {
-      const expected = [sections.referral, sections.newReferral]
-      expect(sectionsForUser(['ROLE_POM'])).toEqual(expected)
+    describe('when prison dashboard is enabled', () => {
+      it('should return correct sections including the prison dashboard for a POM', () => {
+        config.flags.isPrisonDashboardEnabled = true
+        const expected = [sections.referral, sections.newReferral, sections.prisonDashboard]
+        expect(sectionsForUser(['ROLE_POM'])).toEqual(expected)
+      })
+    })
+
+    describe('when prison dashboard is NOT enabled', () => {
+      it('should return correct sections without prison dashboard for a POM', () => {
+        config.flags.isPrisonDashboardEnabled = false
+        const expected = [sections.referral, sections.newReferral]
+        expect(sectionsForUser(['ROLE_POM'])).toEqual(expected)
+      })
     })
 
     it('should return correct sections for an admin', () => {

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -3,6 +3,7 @@ import { ServiceSection } from '@approved-premises/ui'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import reportsPaths from '../paths/report'
+import config from '../config'
 
 export const sections = {
   referral: {
@@ -33,6 +34,13 @@ export const sections = {
     shortTitle: 'Management information reports',
     href: reportsPaths.report.new.pattern,
   },
+  prisonDashboard: {
+    id: 'prison-dashboard',
+    title: 'View your prison’s applications',
+    description: 'View recently submitted CAS-2 applications from your prison.',
+    shortTitle: 'View your prison’s applications',
+    href: applyPaths.applications.prison.pattern,
+  },
 }
 
 export const hasRole = (userRoles: Array<string>, role: string): boolean => {
@@ -45,6 +53,9 @@ export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection>
   if (hasRole(userRoles, 'ROLE_POM')) {
     items.push(sections.referral)
     items.push(sections.newReferral)
+    if (config.flags.isPrisonDashboardEnabled) {
+      items.push(sections.prisonDashboard)
+    }
   }
   if (hasRole(userRoles, 'ROLE_CAS2_ADMIN')) {
     items.push(sections.submittedApplications)

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -19,6 +19,20 @@
       <h1 class="govuk-heading-l">Short-Term Accommodation (CAS-2) applications</h1>
       {{ showErrorSummary(errorSummary) }}
 
+      {% if isPrisonDashboardEnabled %}
+        {{ mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+            text: 'Your applications',
+            href: paths.applications.index(),
+            active: true
+          }, {
+            text: "Your prison's applications",
+            href: paths.applications.prison()
+          }]
+        }) }}
+      {% endif %}
+
       {{ govukTabs({
         items: [
           {

--- a/server/views/applications/prison-dashboard.njk
+++ b/server/views/applications/prison-dashboard.njk
@@ -1,0 +1,28 @@
+{% extends "../partials/layout.njk" %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% set pageTitle = applicationName + " - your prison's applications"  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Short-Term Accommodation (CAS-2) applications</h1>
+
+      {{ mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+            text: 'Your applications',
+            href: paths.applications.index()
+          }, {
+            text: "Your prison's applications",
+            href: paths.applications.prison(),
+            active: true
+          }]
+        }) }}
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
# Context

There is more info in the slack message here:
https://mojdt.slack.com/archives/C04T6SC31HA/p1712920017883269?thread_ts=1712143310.370659&cid=C04T6SC31HA 

Essentially we want to add these things behind the recently introduced feature flag:
1. Sub-nav on referrer's existing applications page to toggle between their applications and applications in their prison
2. a blank page with same sub-nav on it where the prison dashboard will eventually go.
3. A tile on the home page to go directly to the prison dashboard page


# Changes in this PR

This PR introduces most of the boiler plate to add a new route and tile - Content of the page to come in future PR.
I've set the prison dashboard up on a separate route to make things simpler, and because I think it makes sense - it's a subset of applications, and it appears visually as a 'tab' on the same page, but it's still technically a different 'page'.

Points to note: I've tried again briefly to see if we can set the process.env vars dynamically in the cypress integration tests, again with no luck. The tests take in the `feature.env` through the cli and then they seem impossible to change at run time, I guess because the app is already built?
We have to choose whether we set the feature flag to `true` or `false` for all integration tests - should we keep it as true in order to see the components working, or set to false to check the components are definitely hidden, and rely on unit and manua tests for enough confidence?

## Screenshots of UI changes

### Before (and without flag enabled)


### After (with flag enabled)
![Screenshot 2024-04-12 at 15 01 16](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/3d3d90d4-5788-44cb-92ef-5580990ef0a0)
![Screenshot 2024-04-12 at 15 01 06](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/4081ad71-feee-4cb9-bb71-952f9d255e01)
![Screenshot 2024-04-12 at 15 00 57](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/16647486/a992de97-4fcd-4ca8-bc4f-b3eda8c7a1bc)




# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
