### PR TITLE
CAS2-412 Start using personName on the applications dashboard

### DIFF
--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -1,7 +1,6 @@
 import Page from '../page'
 import paths from '../../../server/paths/apply'
-import { Cas2Application as Application, Cas2ApplicationSummary, FullPerson } from '../../../server/@types/shared'
-import { nameOrPlaceholderCopy } from '../../../server/utils/utils'
+import { Cas2Application as Application, Cas2ApplicationSummary } from '../../../server/@types/shared'
 
 export default class ListPage extends Page {
   constructor(
@@ -14,9 +13,7 @@ export default class ListPage extends Page {
   static visit(applications: Array<Cas2ApplicationSummary>): ListPage {
     cy.visit(paths.applications.index.pattern)
 
-    const person = applications[0]?.person as FullPerson
-
-    return new ListPage(applications, person?.name)
+    return new ListPage(applications, applications[0]?.personName)
   }
 
   shouldShowInProgressApplications(): void {
@@ -38,7 +35,7 @@ export default class ListPage extends Page {
 
   private shouldShowApplications(applications: Array<Cas2ApplicationSummary>, inProgress = false): void {
     applications.forEach(application => {
-      const personName = nameOrPlaceholderCopy(application.person)
+      const { personName } = application
       cy.contains(personName)
         .should(
           'have.attr',

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -15,4 +15,7 @@ export default Factory.define<Cas2ApplicationSummary>(() => ({
   createdByUserId: faker.string.uuid(),
   status: 'inProgress' || 'submitted',
   latestStatusUpdate: latestStatusUpdateFactory.build(),
+  personName: faker.person.fullName(),
+  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  nomsNumber: `NOMS${faker.number.int({ min: 100, max: 999 })}`,
 }))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,5 +1,7 @@
 import { QuestionAndAnswer } from '@approved-premises/ui'
-import { applicationFactory, applicationSummaryFactory } from '../testutils/factories'
+
+import { applicationSummaryFactory } from '../testutils/factories'
+
 import {
   documentSummaryListRows,
   inProgressApplicationTableRows,
@@ -7,22 +9,12 @@ import {
   assessmentsTableRows,
   getStatusTag,
 } from './applicationUtils'
-import { fullPersonFactory } from '../testutils/factories/person'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
 
 describe('inProgressApplicationTableRows', () => {
   it('returns an array of applications as table rows', async () => {
-    const personA = fullPersonFactory.build({ name: 'A' })
-    const personB = fullPersonFactory.build({ name: 'B' })
-
-    const applicationA = applicationFactory.build({
-      person: personA,
-      createdAt: '2022-11-10T21:47:28Z',
-    })
-    const applicationB = applicationFactory.build({
-      person: personB,
-      createdAt: '2022-11-11T21:47:28Z',
-    })
+    const applicationA = applicationSummaryFactory.build({ personName: 'A', createdAt: '2022-11-10T21:47:28Z' })
+    const applicationB = applicationSummaryFactory.build({ personName: 'B', createdAt: '2022-11-11T21:47:28Z' })
 
     const result = inProgressApplicationTableRows([applicationA, applicationB])
 
@@ -32,10 +24,10 @@ describe('inProgressApplicationTableRows', () => {
           html: `<a href=/applications/${applicationA.id} data-cy-id="${applicationA.id}">A</a>`,
         },
         {
-          text: personA.nomsNumber,
+          text: applicationA.nomsNumber,
         },
         {
-          text: personA.crn,
+          text: applicationA.crn,
         },
         {
           text: '10 November 2022',
@@ -46,10 +38,10 @@ describe('inProgressApplicationTableRows', () => {
           html: `<a href=/applications/${applicationB.id} data-cy-id="${applicationB.id}">B</a>`,
         },
         {
-          text: personB.nomsNumber,
+          text: applicationB.nomsNumber,
         },
         {
-          text: applicationB.person.crn,
+          text: applicationB.crn,
         },
         {
           text: '11 November 2022',
@@ -61,17 +53,8 @@ describe('inProgressApplicationTableRows', () => {
 
 describe('submittedApplicationTableRows', () => {
   it('returns an array of applications as table rows', async () => {
-    const personA = fullPersonFactory.build({ name: 'A' })
-    const personB = fullPersonFactory.build({ name: 'B' })
-
-    const applicationA = applicationSummaryFactory.build({
-      person: personA,
-      submittedAt: '2022-12-10T21:47:28Z',
-    })
-    const applicationB = applicationSummaryFactory.build({
-      person: personB,
-      submittedAt: '2022-12-11T21:47:28Z',
-    })
+    const applicationA = applicationSummaryFactory.build({ personName: 'A', submittedAt: '2022-12-10T21:47:28Z' })
+    const applicationB = applicationSummaryFactory.build({ personName: 'B', submittedAt: '2022-12-11T21:47:28Z' })
 
     const result = submittedApplicationTableRows([applicationA, applicationB])
 
@@ -81,10 +64,10 @@ describe('submittedApplicationTableRows', () => {
           html: `<a href=/applications/${applicationA.id}/overview data-cy-id="${applicationA.id}">A</a>`,
         },
         {
-          text: personA.nomsNumber,
+          text: applicationA.nomsNumber,
         },
         {
-          text: personA.crn,
+          text: applicationA.crn,
         },
         {
           text: '10 December 2022',
@@ -98,10 +81,10 @@ describe('submittedApplicationTableRows', () => {
           html: `<a href=/applications/${applicationB.id}/overview data-cy-id="${applicationB.id}">B</a>`,
         },
         {
-          text: personB.nomsNumber,
+          text: applicationB.nomsNumber,
         },
         {
-          text: personB.crn,
+          text: applicationB.crn,
         },
         {
           text: '11 December 2022',

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,23 +1,16 @@
-import type {
-  Cas2Application as Application,
-  Cas2ApplicationSummary,
-  Cas2SubmittedApplicationSummary,
-  FullPerson,
-} from '@approved-premises/api'
+import type { Cas2SubmittedApplicationSummary, Cas2ApplicationSummary } from '@approved-premises/api'
 import type { QuestionAndAnswer, TableRow } from '@approved-premises/ui'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import { DateFormats } from './dateUtils'
-import { nameOrPlaceholderCopy } from './utils'
 import { formatLines } from './viewUtils'
 
-export const inProgressApplicationTableRows = (applications: Array<Application>): Array<TableRow> => {
+export const inProgressApplicationTableRows = (applications: Array<Cas2ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => {
-    const person = application.person as FullPerson
     return [
-      nameAnchorElement(nameOrPlaceholderCopy(person), application.id, false, true),
-      textValue(person.nomsNumber),
-      textValue(person.crn),
+      nameAnchorElement(application.personName, application.id, false, true),
+      textValue(application.nomsNumber),
+      textValue(application.crn),
       textValue(DateFormats.isoDateToUIDate(application.createdAt, { format: 'medium' })),
     ]
   })
@@ -28,11 +21,10 @@ export const submittedApplicationTableRows = (
   isAssessPath: boolean = false,
 ): Array<TableRow> => {
   return applications.map(application => {
-    const person = application.person as FullPerson
     return [
-      nameAnchorElement(nameOrPlaceholderCopy(person), application.id, isAssessPath),
-      textValue(person.nomsNumber),
-      textValue(person.crn),
+      nameAnchorElement(application.personName, application.id, isAssessPath),
+      textValue(application.nomsNumber),
+      textValue(application.crn),
       textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'medium' })),
       htmlValue(getStatusTag(application.latestStatusUpdate?.label, application.latestStatusUpdate?.statusId)),
     ]


### PR DESCRIPTION
Ref: JIRA ticket [CAS2-412](https://dsdmoj.atlassian.net/browse/CAS2-412)

This PR contains the work required for the second sub task of [CAS2-401](https://dsdmoj.atlassian.net/browse/CAS2-401)

Tasks:
- UI: start using personName on the applications dashboard

We currently return for ApplicationSummaries a full Person result, which includes a lot of data, and causes issues with how we handle whether the person has been found/is restricted.

We propose that we follow the standard set for /submissions and just return a personName which will be ‘Unknown’ if person not found or restricted.

This will mean we can then do a bulk search with the CRNs more easily, and just get the person’s name.

[CAS2-401]: https://dsdmoj.atlassian.net/browse/CAS2-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAS2-412]: https://dsdmoj.atlassian.net/browse/CAS2-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ