### PR TITLE
Fix content display on review application pages

### DIFF
--- a/assets/scss/components/_side-nav.scss
+++ b/assets/scss/components/_side-nav.scss
@@ -1,4 +1,6 @@
 .side-nav {
-  position: sticky;
-  top: 0.5rem;
+  @include govuk-media-query($from: tablet) {
+    position: sticky;
+    top: 0.5rem;
+  }
 }


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=CAS2-464

# Changes in this PR

On smaller screen displays, this content was layering, making it impossible to read. This media query fixes that.

However, tabbing doesn't provide a very satisfactory experience, because when you hit return on a specific item, you navigate there, but lose your place in the side nav component (so then need to tab all the way through the page to get back to it). This is a preexisting issue and I'm not sure how easy it would be to solve, but if anyone has any ideas, do share them.

## Screenshots of UI changes

### Before

![Screenshot 2024-05-10 at 15 14 55](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/7f039dd9-2203-4341-b9bb-ef1568a78b4e)

### After

![Screenshot 2024-05-10 at 15 14 21](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/assets/70749355/0b3afe86-1211-4087-bd62-2249f51e9fab)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
