### PR TITLE
Fix back buttons for pre-task list pages

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -10,6 +10,7 @@ import {
   getStatusTag,
   prisonDashboardTableRows,
   hasOasys,
+  arePreTaskListTasksIncomplete,
 } from './applicationUtils'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
 
@@ -322,5 +323,81 @@ describe('documentSummaryListRows', () => {
 
       expect(hasOasys(application, 'risk-of-serious-harm')).toEqual(false)
     })
+  })
+})
+
+describe('arePreTaskListTasksIncomplete', () => {
+  it('returns false if all there is data for all three tasks', () => {
+    const application = applicationFactory.build({
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': {
+            isEligible: 'yes',
+          },
+        },
+        'confirm-consent': {
+          'confirm-consent': {
+            hasGivenConsent: 'yes',
+            consentDate: '2023-01-01',
+            'consentDate-year': '2023',
+            'consentDate-month': '1',
+            'consentDate-day': '1',
+          },
+        },
+        'hdc-licence-dates': {
+          'hdc-licence-dates': {
+            hdcEligibilityDate: '2026-02-22',
+            'hdcEligibilityDate-year': '2026',
+            'hdcEligibilityDate-month': '2',
+            'hdcEligibilityDate-day': '22',
+            conditionalReleaseDate: '2026-03-28',
+            'conditionalReleaseDate-year': '2026',
+            'conditionalReleaseDate-month': '3',
+            'conditionalReleaseDate-day': '28',
+          },
+          'hdc-warning': {},
+          'hdc-ineligible': {},
+        },
+      },
+    })
+
+    expect(arePreTaskListTasksIncomplete(application)).toEqual(false)
+  })
+
+  it('returns true if all there is data for none of the tasks', () => {
+    const application = applicationFactory.build({
+      data: {
+        'referrer-details': {
+          'confirm-details': { name: 'Eric Dier', email: 'eric.dier@moj.gov.uk' },
+          'job-title': { jobTitle: 'POM' },
+          'contact-number': { telephone: '1234567' },
+        },
+      },
+    })
+
+    expect(arePreTaskListTasksIncomplete(application)).toEqual(true)
+  })
+
+  it('returns true if all there is data for some of the tasks', () => {
+    const application = applicationFactory.build({
+      data: {
+        'confirm-eligibility': {
+          'confirm-eligibility': {
+            isEligible: 'yes',
+          },
+        },
+        'confirm-consent': {
+          'confirm-consent': {
+            hasGivenConsent: 'yes',
+            consentDate: '2023-01-01',
+            'consentDate-year': '2023',
+            'consentDate-month': '1',
+            'consentDate-day': '1',
+          },
+        },
+      },
+    })
+
+    expect(arePreTaskListTasksIncomplete(application)).toEqual(true)
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -133,9 +133,9 @@ export const hasOasys = (application: Cas2Application, task: 'risk-to-self' | 'r
 
 export const arePreTaskListTasksIncomplete = (application: Cas2Application): boolean => {
   if (
-    application.data['confirm-eligibility'] &&
-    application.data['confirm-consent'] &&
-    application.data['hdc-licence-dates']
+    application.data?.['confirm-eligibility'] &&
+    application.data?.['confirm-consent'] &&
+    application.data?.['hdc-licence-dates']
   ) {
     return false
   }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -130,3 +130,14 @@ export const hasOasys = (application: Cas2Application, task: 'risk-to-self' | 'r
   }
   return false
 }
+
+export const arePreTaskListTasksIncomplete = (application: Cas2Application): boolean => {
+  if (
+    application.data['confirm-eligibility'] &&
+    application.data['confirm-consent'] &&
+    application.data['hdc-licence-dates']
+  ) {
+    return false
+  }
+  return true
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -17,6 +17,7 @@ import {
   submittedApplicationTableRows,
   assessmentsTableRows,
   prisonDashboardTableRows,
+  arePreTaskListTasksIncomplete,
 } from './applicationUtils'
 import {
   getApplicationTimelineEvents,
@@ -125,4 +126,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('camelToKebabCase', camelToKebabCase)
 
   njkEnv.addGlobal('pagination', pagination)
+
+  njkEnv.addGlobal('arePreTaskListTasksIncomplete', arePreTaskListTasksIncomplete)
 }

--- a/server/views/applications/pages/confirm-consent/confirm-consent.njk
+++ b/server/views/applications/pages/confirm-consent/confirm-consent.njk
@@ -1,4 +1,23 @@
 {% extends "../layout.njk" %}
+
+{% block beforeContent %}
+  {% if arePreTaskListTasksIncomplete(page.application) %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.pages.show({
+        id: applicationId,
+        task: 'confirm-eligibility',
+        page: 'confirm-eligibility'
+      })
+    }) }}
+  {% elif page.previous() === 'taskList' %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.show({ id: applicationId })
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block questions %}
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -1,4 +1,14 @@
 {% extends "../layout.njk" %}
+
+{% block beforeContent %}
+  {% if not arePreTaskListTasksIncomplete(page.application)and page.previous() === 'taskList' %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.show({ id: applicationId })
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block questions %}
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/server/views/applications/pages/hdc-licence-dates/hdc-licence-dates.njk
+++ b/server/views/applications/pages/hdc-licence-dates/hdc-licence-dates.njk
@@ -3,6 +3,24 @@
 
 {% extends "../layout.njk" %}
 
+{% block beforeContent %}
+  {% if arePreTaskListTasksIncomplete(page.application) %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.pages.show({
+        id: applicationId,
+        task: 'confirm-consent',
+        page: 'confirm-consent'
+      })
+    }) }}
+  {% elif page.previous() === 'taskList' %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.show({ id: applicationId })
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block questions %}
 
   <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CAS2/boards/1347?assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=CAS2-123

# Changes in this PR

Bug fix for the back buttons on the pages a user completes after creating an application but before reaching the task list.

This change ensures that for the confirm eligibility page, no back button will render when it is accessed prior to reaching the task list. This makes sense as continuing from the previous page has completed the irreversible step of creating a new application.

For the confirm consent and HDC pages, the back buttons will point to confirm eligibility and confirm consent, respectively.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
