### PR TITLE
Update content to use application instead of referral

### DIFF
--- a/e2e-tests/pages/apply/dashboardPage.ts
+++ b/e2e-tests/pages/apply/dashboardPage.ts
@@ -5,7 +5,7 @@ export class DashboardPage extends BasePage {
     await this.page.goto('/')
   }
 
-  async makeNewReferral() {
-    await this.page.getByText('New referral').click()
+  async makeNewApplication() {
+    await this.page.getByText('Start a new application').click()
   }
 }

--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -36,8 +36,8 @@ export const startAnApplication = async (page: Page) => {
   const dashboardPage = new DashboardPage(page)
   await dashboardPage.goto()
 
-  // Follow link to 'new referral'
-  await dashboardPage.makeNewReferral()
+  // Follow link to 'new application'
+  await dashboardPage.makeNewApplication()
 
   // // confirm that I'm ready to start
   const beforeYouStartPage = new BeforeYouStartPage(page)

--- a/integration_tests/tests/home_page.cy.ts
+++ b/integration_tests/tests/home_page.cy.ts
@@ -44,7 +44,7 @@ context('Home', () => {
     const page = Page.verifyOnPage(HomePage)
 
     //  Then see the correct cards
-    page.shouldShowCards(['referrals', 'new-referral', 'prison-dashboard'])
+    page.shouldShowCards(['applications', 'new-application', 'prison-dashboard'])
 
     //  And I see the sign out button
     page.shouldShowSignOutButton()
@@ -77,7 +77,7 @@ context('Home', () => {
     const page = Page.verifyOnPage(HomePage)
 
     //  Then I see no cards
-    page.shouldNotShowCards(['referrals', 'new-referral'])
+    page.shouldNotShowCards(['applications', 'new-application'])
   })
 
   //  Scenario: viewing the home page as an Management Info user

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -7,12 +7,12 @@ describe('userUtils', () => {
     })
 
     it('should return correct sections for a POM', () => {
-      const expected = [sections.referral, sections.newReferral, sections.prisonDashboard]
+      const expected = [sections.applications, sections.newApplication, sections.prisonDashboard]
       expect(sectionsForUser(['ROLE_POM'])).toEqual(expected)
     })
 
     it('should return the prison dashboard for a Licence CA', () => {
-      const expected = [sections.referral, sections.newReferral, sections.prisonDashboard]
+      const expected = [sections.applications, sections.newApplication, sections.prisonDashboard]
       expect(sectionsForUser(['ROLE_LICENCE_CA'])).toEqual(expected)
     })
 

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -5,18 +5,18 @@ import assessPaths from '../paths/assess'
 import reportsPaths from '../paths/report'
 
 export const sections = {
-  referral: {
-    id: 'referrals',
-    title: 'View referrals',
-    description: 'View all in progress and submitted CAS-2 referrals.',
-    shortTitle: 'Referrals',
+  applications: {
+    id: 'applications',
+    title: 'View your applications',
+    description: 'View all of your in progress and submitted CAS-2 applications.',
+    shortTitle: 'Applications',
     href: applyPaths.applications.index({}),
   },
-  newReferral: {
-    id: 'new-referral',
-    title: 'Start a new referral',
-    description: 'Start a new CAS-2 referral for a HDC applicant.',
-    shortTitle: 'New referral',
+  newApplication: {
+    id: 'new-application',
+    title: 'Start a new application',
+    description: 'Start a new CAS-2 application for a HDC applicant.',
+    shortTitle: 'New application',
     href: applyPaths.applications.beforeYouStart({}),
   },
   submittedApplications: {
@@ -50,8 +50,8 @@ export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection>
   const items = []
 
   if (hasRole(userRoles, 'ROLE_POM') || hasRole(userRoles, 'ROLE_LICENCE_CA')) {
-    items.push(sections.referral)
-    items.push(sections.newReferral)
+    items.push(sections.applications)
+    items.push(sections.newApplication)
     items.push(sections.prisonDashboard)
   }
   if (hasRole(userRoles, 'ROLE_CAS2_ADMIN')) {


### PR DESCRIPTION
# Context
Update content to:
- make language consistent with rest of the service where we generally use "application" instead of "referrer" 
- make it clearer which applications you are viewing now that prison applications are viewable

[Jira ticket 433](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?selectedIssue=CAS2-433)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
