### PR TITLE
CAS-401: CAS2 ip ranges updates

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -56,9 +56,8 @@ generic-service:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
 
-  allowlist:
-    groups:
-      - internal
+  # CAS2 relies on MFA for managing access and therefore does not require allowlists, see: https://dsdmoj.atlassian.net/wiki/x/R4G2DgE
+  allowlist: null
 
 generic-prometheus-alerts:
   targetApplication: hmpps-community-accommodation-tier-2-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,7 +25,5 @@ generic-service:
       AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
       AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,7 +23,5 @@ generic-service:
       AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
       AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,5 +24,3 @@ generic-service:
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
       AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
-
-  allowlist: null

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -19,7 +19,5 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-401

# Changes in this PR

CAS2 does not apply any allowlist to control access, instead relying on auth and MFA (https://dsdmoj.atlassian.net/wiki/x/R4G2DgE), so there is no need to add extra ranges. This PR moves the default `allowlists: null` setting to the base config, and removes confusing overrides per environment.


## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
