### PR TITLE
CAS-435: Update URL to satisfaction survey

### DIFF
--- a/integration_tests/pages/apply/applicationSubmittedPage.ts
+++ b/integration_tests/pages/apply/applicationSubmittedPage.ts
@@ -1,5 +1,6 @@
 import { Cas2Application as Application, FullPerson } from '@approved-premises/api'
 import Page from '../page'
+import * as PhaseBannerUtils from '../../../server/utils/phaseBannerUtils'
 
 export default class ApplicationSubmittedPage extends Page {
   constructor(private readonly application: Application) {
@@ -15,5 +16,13 @@ export default class ApplicationSubmittedPage extends Page {
       cy.get('li').contains(person.name)
       cy.get('li').contains(person.nomsNumber)
     })
+  }
+
+  shouldShowLinkToFeedbackSurvey(): void {
+    cy.contains('a', 'Share your feedback for this service').should(
+      'have.attr',
+      'href',
+      PhaseBannerUtils.feedbackSurveyUrl,
+    )
   }
 }

--- a/integration_tests/tests/apply/submit.cy.ts
+++ b/integration_tests/tests/apply/submit.cy.ts
@@ -49,5 +49,6 @@ context('Applications dashboard', () => {
     // And I see a confirmation page
     const applicationSubmittedPage = Page.verifyOnPage(ApplicationSubmittedPage, this.application)
     applicationSubmittedPage.shouldShowApplicationDetails()
+    applicationSubmittedPage.shouldShowLinkToFeedbackSurvey()
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -34,6 +34,7 @@ import * as TaskListUtils from './taskListUtils'
 import { initialiseName, removeBlankSummaryListItems, stringToKebabCase, camelToKebabCase } from './utils'
 import { pagination } from './pagination'
 import { formatLines } from './viewUtils'
+import * as PhaseBannerUtils from './phaseBannerUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -128,4 +129,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('pagination', pagination)
 
   njkEnv.addGlobal('arePreTaskListTasksIncomplete', arePreTaskListTasksIncomplete)
+  njkEnv.addGlobal('PhaseBannerUtils', PhaseBannerUtils)
 }

--- a/server/utils/phaseBannerUtils.test.ts
+++ b/server/utils/phaseBannerUtils.test.ts
@@ -1,0 +1,9 @@
+import { getContent } from './phaseBannerUtils'
+
+describe('PhaseBannerUtils', () => {
+  it('returns the phase banner content', () => {
+    const content = `This is a new service. <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2KxXUZ1jbxlMsEoiPoZPWGNURVpKVERMMzRYOEpYS1cwVVBDUTZQUThFSS4u">Complete our feedback form</a> (opens in new tab) or <a class="govuk-link" href="mailto:cas2support@digital.justice.gov.uk">email us</a> (cas2support@digital.justice.gov.uk) to report a bug`
+
+    expect(getContent()).toEqual(content)
+  })
+})

--- a/server/utils/phaseBannerUtils.ts
+++ b/server/utils/phaseBannerUtils.ts
@@ -1,0 +1,7 @@
+export const supportEmail = 'cas2support@digital.justice.gov.uk'
+export const feedbackSurveyUrl =
+  'https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2KxXUZ1jbxlMsEoiPoZPWGNURVpKVERMMzRYOEpYS1cwVVBDUTZQUThFSS4u'
+
+export const getContent = () => {
+  return `This is a new service. <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="${feedbackSurveyUrl}">Complete our feedback form</a> (opens in new tab) or <a class="govuk-link" href="mailto:${supportEmail}">email us</a> (${supportEmail}) to report a bug`
+}

--- a/server/views/applications/confirm.njk
+++ b/server/views/applications/confirm.njk
@@ -29,7 +29,7 @@
             <p>This application has been sent to the CAS-2 team for review.</p>
             <p>The CAS-2 team will make an assessment and decide whether to offer a placement.</p>
             <p>You may need to provide more information if the CAS-2 team does not have everything they need to make an asessment.</p>
-            <p><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://forms.office.com/Pages/ResponsePage.aspx?id=8Guh-9qHxkGcH5mz3N5BRLMVmprlPbhNoMYbqf52APRUNzBDWDJNOEgzTzlJV0RWTE5NNUpZRktNSS4u">Share your feedback for this service</a> (opens in new tab) to help us improve it.</p>
+            <p><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ PhaseBannerUtils.feedbackSurveyUrl }}">Share your feedback for this service</a> (opens in new tab) to help us improve it.</p>
 
             {{ govukButton({
                 text: "Start new application",

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -41,6 +41,6 @@
     tag: {
       text: "Beta"
     },
-    html: 'This is a new service. <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://forms.office.com/Pages/ResponsePage.aspx?id=8Guh-9qHxkGcH5mz3N5BRLMVmprlPbhNoMYbqf52APRUNzBDWDJNOEgzTzlJV0RWTE5NNUpZRktNSS4u">Complete our feedback form</a> (opens in new tab) or <a class="govuk-link" href="mailto:cas2support@digital.justice.gov.uk">email us</a> (cas2support@digital.justice.gov.uk) to report a bug'
+    html: PhaseBannerUtils.getContent()
   }) }}
 {% endblock %}

--- a/server/views/static/accessibility-statement.njk
+++ b/server/views/static/accessibility-statement.njk
@@ -40,7 +40,7 @@
 
       <h2 class="govuk-heading-m">Feedback, contact information and reporting accessibility problems with this website</h2>
       <p>We are always looking to improve our service, including its accessibility.</p>
-      <p>If you find any problems that are not listed on this page or you think we’re not meeting the accessibility requirements, you can email <a href="mailto:cas2support@digital.justice.gov.uk" class="govuk-link">cas2support@digital.justice.gov.uk</a>
+      <p>If you find any problems that are not listed on this page or you think we’re not meeting the accessibility requirements, you can email <a href="mailto:{{ PhaseBannerUtils.supportEmail }}" class="govuk-link">{{ PhaseBannerUtils.supportEmail }}</a>
       </p>
 
       <h2 class="govuk-heading-m">Enforcement procedure</h2>


### PR DESCRIPTION
The URL for the satisfaction/feedback survey is now extracted into an exported constant to ensure it can be easily updated service-wide.

# Context

https://dsdmoj.atlassian.net/browse/CAS-435

# Changes in this PR

Updates the URL for the external feedback form.

The URL is now exported from a new `PhaseBannerUtils` file, which also exports the support email -- this ensures any updates to either of these can be applied service-wide easily.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
