### PR TITLE
Cas2 327 repoint notes to assessments part 2

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -103,11 +103,11 @@ export default {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       },
     }),
-  stubAddNote: (args: { applicationId: string; note: ApplicationNote }): SuperAgentRequest =>
+  stubAddNote: (args: { assessmentId: string; note: ApplicationNote }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
-        url: paths.submissions.applicationNotes.create({ id: args.applicationId }),
+        url: paths.assessments.applicationNotes.create({ id: args.assessmentId }),
       },
       response: {
         status: 201,
@@ -115,11 +115,11 @@ export default {
         jsonBody: args.note,
       },
     }),
-  stubAddNoteBadRequest: (args: { applicationId: string }): SuperAgentRequest =>
+  stubAddNoteBadRequest: (args: { assessmentId: string }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
-        url: paths.submissions.applicationNotes.create({ id: args.applicationId }),
+        url: paths.assessments.applicationNotes.create({ id: args.assessmentId }),
       },
       response: {
         status: 400,

--- a/integration_tests/tests/apply/submitted_applications/add_an_application_note.cy.ts
+++ b/integration_tests/tests/apply/submitted_applications/add_an_application_note.cy.ts
@@ -17,7 +17,7 @@
 //    Then I see an error message
 
 import SubmittedApplicationOverviewPage from '../../../pages/apply/submittedApplicationOverviewPage'
-import { applicationFactory, applicationNoteFactory } from '../../../../server/testutils/factories'
+import { applicationFactory, applicationNoteFactory, assessmentFactory } from '../../../../server/testutils/factories'
 import { fullPersonFactory } from '../../../../server/testutils/factories/person'
 import Page from '../../../pages/page'
 
@@ -38,6 +38,7 @@ context('Referrer adds a note to a submitted application', () => {
           submittedAt: '2022-12-10T21:47:28Z',
           person: fullPersonFactory.build({ name: 'Robert Smith' }),
           telephoneNumber: '0800 123',
+          assessment: assessmentFactory.build(),
         })
         cy.wrap(submittedApplication).as('application')
       })
@@ -58,7 +59,7 @@ context('Referrer adds a note to a submitted application', () => {
     //  And I add a note
     const note = applicationNoteFactory.build()
     const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, this.application)
-    cy.task('stubAddNote', { applicationId: this.application.id, note })
+    cy.task('stubAddNote', { assessmentId: this.application.assessment.id, note })
     page.addANote()
 
     //  Then I see a success message
@@ -69,7 +70,7 @@ context('Referrer adds a note to a submitted application', () => {
   it('shows an error message', function test() {
     //  And I add a note
     const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, this.application)
-    cy.task('stubAddNoteBadRequest', { applicationId: this.application.id })
+    cy.task('stubAddNoteBadRequest', { assessmentId: this.application.assessment.id })
     page.addANote()
 
     //   Then I see an error message

--- a/integration_tests/tests/assess/add_an_application_note.cy.ts
+++ b/integration_tests/tests/assess/add_an_application_note.cy.ts
@@ -45,7 +45,7 @@ context('Assessor adds a note to a submitted application', () => {
     //  And I add a note
     const note = applicationNoteFactory.build()
     const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, submittedApplication)
-    cy.task('stubAddNote', { applicationId: submittedApplication.id, note })
+    cy.task('stubAddNote', { assessmentId: submittedApplication.assessment.id, note })
     page.addANote()
 
     //  Then I see a success message
@@ -56,7 +56,7 @@ context('Assessor adds a note to a submitted application', () => {
   it('shows an error message', function test() {
     //  And I add a note
     const page = Page.verifyOnPage(SubmittedApplicationOverviewPage, submittedApplication)
-    cy.task('stubAddNoteBadRequest', { applicationId: submittedApplication.id })
+    cy.task('stubAddNoteBadRequest', { assessmentId: submittedApplication.assessment.id })
     page.addANote()
 
     //   Then I see an error message

--- a/server/@types/shared/models/MigrationJobType.ts
+++ b/server/@types/shared/models/MigrationJobType.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type MigrationJobType = 'update_all_users_from_community_api' | 'update_sentence_type_and_situation' | 'update_booking_status' | 'update_application_ap_areas' | 'update_task_due_dates' | 'update_cas2_applications_with_assessments' | 'update_cas2_status_updates_with_assessments' | 'update_cas1_user_details' | 'update_cas1_fix_placement_app_links' | 'update_cas1_notice_types' | 'update_cas1_backfill_user_ap_area' | 'update_cas3_application_offender_name' | 'update_cas3_users_pdu_from_community_api';
+export type MigrationJobType = 'update_all_users_from_community_api' | 'update_sentence_type_and_situation' | 'update_booking_status' | 'update_application_ap_areas' | 'update_task_due_dates' | 'update_cas2_applications_with_assessments' | 'update_cas2_status_updates_with_assessments' | 'update_cas2_notes_with_assessments' | 'update_cas1_user_details' | 'update_cas1_fix_placement_app_links' | 'update_cas1_notice_types' | 'update_cas1_backfill_user_ap_area' | 'update_cas3_application_offender_name' | 'update_cas3_users_pdu_from_community_api';

--- a/server/@types/shared/models/SituationOption.ts
+++ b/server/@types/shared/models/SituationOption.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type SituationOption = 'riskManagement' | 'residencyManagement' | 'bailAssessment' | 'bailSentence';
+export type SituationOption = 'riskManagement' | 'residencyManagement' | 'bailAssessment' | 'bailSentence' | 'awaitingSentence';

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -640,6 +640,11 @@ describe('applicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const note = applicationNoteFactory.build()
@@ -650,7 +655,7 @@ describe('applicationsController', () => {
         await requestHandler(request, response)
 
         expect(request.flash).toHaveBeenCalledWith('success', 'Your note was saved.')
-        expect(response.redirect).toHaveBeenCalledWith(paths.applications.overview({ id: 'abc123' }))
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.overview({ id: 'application-id' }))
       })
     })
 
@@ -659,6 +664,11 @@ describe('applicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const err = new Error()
@@ -672,7 +682,7 @@ describe('applicationsController', () => {
           request,
           response,
           err,
-          paths.applications.overview({ id: 'abc123' }),
+          paths.applications.overview({ id: 'application-id' }),
         )
       })
     })
@@ -682,6 +692,11 @@ describe('applicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const err = { data: {}, status: 400 }
@@ -695,7 +710,7 @@ describe('applicationsController', () => {
         expect(request.flash).toHaveBeenCalledWith('errors', {
           note: { text: 'Enter a note for the assessor' },
         })
-        expect(response.redirect).toHaveBeenCalledWith(paths.applications.overview({ id: 'abc123' }))
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.overview({ id: 'application-id' }))
       })
     })
   })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -264,21 +264,22 @@ export default class ApplicationsController {
   addNote() {
     return async (req: Request, res: Response) => {
       const { id } = req.params
+      const { applicationId } = req.query as { applicationId: string }
       const { note } = req.body
 
       try {
         await this.submittedApplicationService.addApplicationNote(req.user.token, id, note)
         req.flash('success', 'Your note was saved.')
-        res.redirect(paths.applications.overview({ id }))
+        res.redirect(paths.applications.overview({ id: applicationId }))
       } catch (err) {
         if (err.status === 400) {
           req.flash('errors', {
             note: { text: 'Enter a note for the assessor' },
           })
           req.flash('errorSummary', [{ text: 'Enter a note for the assessor', href: '#note' }])
-          res.redirect(paths.applications.overview({ id }))
+          res.redirect(paths.applications.overview({ id: applicationId }))
         } else {
-          catchValidationErrorOrPropogate(req, res, err, paths.applications.overview({ id }))
+          catchValidationErrorOrPropogate(req, res, err, paths.applications.overview({ id: applicationId }))
         }
       }
     }

--- a/server/controllers/assess/submittedApplicationsController.test.ts
+++ b/server/controllers/assess/submittedApplicationsController.test.ts
@@ -164,6 +164,11 @@ describe('submittedApplicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const note = applicationNoteFactory.build()
@@ -174,7 +179,7 @@ describe('submittedApplicationsController', () => {
         await requestHandler(request, response)
 
         expect(request.flash).toHaveBeenCalledWith('success', 'Your note was saved.')
-        expect(response.redirect).toHaveBeenCalledWith(paths.submittedApplications.overview({ id: 'abc123' }))
+        expect(response.redirect).toHaveBeenCalledWith(paths.submittedApplications.overview({ id: 'application-id' }))
       })
     })
 
@@ -183,6 +188,11 @@ describe('submittedApplicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const err = { data: {}, status: 400 }
@@ -196,7 +206,7 @@ describe('submittedApplicationsController', () => {
         expect(request.flash).toHaveBeenCalledWith('errors', {
           note: { text: 'Enter a note for the referrer' },
         })
-        expect(response.redirect).toHaveBeenCalledWith(paths.submittedApplications.overview({ id: 'abc123' }))
+        expect(response.redirect).toHaveBeenCalledWith(paths.submittedApplications.overview({ id: 'application-id' }))
       })
     })
 
@@ -205,6 +215,11 @@ describe('submittedApplicationsController', () => {
         request.params = {
           id: 'abc123',
         }
+
+        request.query = {
+          applicationId: 'application-id',
+        }
+
         request.body = { note: 'some notes' }
 
         const err = new Error()
@@ -218,7 +233,7 @@ describe('submittedApplicationsController', () => {
           request,
           response,
           err,
-          paths.submittedApplications.overview({ id: 'abc123' }),
+          paths.submittedApplications.overview({ id: 'application-id' }),
         )
       })
     })

--- a/server/controllers/assess/submittedApplicationsController.ts
+++ b/server/controllers/assess/submittedApplicationsController.ts
@@ -61,21 +61,27 @@ export default class SubmittedApplicationsController {
   addNote() {
     return async (req: Request, res: Response) => {
       const { id } = req.params
+      const { applicationId } = req.query as { applicationId: string }
       const { note } = req.body
 
       try {
         await this.submittedApplicationService.addApplicationNote(req.user.token, id, note)
         req.flash('success', 'Your note was saved.')
-        res.redirect(assessPaths.submittedApplications.overview({ id }))
+        res.redirect(assessPaths.submittedApplications.overview({ id: applicationId }))
       } catch (err) {
         if (err.status === 400) {
           req.flash('errors', {
             note: { text: 'Enter a note for the referrer' },
           })
           req.flash('errorSummary', [{ text: 'Enter a note for the referrer', href: '#note' }])
-          res.redirect(assessPaths.submittedApplications.overview({ id }))
+          res.redirect(assessPaths.submittedApplications.overview({ id: applicationId }))
         } else {
-          catchValidationErrorOrPropogate(req, res, err, assessPaths.submittedApplications.overview({ id }))
+          catchValidationErrorOrPropogate(
+            req,
+            res,
+            err,
+            assessPaths.submittedApplications.overview({ id: applicationId }),
+          )
         }
       }
     }

--- a/server/data/submittedApplicationClient.test.ts
+++ b/server/data/submittedApplicationClient.test.ts
@@ -90,7 +90,7 @@ describeClient('SubmittedApplicationClient', provider => {
         uponReceiving: 'A request to add a note to an application',
         withRequest: {
           method: 'POST',
-          path: paths.submissions.applicationNotes.create({ id: application.id }),
+          path: paths.assessments.applicationNotes.create({ id: application.id }),
           body,
           headers: {
             authorization: `Bearer ${token}`,

--- a/server/data/submittedApplicationClient.ts
+++ b/server/data/submittedApplicationClient.ts
@@ -29,9 +29,9 @@ export default class SubmittedApplicationClient {
     })) as SubmittedApplication
   }
 
-  async addNote(applicationId: string, newNote: string): Promise<Cas2ApplicationNote> {
+  async addNote(assessmentId: string, newNote: string): Promise<Cas2ApplicationNote> {
     return (await this.restClient.post({
-      path: paths.submissions.applicationNotes.create({ id: applicationId }),
+      path: paths.assessments.applicationNotes.create({ id: assessmentId }),
       data: { note: newNote },
     })) as Cas2ApplicationNote
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -28,9 +28,6 @@ export default {
     index: submissionsPath,
     create: submissionsPath,
     show: singleSubmissionPath,
-    applicationNotes: {
-      create: singleSubmissionPath.path('notes'),
-    },
   },
   applications: {
     new: applicationsPath,
@@ -41,7 +38,7 @@ export default {
   assessments: {
     show: singleAssessmentPath,
     update: singleAssessmentPath,
-    assessmentNotes: {
+    applicationNotes: {
       create: singleAssessmentPath.path('notes'),
     },
   },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -41,6 +41,9 @@ export default {
   assessments: {
     show: singleAssessmentPath,
     update: singleAssessmentPath,
+    assessmentNotes: {
+      create: singleAssessmentPath.path('notes'),
+    },
   },
   referenceData: {
     applicationStatuses: referenceDataPath.path('application-status'),

--- a/server/views/applications/overview.njk
+++ b/server/views/applications/overview.njk
@@ -54,7 +54,7 @@
         Application history
       </h2>
 
-      <form action="{{ paths.applications.addNote({ id: application.id }) }}" method="post">
+      <form action="{{ paths.applications.addNote({ id: application.assessment.id }) }}?applicationId={{application.id}}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukTextarea({

--- a/server/views/assess/applications/overview.njk
+++ b/server/views/assess/applications/overview.njk
@@ -112,7 +112,7 @@ printButtonScript %}
         Application history
       </h2>
 
-      <form action="{{ paths.submittedApplications.addNote({ id: application.id }) }}" method="post">
+      <form action="{{ paths.submittedApplications.addNote({ id: application.assessment.id }) }}?applicationId={{application.id}}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukTextarea({


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This is the second part of the work to repoint notes to assessments and is described in more detail here:

https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4897341539/Associate+Application+Notes+with+Assessments+CAS2-327

The work is to change the front end to use the `/assessments/{assessmentId}/notes` endpoint instead of the `/submissions/{applicationId}/notes` endpoint.

1. Update types.
2. Add path to add note via assessments.
3. Update views to pass assessment and application ids. 
4. Change api path to use /assessments/{assessmentId}/notes. 
5. Update client to use new assessments endpoint. 
6. Update addNote() for apply route to use assessmentId. 
7. Update addNote() for assess route to use assessmentId. 
8. Update integration tests in accordance with updated addNote(). 

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
