### PR TITLE
update 'no Oasys' nomsNumber

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig<TestOptions>({
         personWithoutOasys: {
           name: 'James Brown',
           crn: 'C246139',
-          nomsNumber: 'A5671YZ',
+          nomsNumber: 'A1234AJ',
         },
         pomUser: {
           name: 'Prison Officer',


### PR DESCRIPTION
Using work merged in this AP Tools PR: https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/67

We will shortly be restricting referrer
permissions to only create applications for
offenders within the same prison. The previous
nomsNumber used here did not have prison data, and a new one has been added in AP Tools with more
detail here:
https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/67s
