### PR TITLE
Fix bug with HDC and conditional release date errors

### DIFF
--- a/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.test.ts
+++ b/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.test.ts
@@ -64,10 +64,10 @@ describe('HDCLicenceDates', () => {
   })
 
   describe('errors', () => {
-    describe('when the dates given are not valid', () => {
+    describe('when no dates are provided', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
       })
 
       it('returns errors', () => {
@@ -82,7 +82,7 @@ describe('HDCLicenceDates', () => {
     describe('when false dates are provided', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => false)
       })
 
@@ -98,7 +98,7 @@ describe('HDCLicenceDates', () => {
     describe('when the conditional release date (CRD) is in the past', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => false)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => false)
@@ -116,7 +116,7 @@ describe('HDCLicenceDates', () => {
     describe('when the HDC date is more than 6 months before the CRD date', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => true)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => true)
@@ -134,7 +134,7 @@ describe('HDCLicenceDates', () => {
     describe('when the HDC date is after the CRD date', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => true)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => false)

--- a/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.test.ts
+++ b/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.test.ts
@@ -7,6 +7,7 @@ import {
   isBeforeDate,
   isMoreThanMonthsBetweenDates,
   differenceInDaysFromToday,
+  dateIsComplete,
 } from '../../../../utils/dateUtils'
 
 jest.mock('../../../../utils/dateUtils', () => {
@@ -18,6 +19,7 @@ jest.mock('../../../../utils/dateUtils', () => {
     isMoreThanMonthsBetweenDates: jest.fn(),
     isBeforeDate: jest.fn(),
     differenceInDaysFromToday: jest.fn(),
+    dateIsComplete: jest.fn(),
   }
 })
 
@@ -65,10 +67,7 @@ describe('HDCLicenceDates', () => {
     describe('when the dates given are not valid', () => {
       beforeEach(() => {
         jest.resetAllMocks()
-        ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => false)
-        ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => true)
-        ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => false)
-        ;(isBeforeDate as jest.Mock).mockImplementation(() => true)
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
       })
 
       it('returns errors', () => {
@@ -80,9 +79,26 @@ describe('HDCLicenceDates', () => {
       })
     })
 
+    describe('when false dates are provided', () => {
+      beforeEach(() => {
+        jest.resetAllMocks()
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
+        ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => false)
+      })
+
+      it('returns errors', () => {
+        const page = new HDCLicenceDates({}, application)
+        expect(page.errors()).toEqual({
+          hdcEligibilityDate: 'Eligibility date must be a real date',
+          conditionalReleaseDate: 'Conditional release date must be a real date',
+        })
+      })
+    })
+
     describe('when the conditional release date (CRD) is in the past', () => {
       beforeEach(() => {
         jest.resetAllMocks()
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => false)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => false)
@@ -100,6 +116,7 @@ describe('HDCLicenceDates', () => {
     describe('when the HDC date is more than 6 months before the CRD date', () => {
       beforeEach(() => {
         jest.resetAllMocks()
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => true)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => true)
@@ -117,6 +134,7 @@ describe('HDCLicenceDates', () => {
     describe('when the HDC date is after the CRD date', () => {
       beforeEach(() => {
         jest.resetAllMocks()
+        ;(dateIsComplete as jest.Mock).mockImplementation(() => false)
         ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => true)
         ;(dateIsTodayOrInTheFuture as jest.Mock).mockImplementation(() => true)
         ;(isMoreThanMonthsBetweenDates as jest.Mock).mockImplementation(() => false)

--- a/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.ts
+++ b/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.ts
@@ -12,6 +12,7 @@ import {
   isBeforeDate,
   differenceInDaysFromToday,
   isMoreThanMonthsBetweenDates,
+  dateIsComplete,
 } from '../../../../utils/dateUtils'
 import { dateBodyProperties } from '../../../utils'
 
@@ -76,10 +77,12 @@ export default class HDCLicenceDates implements TaskListPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
-    if (!dateAndTimeInputsAreValidDates(this.body, 'hdcEligibilityDate')) {
+
+    if (dateIsComplete(this.body, 'hdcEligibilityDate')) {
       errors.hdcEligibilityDate = "Enter the applicant's HDC eligibility date"
     }
-    if (!dateAndTimeInputsAreValidDates(this.body, 'conditionalReleaseDate')) {
+
+    if (dateIsComplete(this.body, 'conditionalReleaseDate')) {
       errors.conditionalReleaseDate = "Enter the applicant's conditional release date"
     }
     if (!dateIsTodayOrInTheFuture(this.body, 'conditionalReleaseDate')) {

--- a/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.ts
+++ b/server/form-pages/apply/before-you-start/hdc-licence-dates/hdcLicenceDates.ts
@@ -78,16 +78,24 @@ export default class HDCLicenceDates implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (dateIsComplete(this.body, 'hdcEligibilityDate')) {
+    if (!dateIsComplete(this.body, 'hdcEligibilityDate')) {
       errors.hdcEligibilityDate = "Enter the applicant's HDC eligibility date"
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'hdcEligibilityDate')) {
+      errors.hdcEligibilityDate = 'Eligibility date must be a real date'
     }
 
-    if (dateIsComplete(this.body, 'conditionalReleaseDate')) {
+    if (!dateIsComplete(this.body, 'conditionalReleaseDate')) {
       errors.conditionalReleaseDate = "Enter the applicant's conditional release date"
-    }
-    if (!dateIsTodayOrInTheFuture(this.body, 'conditionalReleaseDate')) {
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'conditionalReleaseDate')) {
+      errors.conditionalReleaseDate = 'Conditional release date must be a real date'
+    } else if (!dateIsTodayOrInTheFuture(this.body, 'conditionalReleaseDate')) {
       errors.conditionalReleaseDate = 'Conditional release date cannot be in the past'
     }
+
+    if (errors.hdcEligibilityDate || errors.conditionalReleaseDate) {
+      return errors
+    }
+
     if (
       isMoreThanMonthsBetweenDates(
         this.body,

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -11,6 +11,7 @@ import {
   isMoreThanMonthsBetweenDates,
   differenceInDaysFromToday,
   isBeforeDate,
+  dateIsComplete,
 } from './dateUtils'
 
 jest.mock('date-fns', () => {
@@ -373,6 +374,51 @@ describe('DateFormats', () => {
       expect(result.month).toBeTruthy()
       expect(result.day).toBeTruthy()
       expect(result.formattedDate).toBeTruthy()
+    })
+  })
+
+  describe('dateIsComplete', () => {
+    it('returns true if the date is complete', () => {
+      const date: ObjectWithDateParts<'field'> = {
+        'field-day': '12',
+        'field-month': '1',
+        'field-year': '2022',
+      }
+
+      expect(dateIsComplete(date, 'field')).toEqual(true)
+    })
+
+    it('returns false if the date is blank', () => {
+      const date: ObjectWithDateParts<'field'> = {
+        'field-day': '',
+        'field-month': '',
+        'field-year': '',
+      }
+
+      expect(dateIsComplete(date, 'field')).toEqual(false)
+    })
+
+    it('returns false if a partial date is entered', () => {
+      const date: ObjectWithDateParts<'field'> = {
+        'field-day': '12',
+        'field-month': '1',
+        'field-year': '',
+      }
+
+      expect(dateIsComplete(date, 'field')).toEqual(false)
+    })
+
+    it('ignores irrelevant fields', () => {
+      const date: ObjectWithDateParts<'field'> & ObjectWithDateParts<'otherField'> = {
+        'field-day': '12',
+        'field-month': '1',
+        'field-year': '2022',
+        'otherField-day': undefined,
+        'otherField-month': undefined,
+        'otherField-year': undefined,
+      }
+
+      expect(dateIsComplete(date, 'field')).toEqual(true)
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -269,3 +269,21 @@ export const getTodaysDatePlusMonthsAndDays = (monthsToAdd = 0, daysToAdd = 0): 
 }
 
 export class InvalidDateStringError extends Error {}
+
+export const dateIsComplete = <K extends string | number>(
+  dateInputObj: Partial<ObjectWithDateParts<K>>,
+  key: K,
+): boolean => {
+  const dateParts = ['year', 'month', 'day'] as const
+  let allPartsExist = true
+
+  for (const part of dateParts) {
+    const keyExists = Boolean(dateInputObj[`${key}-${part}`])
+    if (!keyExists) {
+      allPartsExist = false
+      break
+    }
+  }
+
+  return allPartsExist
+}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=CAS2-421

# Changes in this PR

Previously, invalid dates were being passed into isMoreThanMonthsBetweenDates, which was causing errors. This introduces return statements to ensure that empty or invalid dates are returned before those checks.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
