### PR TITLE
CAS2: Fix cancel application e2e's

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -28,6 +28,7 @@ import {
   completeOffenceHistoryTask,
 } from './offenceAndLicenceInformationSection'
 import { completeCheckAnswersTask } from './checkAnswersSection'
+import { TestOptions } from '../testOptions'
 
 export const startAnApplication = async (page: Page) => {
   // Start page
@@ -135,4 +136,10 @@ export const viewApplicationMadeByAnotherUser = async (page: Page, name: string)
   const rowWithOtherUser = tableRows.filter({ hasNotText: name }).last()
   await rowWithOtherUser.getByRole('link').click()
   await expect(page.locator('h2').first()).toContainText('Application history')
+}
+
+export const createAnInProgressApplication = async (page: Page, person: TestOptions['person']) => {
+  await startAnApplication(page)
+  await enterPrisonerNumber(page, person.nomsNumber)
+  await confirmApplicant(page)
 }

--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -52,7 +52,7 @@ export const enterPrisonerNumber = async (page: Page, prisonNumber: string) => {
 
 export const confirmApplicant = async (page: Page) => {
   const confirmApplicantPage = new TaskListPage(page)
-  confirmApplicantPage.clickButton('Confirm and continue')
+  await confirmApplicantPage.clickButton('Confirm and continue')
 }
 
 export const completeBeforeYouStartSection = async (page: Page, name: string) => {

--- a/e2e-tests/steps/cancelInProgressApplication.ts
+++ b/e2e-tests/steps/cancelInProgressApplication.ts
@@ -7,6 +7,8 @@ export const cancelAnApplication = async (page: Page, name: string) => {
   await cancelPage.clickButton('Confirm')
 }
 
-export const clickCancel = async (page: Page) => {
-  await page.getByRole('link', { name: 'Cancel' }).last().click()
+export const clickCancel = async (page: Page, name: string) => {
+  const tableRows = page.locator('.govuk-table__row')
+  const rowWithPersonIn = tableRows.filter({ hasText: name }).first()
+  await rowWithPersonIn.getByRole('link', { name: 'Cancel' }).click()
 }

--- a/e2e-tests/tests/01_apply_as_pom.spec.ts
+++ b/e2e-tests/tests/01_apply_as_pom.spec.ts
@@ -66,9 +66,12 @@ test('create a CAS-2 application with no OASys', async ({ page, personWithoutOas
 
 test('cancel an in progress application from the task list', async ({ page, pomUser, person }) => {
   await signIn(page, pomUser)
+  await startAnApplication(page)
+  await enterPrisonerNumber(page, person.nomsNumber)
+  await confirmApplicant(page)
   await viewInProgressDashboard(page)
   const numberOfApplicationsBeforeCancellation = (await page.locator('tr').all()).length
-  await clickCancel(page)
+  await clickCancel(page, person.name)
   await cancelAnApplication(page, person.name)
   const numberOfApplicationsAfterCancellation = (await page.locator('tr').all()).length
   await expect(page.getByText('Your CAS-2 applications')).toBeVisible()

--- a/e2e-tests/tests/01_apply_as_pom.spec.ts
+++ b/e2e-tests/tests/01_apply_as_pom.spec.ts
@@ -18,6 +18,7 @@ import {
   goToPrisonDashboard,
   checkAnApplicationByUserExists,
   viewInProgressDashboard,
+  createAnInProgressApplication,
 } from '../steps/apply'
 import { signIn } from '../steps/signIn'
 import { cancelAnApplication, clickCancel } from '../steps/cancelInProgressApplication'
@@ -66,9 +67,7 @@ test('create a CAS-2 application with no OASys', async ({ page, personWithoutOas
 
 test('cancel an in progress application from the task list', async ({ page, pomUser, person }) => {
   await signIn(page, pomUser)
-  await startAnApplication(page)
-  await enterPrisonerNumber(page, person.nomsNumber)
-  await confirmApplicant(page)
+  await createAnInProgressApplication(page, person)
   await viewInProgressDashboard(page)
   const numberOfApplicationsBeforeCancellation = (await page.locator('tr').all()).length
   await clickCancel(page, person.name)


### PR DESCRIPTION
# Changes in this PR

This fixes currently failing e2es on the dev environment for cancelling an Application. 

Previously this test just chose the last in progress application to cancel, by looking for the last `Cancel` anchor tag.

This meant that depending on the state of applications in the database the name of the person on the application could have been anything, and we need to assert that the page is showing the applicant's name in the header.

This changes the test to create an in progress application for our standard person, to ensure there will always be a most recent application for that person first in the list, and then selects that application row to cancel it.


## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
