### PR TITLE
Add date validation on old oasys form pages

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.test.ts
@@ -1,6 +1,16 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
 import OldOasys from './oldOasys'
+import { dateAndTimeInputsAreValidDates, dateIsComplete } from '../../../../utils/dateUtils'
+
+jest.mock('../../../../utils/dateUtils', () => {
+  const actual = jest.requireActual('../../../../utils/dateUtils')
+  return {
+    ...actual,
+    dateAndTimeInputsAreValidDates: jest.fn(),
+    dateIsComplete: jest.fn(),
+  }
+})
 
 describe('OldOasys', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -23,10 +33,26 @@ describe('OldOasys', () => {
         hasOldOasys: 'Confirm whether they have an older OASys with risk of serious harm (RoSH) information',
       })
     })
-    it('returns an error when hasOldOasys is yes but oasysCompletedDate is blank', () => {
-      const page = new OldOasys({ hasOldOasys: 'yes' }, application)
-      expect(page.errors()).toEqual({
-        oasysCompletedDate: 'Enter the date the OASys was completed',
+    describe('when hasOldOasys is yes', () => {
+      it('returns an error when oasysCompletedDate is blank', () => {
+        const page = new OldOasys({ hasOldOasys: 'yes' }, application)
+        expect(page.errors()).toEqual({
+          oasysCompletedDate: 'Enter the date the OASys was completed',
+        })
+      })
+
+      describe('when the date is not valid', () => {
+        beforeEach(() => {
+          jest.resetAllMocks()
+          ;(dateAndTimeInputsAreValidDates as jest.Mock).mockImplementation(() => false)
+          ;(dateIsComplete as jest.Mock).mockImplementation(() => true)
+        })
+        it('returns an error', () => {
+          const page = new OldOasys({ hasOldOasys: 'yes' }, application)
+          expect(page.errors()).toEqual({
+            oasysCompletedDate: 'OASys completed date must be a real date',
+          })
+        })
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { dateBodyProperties } from '../../../utils'
 import { getQuestions } from '../../../utils/questions'
-import { DateFormats, dateIsComplete } from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsComplete } from '../../../../utils/dateUtils'
 
 type OldOasysBody = {
   hasOldOasys: YesOrNo
@@ -59,8 +59,15 @@ export default class OldOasys implements TaskListPage {
     if (!this.body.hasOldOasys) {
       errors.hasOldOasys = 'Confirm whether they have an older OASys with risk of serious harm (RoSH) information'
     }
-    if (this.body.hasOldOasys === 'yes' && !dateIsComplete(this.body, 'oasysCompletedDate')) {
-      errors.oasysCompletedDate = 'Enter the date the OASys was completed'
+    if (this.body.hasOldOasys === 'yes') {
+      if (!dateIsComplete(this.body, 'oasysCompletedDate')) {
+        errors.oasysCompletedDate = 'Enter the date the OASys was completed'
+        return errors
+      }
+
+      if (!dateAndTimeInputsAreValidDates(this.body, 'oasysCompletedDate')) {
+        errors.oasysCompletedDate = 'OASys completed date must be a real date'
+      }
     }
 
     return errors

--- a/server/form-pages/apply/risks-and-needs/risk-to-self/oldOasys.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-to-self/oldOasys.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { dateBodyProperties } from '../../../utils'
 import { getQuestions } from '../../../utils/questions'
-import { DateFormats, dateIsComplete } from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsComplete } from '../../../../utils/dateUtils'
 
 type OldOasysBody = {
   hasOldOasys: YesOrNo
@@ -59,8 +59,14 @@ export default class OldOasys implements TaskListPage {
     if (!this.body.hasOldOasys) {
       errors.hasOldOasys = 'Confirm whether they have an older OASys with risk to self information'
     }
-    if (this.body.hasOldOasys === 'yes' && !dateIsComplete(this.body, 'oasysCompletedDate')) {
-      errors.oasysCompletedDate = 'Enter the date the OASys was completed'
+    if (this.body.hasOldOasys === 'yes') {
+      if (!dateIsComplete(this.body, 'oasysCompletedDate')) {
+        errors.oasysCompletedDate = 'Enter the date the OASys was completed'
+        return errors
+      }
+      if (!dateAndTimeInputsAreValidDates(this.body, 'oasysCompletedDate')) {
+        errors.oasysCompletedDate = 'OASys completed date must be a real date'
+      }
     }
 
     return errors


### PR DESCRIPTION
This was previously omitted, causing a bug for users.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
