### PR TITLE
Fix e2e test for adding note via prison dashboard

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -117,8 +117,18 @@ export const addNote = async (page: Page) => {
   await expect(page.locator('.moj-timeline__title').first()).toContainText('Note')
 }
 
-export const viewApplicationFromPrisonDashboard = async (applicationId: string, page: Page) => {
+export const goToPrisonDashboard = async (page: Page) => {
   await page.goto(`/applications/prison`)
-  await page.locator(`a[href="/applications/${applicationId}/overview"]`).click()
+}
+
+export const checkAnApplicationByUserExists = async (page: Page, name: string) => {
+  const tableRows = page.locator('.govuk-table__row')
+  expect(tableRows.filter({ hasText: name }).first()).toBeVisible()
+}
+
+export const viewApplicationMadeByAnotherUser = async (page: Page, name: string) => {
+  const tableRows = page.locator('.govuk-table__row')
+  const rowWithOtherUser = tableRows.filter({ hasNotText: name }).last()
+  await rowWithOtherUser.getByRole('link').click()
   await expect(page.locator('h2').first()).toContainText('Application history')
 }

--- a/e2e-tests/test.ts
+++ b/e2e-tests/test.ts
@@ -21,7 +21,7 @@ export const test = base.extend<TestOptions>({
   ],
   pomUser: [
     {
-      name: 'CAS2 Pom E2ETester',
+      name: 'Cas-two Test-user',
       username: process.env.CAS2_HMPPS_AUTH_USERNAME as string,
       password: process.env.CAS2_HMPPS_AUTH_PASSWORD as string,
     },
@@ -29,7 +29,7 @@ export const test = base.extend<TestOptions>({
   ],
   lcaUser: [
     {
-      name: 'CAS2 Licence CA E2ETester',
+      name: 'Licence Case-admin',
       username: process.env.CAS2_LCA_USERNAME as string,
       password: process.env.CAS2_LCA_PASSWORD as string,
     },

--- a/e2e-tests/tests/01_apply_as_pom.spec.ts
+++ b/e2e-tests/tests/01_apply_as_pom.spec.ts
@@ -13,8 +13,10 @@ import {
   submitApplication,
   viewSubmittedApplication,
   addNote,
-  viewApplicationFromPrisonDashboard,
+  viewApplicationMadeByAnotherUser,
   enterOldOasysDates,
+  goToPrisonDashboard,
+  checkAnApplicationByUserExists,
 } from '../steps/apply'
 import { signIn } from '../steps/signIn'
 
@@ -44,9 +46,10 @@ test(`add a note to a submitted application created by another user within user'
   page,
   pomUser,
 }) => {
-  const SEEDED_APPLICATION_ID = 'edd787eb-31a3-4fad-a473-9cf8969f1487'
   await signIn(page, pomUser)
-  await viewApplicationFromPrisonDashboard(SEEDED_APPLICATION_ID, page)
+  await goToPrisonDashboard(page)
+  await checkAnApplicationByUserExists(page, pomUser.name)
+  await viewApplicationMadeByAnotherUser(page, pomUser.name)
   await addNote(page)
 })
 

--- a/e2e-tests/tests/02_apply_as_lca.spec.ts
+++ b/e2e-tests/tests/02_apply_as_lca.spec.ts
@@ -13,7 +13,9 @@ import {
   submitApplication,
   viewSubmittedApplication,
   addNote,
-  viewApplicationFromPrisonDashboard,
+  viewApplicationMadeByAnotherUser,
+  goToPrisonDashboard,
+  checkAnApplicationByUserExists,
 } from '../steps/apply'
 import { signIn } from '../steps/signIn'
 
@@ -43,8 +45,9 @@ test(`add a note to a submitted application created by another user within user'
   page,
   lcaUser,
 }) => {
-  const SEEDED_APPLICATION_ID = 'edd787eb-31a3-4fad-a473-9cf8969f1487'
   await signIn(page, lcaUser)
-  await viewApplicationFromPrisonDashboard(SEEDED_APPLICATION_ID, page)
+  await goToPrisonDashboard(page)
+  await checkAnApplicationByUserExists(page, lcaUser.name)
+  await viewApplicationMadeByAnotherUser(page, lcaUser.name)
   await addNote(page)
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig<TestOptions>({
       use: {
         baseURL: 'http://localhost:3000',
         pomUser: {
-          name: 'Pom User',
+          name: 'Prison Officer',
           username: 'POM_USER',
           password: 'password123456',
         },
@@ -73,12 +73,12 @@ export default defineConfig<TestOptions>({
           nomsNumber: 'A5671YZ',
         },
         pomUser: {
-          name: 'Pom User',
+          name: 'Prison Officer',
           username: 'POM_USER',
           password: 'password123456',
         },
         lcaUser: {
-          name: 'LCA User',
+          name: 'Licence Case-Admin',
           username: 'CAS2_LICENCE_USER',
           password: 'password123456',
         },


### PR DESCRIPTION
We need to test that our POM and LCA users can view and
add notes to applications on their prison dashboard.

Previously we hardcoded the application ID to be used locally
and in dev environment, because we had a standard
prison for our users across both environments.

Since we now are restricting users to only create applications
for offenders within their own prison, we have discovered that
the example offenders in dev and local have different prisons (LEI for local,
MDI for dev). [1] So our local and dev test users do not have the same prison
any more, and that hardcoded UUID no longer works.

In this commit we use the user's name to find an application by any user
that is not them, thus removing the need for a hardcoded id.

This has the added benefit that it's agnostic to what the seeded data is,
and when [we introduce pagination we don't care what page we are on.](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/666)

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1879
