### PR TITLE
Retain trace and video on E2E test failure

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ export default defineConfig<TestOptions>({
   reporter: [['html', { outputFolder: './e2e-tests/playwright-report/index.html' }]],
   timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,
   use: {
-    trace: 'on-first-retry',
-    video: 'on-first-retry',
+      trace: 'retain-on-failure',
+      video: 'retain-on-failure',
   },
   projects: [
     {


### PR DESCRIPTION
If the test fails in CI we want to be able to playback the trace and/or video in order to better understand what went wrong.
