### PR TITLE
Chore/check your answers uses safe page keys

### DIFF
--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -767,19 +767,27 @@ describe('getPage', () => {
   })
 
   describe('removeAnyOldPageKeys', () => {
-    it('should remove any task keys that appear in the application but are no longer part of the latest set of questions', () => {
+    it('should remove any page keys that appear in the application but are no longer part of the latest set of questions', () => {
       const questions = {
         task1: {
           page1: { question1: { question: 'A question', answers: { yes: 'Yes', no: 'No' } } },
           page2: { question2: { question: 'Another question' } },
         },
       } as unknown as Questions
-
       const applicationPageKeys = ['page1', 'page2', 'oldPageKey']
-
       const expected = ['page1', 'page2']
-
       expect(removeAnyOldPageKeys(questions, 'task1', applicationPageKeys)).toEqual(expected)
     })
+  })
+  it('should retain ACCT, current offences and historic offences even where they do not appear in the question schema', () => {
+    const questions = {
+      task1: {
+        page1: { question1: { question: 'A question', answers: { yes: 'Yes', no: 'No' } } },
+        page2: { question2: { question: 'Another question' } },
+      },
+    } as unknown as Questions
+    const applicationPageKeys = ['page1', 'page2', 'oldPageKey', 'acct', 'current-offences', 'offence-history']
+    const expected = ['page1', 'page2', 'acct', 'current-offences', 'offence-history']
+    expect(removeAnyOldPageKeys(questions, 'task1', applicationPageKeys)).toEqual(expected)
   })
 })

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -1,12 +1,12 @@
 import { SummaryListItem } from '@approved-premises/ui'
-import { applicationFactory, personFactory } from '../testutils/factories'
-import * as checkYourAnswersUtils from './checkYourAnswersUtils'
-import * as getQuestionsUtil from '../form-pages/utils/questions'
-import { formatLines } from './viewUtils'
 import applicationData from '../../integration_tests/fixtures/applicationData.json'
 import Apply from '../form-pages/apply'
-import { UnknownPageError } from './errors'
+import * as getQuestionsUtil from '../form-pages/utils/questions'
+import { applicationFactory, personFactory } from '../testutils/factories'
+import * as checkYourAnswersUtils from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
+import { UnknownPageError } from './errors'
+import { formatLines } from './viewUtils'
 
 jest.mock('./formUtils')
 jest.mock('./viewUtils')
@@ -20,7 +20,7 @@ const {
   checkYourAnswersSections,
   getSections,
   getPage,
-  getPages,
+  getKeysForPages,
   getApplicantDetails,
 } = checkYourAnswersUtils
 
@@ -522,9 +522,9 @@ describe('checkYourAnswersUtils', () => {
     })
   })
 
-  describe('getPages', () => {
-    it('returns an array of page keys without oasys-import for risk to self', () => {
-      expect(getPages(application, 'risk-to-self')).toEqual([
+  describe('getKeysForPages', () => {
+    it('returns an array of page keys for risk to self', () => {
+      expect(getKeysForPages(application, 'risk-to-self')).toEqual([
         'current-risk',
         'vulnerability',
         'historical-risk',

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -299,10 +299,11 @@ export const getApplicantDetails = (application: Application | Cas2SubmittedAppl
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const removeAnyOldPageKeys = (questions: any, task: string, applicationPageKeys: string[]): string[] => {
   const latestPageKeys = Object.keys(questions[task])
-  const matchedKeys = latestPageKeys.filter(key => applicationPageKeys.includes(key))
+  const matchedKeys = applicationPageKeys.filter(
+    key => latestPageKeys.includes(key) || ['acct', 'current-offences', 'offence-history'].includes(key),
+  )
   return matchedKeys
 }
-
 const pagesWeNeverWantToPresent = (key: string): boolean => {
   return ['summary-data', 'oasys-import'].includes(key)
 }

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -38,7 +38,7 @@ export const getTaskAnswersAsSummaryListItems = (
 
   const questions = getQuestions(nameOrPlaceholderCopy(application.person))
 
-  const pagesKeys = getPages(application, task)
+  const pagesKeys = getKeysForPages(application, task)
 
   pagesKeys.forEach(pageKey => {
     if (!['behaviour-notes', 'behaviour-notes-data', 'reducing-risk'].includes(pageKey)) {
@@ -173,7 +173,7 @@ export const getSections = (): Array<FormSection> => {
   return sections.filter(section => section.name !== CheckYourAnswers.name)
 }
 
-export const getPages = (application: Application, task: string) => {
+export const getKeysForPages = (application: Application, task: string) => {
   const pagesWithoutQuestions = ['summary-data', 'oasys-import']
   const pages = application.data[task]
 


### PR DESCRIPTION
This is a proposal to make removing a task from the application more robust. We've run out of time to release this and so need to hand it over.

# Context

[We experienced a production error after removing removing a section from the question form](https://mojdt.slack.com/archives/C05FN6Y2CSV/p1716972264605899). They already had a referral in progress when we released a change to remove a task from the journey, they were then unable to render their check your answers page. We released a fix the user was able to get their existing in progress referral through to submission. 

This would have affected every in progress referral so the potential impact of this bug was much more than 1 user.

This case highlights a fragility in the question framework. When we want to remove a task we have to remember [to hard code that page key into a list of questions to avoid](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/60554b22eec1f11d2735d551d95356156bf11415/server/utils/checkYourAnswersUtils.ts#L44). This is easily forgotten as this case demonstrates.

```typescript
pagesKeys.forEach(pageKey => {
    if (!['behaviour-notes', 'behaviour-notes-data', 'reducing-risk'].includes(pageKey)) {
      addPageAnswersToItemsArray({
        items,
        application,
        task,
        pageKey,
        questions,
        outputFormat,
      })
    }
  })
```

N.B when a _question_ is removed, as opposed to a _task_ [this logic is currently protecting us dynamically](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/blob/60554b22eec1f11d2735d551d95356156bf11415/server/utils/checkYourAnswersUtils.ts#L93).

As a way to improve this we had the idea to dynamically check the latest tasks against the content of the application. When we find a tasks that were present on creation but are no longer supporter we automatically ignore them.

The remaining tasks are to make sure the unit tests for checkYourAnswers are updated to cover this change in design.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
