### PR TITLE
Fix risk to self E2E test

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -113,7 +113,7 @@ export const completeRiskToSelfTask = async (page: Page, name: string) => {
   await completeCurrentRisksPage(page, name)
   await completeHistoricalRisksPage(page, name)
   await addAnAcct(page)
-  await completeAdditionalInformationPage(page)
+  await completeAdditionalInformationPage(page, name)
 }
 
 export const enterOldRiskToSelfOasysDate = async (page: Page, name: string) => {
@@ -190,8 +190,11 @@ async function completeAcctDataPage(page: Page) {
   await acctDataPage.clickButton('Save and add ACCT')
 }
 
-async function completeAdditionalInformationPage(page: Page) {
-  const additionalInformationPage = await ApplyPage.initialize(page, 'Additional Information')
+async function completeAdditionalInformationPage(page: Page, name: string) {
+  const additionalInformationPage = await ApplyPage.initialize(
+    page,
+    `Is there anything else to include about ${name}'s risk to self?`,
+  )
   await additionalInformationPage.checkRadio('No')
   await additionalInformationPage.clickSave()
 }


### PR DESCRIPTION
After updating the risk to self task, the h1 for the ‘additional information’ page has changed.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
