### PR TITLE
Show latest status for submitted applications

### DIFF
--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -38,6 +38,7 @@ context('Applications dashboard', () => {
     // There are applications in the database
     const inProgressApplications = applicationSummaryFactory.buildList(5, {
       status: 'inProgress',
+      latestStatusUpdate: null,
     })
 
     cy.task('stubApplications', inProgressApplications)

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -65,7 +65,7 @@ describe('ApplicationService', () => {
   describe('getAllForLoggedInUser', () => {
     const token = 'SOME_TOKEN'
     const applications: GroupedApplications = {
-      inProgress: applicationSummaryFactory.buildList(1, { status: 'inProgress' }),
+      inProgress: applicationSummaryFactory.buildList(1, { status: 'inProgress', latestStatusUpdate: null }),
       submitted: applicationSummaryFactory.buildList(1, { status: 'submitted' }),
     }
 

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -4,6 +4,7 @@ import { Cas2ApplicationSummary } from '@approved-premises/api'
 
 import { DateFormats } from '../../utils/dateUtils'
 import { fullPersonFactory } from './person'
+import latestStatusUpdateFactory from './latestStatusUpdate'
 
 export default Factory.define<Cas2ApplicationSummary>(() => ({
   id: faker.string.uuid(),
@@ -12,5 +13,6 @@ export default Factory.define<Cas2ApplicationSummary>(() => ({
   createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   submittedAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   createdByUserId: faker.string.uuid(),
-  status: 'inProgress',
+  status: 'inProgress' || 'submitted',
+  latestStatusUpdate: latestStatusUpdateFactory.build(),
 }))

--- a/server/testutils/factories/latestStatusUpdate.ts
+++ b/server/testutils/factories/latestStatusUpdate.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { LatestCas2StatusUpdate } from '@approved-premises/api'
+
+export default Factory.define<LatestCas2StatusUpdate>(() => ({
+  statusId: 'f5cd423b-08eb-4efb-96ff-5cc6bb073905',
+  label: 'More information requested',
+}))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,10 +1,11 @@
 import { QuestionAndAnswer } from '@approved-premises/ui'
-import { applicationFactory } from '../testutils/factories'
+import { applicationFactory, applicationSummaryFactory } from '../testutils/factories'
 import {
   documentSummaryListRows,
   inProgressApplicationTableRows,
   submittedApplicationTableRows,
   assessmentsTableRows,
+  getStatusTag,
 } from './applicationUtils'
 import { fullPersonFactory } from '../testutils/factories/person'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
@@ -63,11 +64,11 @@ describe('submittedApplicationTableRows', () => {
     const personA = fullPersonFactory.build({ name: 'A' })
     const personB = fullPersonFactory.build({ name: 'B' })
 
-    const applicationA = applicationFactory.build({
+    const applicationA = applicationSummaryFactory.build({
       person: personA,
       submittedAt: '2022-12-10T21:47:28Z',
     })
-    const applicationB = applicationFactory.build({
+    const applicationB = applicationSummaryFactory.build({
       person: personB,
       submittedAt: '2022-12-11T21:47:28Z',
     })
@@ -88,6 +89,9 @@ describe('submittedApplicationTableRows', () => {
         {
           text: '10 December 2022',
         },
+        {
+          html: '<strong class="govuk-tag govuk-tag--light-blue">More information requested</strong>',
+        },
       ],
       [
         {
@@ -101,6 +105,9 @@ describe('submittedApplicationTableRows', () => {
         },
         {
           text: '11 December 2022',
+        },
+        {
+          html: '<strong class="govuk-tag govuk-tag--light-blue">More information requested</strong>',
         },
       ],
     ])
@@ -170,5 +177,17 @@ describe('documentSummaryListRows', () => {
         value: { html: 'Answer 2' },
       },
     ])
+  })
+
+  describe('getStatusTag', () => {
+    it('returns the correct HTML string', () => {
+      const expected = `<strong class="govuk-tag govuk-tag--light-blue">More information requested</strong>`
+      expect(getStatusTag('More information requested', 'f5cd423b-08eb-4efb-96ff-5cc6bb073905')).toEqual(expected)
+    })
+
+    it('returns the Received string if status is undefined', () => {
+      const expected = `<strong class="govuk-tag govuk-tag--grey">Received</strong>`
+      expect(getStatusTag(undefined, undefined)).toEqual(expected)
+    })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,5 +1,6 @@
 import type {
   Cas2Application as Application,
+  Cas2ApplicationSummary,
   Cas2SubmittedApplicationSummary,
   FullPerson,
 } from '@approved-premises/api'
@@ -23,7 +24,7 @@ export const inProgressApplicationTableRows = (applications: Array<Application>)
 }
 
 export const submittedApplicationTableRows = (
-  applications: Array<Application>,
+  applications: Array<Cas2ApplicationSummary>,
   isAssessPath: boolean = false,
 ): Array<TableRow> => {
   return applications.map(application => {
@@ -33,6 +34,7 @@ export const submittedApplicationTableRows = (
       textValue(person.nomsNumber),
       textValue(person.crn),
       textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'medium' })),
+      htmlValue(getStatusTag(application.latestStatusUpdate?.label, application.latestStatusUpdate?.statusId)),
     ]
   })
 }
@@ -84,4 +86,34 @@ const nameAnchorElement = (
 
 const textValue = (value: string) => {
   return { text: value }
+}
+
+export const getStatusTag = (statusLabel: string, statusId: string) => {
+  return `<strong class="govuk-tag govuk-tag--${getStatusTagColour(statusId)}">${statusLabel || 'Received'}</strong>`
+}
+
+const getStatusTagColour = (statusId: string) => {
+  // status IDs located at https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+  switch (statusId) {
+    case 'f5cd423b-08eb-4efb-96ff-5cc6bb073905':
+      return 'light-blue'
+    case 'ba4d8432-250b-4ab9-81ec-7eb4b16e5dd1':
+      return 'yellow'
+    case 'a919097d-b324-471c-9834-756f255e87ea':
+      return 'yellow'
+    case '176bbda0-0766-4d77-8d56-18ed8f9a4ef2':
+      return 'purple'
+    case 'fe254d88-ce1d-4cd8-8bd6-88de88f39019':
+      return 'green'
+    case '9a381bc6-22d3-41d6-804d-4e49f428c1de':
+      return 'orange'
+    case '004e2419-9614-4c1e-a207-a8418009f23d':
+      return 'pink'
+    case 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9':
+      return 'pink'
+    case '89458555-3219-44a2-9584-c4f715d6b565':
+      return 'green'
+    default:
+      return 'grey'
+  }
 }

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -78,6 +78,10 @@
                 {
                   text: "Date submitted"
                 }
+                ,
+                {
+                  text: "Status"
+                }
               ],
               submittedApplicationTableRows(applications.submitted))
             }


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-399

# Changes in this PR

Adds a row to the submitted applications table on the referrer dashboard to show the latest status of the application.

## Screenshots of UI changes

### Before

![Screenshot 2024-04-15 at 15 36 28](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/342aa6e8-a992-46b7-b9c5-d2e267ed5877)

### After

<img width="760" alt="Screenshot 2024-04-18 at 15 08 30" src="https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/a4e5c842-ce85-4f5e-a3eb-0e75093a62fd">

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
