### PR TITLE
Change question header size for current and historical risk

### DIFF
--- a/server/views/applications/pages/risk-to-self/current-risk.njk
+++ b/server/views/applications/pages/risk-to-self/current-risk.njk
@@ -18,7 +18,7 @@
           fieldName: 'currentRiskDetail',
           label: {
             text: page.questions.currentRiskDetail.question,
-            classes: "govuk-label--s"
+            classes: "govuk-label--m"
           },
           hint: {
             text: 'Include all current risk information and remove sensitive information, such as names and addresses.'

--- a/server/views/applications/pages/risk-to-self/historical-risk.njk
+++ b/server/views/applications/pages/risk-to-self/historical-risk.njk
@@ -18,7 +18,7 @@
           fieldName: 'historicalRiskDetail',
           label: {
             text: page.questions.historicalRiskDetail.question,
-            classes: "govuk-label--s"
+            classes: "govuk-label--m"
           },
           hint: {
             text: 'Remove sensitive information, such as names and addresses.'


### PR DESCRIPTION
# Context
Change question header size for current risk to self and historical risk to self for consistency with other question pages. 

[Jira ticket 430](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?assignee=712020%3A69692b62-eae7-4d24-a8c3-485fff2e20ee&selectedIssue=CAS2-430)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
