### PR TITLE
Use offender details with prison for 'no oasys' e2e

### DIFF
--- a/e2e-tests/test.ts
+++ b/e2e-tests/test.ts
@@ -13,9 +13,9 @@ export const test = base.extend<TestOptions>({
   ],
   personWithoutOasys: [
     {
-      name: 'Al Kozey',
-      crn: 'X698318',
-      nomsNumber: 'A5297DZ',
+      name: 'Leslie Fahey',
+      crn: 'X698232',
+      nomsNumber: 'A5275DZ',
     },
     { option: true },
   ],


### PR DESCRIPTION
For the dev environment tests. The previous details were for an offender with no
prison info [1] Now that we are checking the
offender's prison [2] this prison data is required to proceed.

[1] https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4467949648/CRNs+for+Testing+in+Development+Environment
[2] https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1877

Can be tested on the dev environment by using this noms number to create an application.
