### PR TITLE
Remove check_outdated job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,10 +294,6 @@ workflows:
               only:
                 - main
     jobs:
-      - hmpps/npm_outdated:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - hmpps-common-vars
       - hmpps/npm_security_audit:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:


### PR DESCRIPTION
This job does not provide any useful output beyond what the npm security audit does. The maintainers of the Typescript template have now removed it from the template itself [1]

[1] https://github.com/ministryofjustice/hmpps-template-typescript/pull/388

