### PR TITLE
Display nationality as "Unknown" when it is not present in person definition

### DIFF
--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -6,6 +6,7 @@ import { formatLines } from './viewUtils'
 import applicationData from '../../integration_tests/fixtures/applicationData.json'
 import Apply from '../form-pages/apply'
 import { UnknownPageError } from './errors'
+import { DateFormats } from './dateUtils'
 
 jest.mock('./formUtils')
 jest.mock('./viewUtils')
@@ -20,6 +21,7 @@ const {
   getSections,
   getPage,
   getPages,
+  getApplicantDetails,
 } = checkYourAnswersUtils
 
 const { getQuestions } = getQuestionsUtil
@@ -553,5 +555,82 @@ describe('getPage', () => {
     expect(() => {
       getPage('confirm-eligibility', 'bar')
     }).toThrow(UnknownPageError)
+  })
+
+  describe('getApplicantDetails', () => {
+    it('should return applicant details in the correct format', () => {
+      const person = personFactory.build({})
+
+      const application = applicationFactory.build({ person })
+
+      const expected = [
+        {
+          key: {
+            text: 'Full name',
+          },
+          value: {
+            html: person.name,
+          },
+        },
+        {
+          key: {
+            text: 'Date of birth',
+          },
+          value: {
+            html: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+          },
+        },
+        {
+          key: {
+            text: 'Nationality',
+          },
+          value: {
+            html: person.nationality,
+          },
+        },
+        {
+          key: {
+            text: 'Sex',
+          },
+          value: {
+            html: person.sex,
+          },
+        },
+        {
+          key: {
+            text: 'Prison number',
+          },
+          value: {
+            html: person.nomsNumber,
+          },
+        },
+        {
+          key: {
+            text: 'Prison',
+          },
+          value: {
+            html: person.prisonName,
+          },
+        },
+        {
+          key: {
+            text: 'PNC number',
+          },
+          value: {
+            html: person.pncNumber,
+          },
+        },
+        {
+          key: {
+            text: 'CRN from nDelius',
+          },
+          value: {
+            html: person.crn,
+          },
+        },
+      ]
+
+      expect(getApplicantDetails(application)).toEqual(expected)
+    })
   })
 })

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -632,5 +632,80 @@ describe('getPage', () => {
 
       expect(getApplicantDetails(application)).toEqual(expected)
     })
+
+    it('should return applicant details with nationality as unknown', () => {
+      const person = personFactory.build({ nationality: null })
+
+      const application = applicationFactory.build({ person })
+
+      const expected = [
+        {
+          key: {
+            text: 'Full name',
+          },
+          value: {
+            html: person.name,
+          },
+        },
+        {
+          key: {
+            text: 'Date of birth',
+          },
+          value: {
+            html: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+          },
+        },
+        {
+          key: {
+            text: 'Nationality',
+          },
+          value: {
+            html: 'Unknown',
+          },
+        },
+        {
+          key: {
+            text: 'Sex',
+          },
+          value: {
+            html: person.sex,
+          },
+        },
+        {
+          key: {
+            text: 'Prison number',
+          },
+          value: {
+            html: person.nomsNumber,
+          },
+        },
+        {
+          key: {
+            text: 'Prison',
+          },
+          value: {
+            html: person.prisonName,
+          },
+        },
+        {
+          key: {
+            text: 'PNC number',
+          },
+          value: {
+            html: person.pncNumber,
+          },
+        },
+        {
+          key: {
+            text: 'CRN from nDelius',
+          },
+          value: {
+            html: person.crn,
+          },
+        },
+      ]
+
+      expect(getApplicantDetails(application)).toEqual(expected)
+    })
   })
 })

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -248,7 +248,7 @@ export const getApplicantDetails = (application: Application | Cas2SubmittedAppl
         text: 'Nationality',
       },
       value: {
-        html: nationality,
+        html: nationality || 'Unknown',
       },
     },
     {

--- a/server/views/people/partials/personDetails.njk
+++ b/server/views/people/partials/personDetails.njk
@@ -22,7 +22,7 @@
         text: "Nationality"
       },
       value: {
-        text: person.nationality
+        text: person.nationality or 'Unknown'
       }
     }, {
       key: {


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-236

# Changes in this PR

As above. Arguably there are other person fields that we should do the same with, but I've limited this to nationality based on what has been flagged.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
