### PR TITLE
Fix bug on disability page

### DIFF
--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.test.ts
@@ -158,6 +158,18 @@ describe('Disability', () => {
         otherDisability: 'Enter the other disability',
       })
     })
+
+    it('should not return errors when user has selected other disability but then selects no to hasDisability', () => {
+      const page = new Disability(
+        {
+          hasDisability: 'no',
+          typeOfDisability: ['other'],
+        },
+        application,
+      )
+
+      expect(page.errors()).toEqual({})
+    })
   })
 
   describe('onSave', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/disability.ts
@@ -63,7 +63,11 @@ export default class Disability implements TaskListPage {
     if (this.body.hasDisability === 'yes' && !this.body.typeOfDisability) {
       errors.typeOfDisability = errorLookups.hasDisability.typeOfDisability
     }
-    if (this.body.typeOfDisability?.includes('other') && !this.body.otherDisability) {
+    if (
+      this.body.hasDisability === 'yes' &&
+      this.body.typeOfDisability?.includes('other') &&
+      !this.body.otherDisability
+    ) {
       errors.otherDisability = errorLookups.hasDisability.otherDisability
     }
     return errors


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-76

# Changes in this PR

Fixes bug that was causing the page to error when the user selected 'yes' and then 'other' disability, without entering anything in the free text field, and then changed the top level answer to 'no'.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
