### PR TITLE
Fix back links from religion page

### DIFF
--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.test.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.test.ts
@@ -14,7 +14,30 @@ describe('Religion', () => {
   })
 
   itShouldHaveNextValue(new Religion({}, application), 'military-veteran')
-  itShouldHavePreviousValue(new Religion({}, application), 'ethnic-group')
+  itShouldHavePreviousValue(
+    new Religion(
+      {},
+      { ...application, data: { 'equality-and-diversity-monitoring': { 'ethnic-group': { ethnicGroup: 'white' } } } },
+    ),
+    'white-background',
+  )
+  itShouldHavePreviousValue(
+    new Religion(
+      {},
+      { ...application, data: { 'equality-and-diversity-monitoring': { 'ethnic-group': { ethnicGroup: 'asian' } } } },
+    ),
+    'asian-background',
+  )
+  itShouldHavePreviousValue(
+    new Religion(
+      {},
+      {
+        ...application,
+        data: { 'equality-and-diversity-monitoring': { 'ethnic-group': { ethnicGroup: 'preferNotToSay' } } },
+      },
+    ),
+    'ethnic-group',
+  )
 
   describe('items', () => {
     it('returns the radio with the expected label text', () => {

--- a/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.ts
+++ b/server/form-pages/apply/about-the-person/equality-diversity-monitoring/religion.ts
@@ -39,7 +39,20 @@ export default class Religion implements TaskListPage {
   }
 
   previous() {
-    return 'ethnic-group'
+    switch (this.application.data?.['equality-and-diversity-monitoring']?.['ethnic-group']?.ethnicGroup) {
+      case 'white':
+        return 'white-background'
+      case 'mixed':
+        return 'mixed-background'
+      case 'asian':
+        return 'asian-background'
+      case 'black':
+        return 'black-background'
+      case 'other':
+        return 'other-background'
+      default:
+        return 'ethnic-group'
+    }
   }
 
   next() {


### PR DESCRIPTION
This ensures that the back button will direct the user back to the correct ethnic background page, depending on the answer they have given.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CAS2-343

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
