### PR TITLE
Paginate applications on the prison dashboard page

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -40,15 +40,24 @@ export default {
         jsonBody: applications,
       },
     }),
-  stubPrisonApplications: (args: { applications: Array<Application>; prisonCode: string }): SuperAgentRequest =>
+  stubPrisonApplications: (args: {
+    applications: Array<Application>
+    prisonCode: string
+    page: number
+  }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/applications?prisonCode=${args.prisonCode}&isSubmitted=true`,
+        url: `/cas2/applications?page=${args.page}&prisonCode=${args.prisonCode}&isSubmitted=true`,
       },
       response: {
         status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '2',
+          'X-Pagination-TotalResults': '20',
+          'X-Pagination-PageSize': '10',
+        },
         jsonBody: args.applications,
       },
     }),

--- a/integration_tests/pages/apply/prisonDashboard.ts
+++ b/integration_tests/pages/apply/prisonDashboard.ts
@@ -15,4 +15,9 @@ export default class PrisonDashboardPage extends Page {
   shouldShowMyApplicationsTab(): void {
     cy.contains(`Your applications`).should('have.attr', 'href', paths.applications.index.pattern)
   }
+
+  clickPageNumber(pageNumber: string): void {
+    const linkText = new RegExp(`^\\s+${pageNumber}\\s+$`)
+    cy.get('a').contains(linkText).click()
+  }
 }

--- a/integration_tests/tests/apply/prison_dashboard.cy.ts
+++ b/integration_tests/tests/apply/prison_dashboard.cy.ts
@@ -23,12 +23,15 @@ context('PrisonDashboard', () => {
 
     //  And there are applications for my prison in the database
     const applications = applicationSummaryFactory.buildList(5)
-    cy.task('stubPrisonApplications', { applications, prisonCode })
+    cy.task('stubPrisonApplications', { applications, prisonCode, page: 1 })
 
     //  When I visit the prison dashboard
     const page = PrisonDashboardPage.visit()
 
     //  Then I can see a list of applications for my prison
+    page.shouldShowApplications(applications)
+    cy.task('stubPrisonApplications', { applications, prisonCode, page: 2 })
+    page.clickPageNumber('2')
     page.shouldShowApplications(applications)
 
     //  And I can tab back to my applications

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
-import { Cas2Application as Application } from '@approved-premises/api'
-import { ErrorsAndUserInput, GroupedApplications } from '@approved-premises/ui'
+import { Cas2Application as Application, Cas2ApplicationSummary } from '@approved-premises/api'
+import { ErrorsAndUserInput, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import createHttpError from 'http-errors'
 
 import { getPage } from '../../utils/applications/getPage'
@@ -11,6 +11,7 @@ import {
   applicationSummaryFactory,
   personFactory,
   applicationNoteFactory,
+  paginatedResponseFactory,
 } from '../../testutils/factories'
 import {
   catchValidationErrorOrPropogate,
@@ -25,6 +26,7 @@ import { buildDocument } from '../../utils/applications/documentUtils'
 import config from '../../config'
 import { showMissingRequiredTasksOrTaskList, generateSuccessMessage } from '../../utils/applications/utils'
 import { validateReferer } from '../../utils/viewUtils'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 jest.mock('../../utils/validation')
 jest.mock('../../services/taskListService')
@@ -32,6 +34,7 @@ jest.mock('../../utils/applications/getPage')
 jest.mock('../../utils/applications/documentUtils')
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/viewUtils')
+jest.mock('../../utils/getPaginationDetails')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -702,7 +705,18 @@ describe('applicationsController', () => {
       response.locals.user = { activeCaseLoadId: '123' }
       const prisonApplications = applicationSummaryFactory.buildList(5)
 
-      applicationService.getAllByPrison.mockResolvedValue(prisonApplications)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: prisonApplications,
+        totalPages: '50',
+        totalResults: '500',
+      }) as PaginatedResponse<Cas2ApplicationSummary>
+
+      const paginationDetails = {
+        hrefPrefix: paths.applications.prison({}),
+        pageNumber: 1,
+      }
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+      applicationService.getAllByPrison.mockResolvedValue(paginatedResponse)
 
       const requestHandler = applicationsController.prisonDashboard()
 
@@ -710,6 +724,9 @@ describe('applicationsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('applications/prison-dashboard', {
         applications: prisonApplications,
+        pageNumber: 1,
+        totalPages: 50,
+        hrefPrefix: paths.applications.prison({}),
       })
     })
   })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -15,6 +15,7 @@ import { getPage } from '../../utils/applications/getPage'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
 import { buildDocument } from '../../utils/applications/documentUtils'
 import { validateReferer } from '../../utils/viewUtils'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export default class ApplicationsController {
   constructor(
@@ -285,12 +286,20 @@ export default class ApplicationsController {
 
   prisonDashboard(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const applications = await this.applicationService.getAllByPrison(
+      const { pageNumber, hrefPrefix } = getPaginationDetails(req, paths.applications.prison({}))
+
+      const result = await this.applicationService.getAllByPrison(
         req.user.token,
         res.locals.user.activeCaseLoadId,
+        pageNumber,
       )
 
-      return res.render('applications/prison-dashboard', { applications })
+      return res.render('applications/prison-dashboard', {
+        applications: result.data,
+        pageNumber: Number(result.pageNumber),
+        totalPages: Number(result.totalPages),
+        hrefPrefix,
+      })
     }
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -107,6 +107,7 @@ describeClient('ApplicationClient', provider => {
           query: {
             prisonCode: '123',
             isSubmitted: 'true',
+            page: '1',
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -115,12 +116,23 @@ describeClient('ApplicationClient', provider => {
         willRespondWith: {
           status: 200,
           body: applications,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
-      const result = await applicationClient.getAllByPrison('123')
+      const result = await applicationClient.getAllByPrison('123', 1)
 
-      expect(result).toEqual(applications)
+      expect(result).toEqual({
+        data: applications,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -4,6 +4,7 @@ import {
   SubmitCas2Application,
   UpdateApplication,
 } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 import { UpdateCas2Application } from '../@types/shared/models/UpdateCas2Application'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -33,9 +34,12 @@ export default class ApplicationClient {
     return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Cas2ApplicationSummary>
   }
 
-  async getAllByPrison(prisonCode: string): Promise<Array<Cas2ApplicationSummary>> {
-    const path = `${paths.applications.index({})}?prisonCode=${prisonCode}&isSubmitted=true`
-    return (await this.restClient.get({ path })) as Array<Cas2ApplicationSummary>
+  async getAllByPrison(prisonCode: string, pageNumber: number): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
+    return this.restClient.getPaginatedResponse<Cas2ApplicationSummary>({
+      path: paths.applications.index.pattern,
+      page: pageNumber.toString(),
+      query: { prisonCode, isSubmitted: 'true' },
+    })
   }
 
   async update(applicationId: string, updateData: UpdateCas2Application): Promise<Application> {

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -9,7 +9,7 @@ const appendToListPath = pagesPath.path('/appendToList')
 
 const removeFromListPath = pagesPath.path(':index/removeFromList')
 
-const prisonDashboardPath = applicationsPath.path('/prison')
+const prisonDashboardPath = applicationsPath.path('prison')
 
 const paths = {
   applications: {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -5,7 +5,7 @@ import {
   Cas2Application,
   Cas2ApplicationSummary,
 } from '@approved-premises/api'
-import type { DataServices, GroupedApplications } from '@approved-premises/ui'
+import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import { getBody, getPageName, getTaskName, pageBodyShallowEquals } from '../form-pages/utils'
 import type { ApplicationClient, RestClientBuilder } from '../data'
 import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
@@ -54,10 +54,14 @@ export default class ApplicationService {
     return result
   }
 
-  async getAllByPrison(token: string, prisonCode: string): Promise<Array<Cas2ApplicationSummary>> {
+  async getAllByPrison(
+    token: string,
+    prisonCode: string,
+    pageNumber: number = 1,
+  ): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const applications = applicationClient.getAllByPrison(prisonCode)
+    const applications = await applicationClient.getAllByPrison(prisonCode, pageNumber)
 
     return applications
   }

--- a/server/views/applications/prison-dashboard.njk
+++ b/server/views/applications/prison-dashboard.njk
@@ -1,5 +1,6 @@
 {% extends "../partials/layout.njk" %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "../partials/table.njk" import applicationsTable %}
 
 {% set pageTitle = applicationName + " - your prison's applications"  %}
@@ -46,6 +47,8 @@
         ],
         prisonDashboardTableRows(applications))
       }}
+
+      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
     </div>
   </div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-409

# Changes in this PR

Adds pagination to the prison dashboard view.

## Screenshots of UI changes

### Before

![Screenshot 2024-04-26 at 15 23 00](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/9b34c44b-6348-42bd-9b25-fbde2c15e74b)

### After

![PrisonDashboard -- sees tab for my applications](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/85d52aa4-050f-4a80-b88f-de5ea3030d52)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
