### PR TITLE
CHORE: Use single branch and PR for types generation

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -30,5 +30,4 @@ jobs:
           commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
           body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
           delete-branch: true
-          branch-suffix: timestamp
           branch: update-api-types


### PR DESCRIPTION
This prevents polluting the PRs on GitHub with a new PR with every type generation action. Instead the same PR gets incremental changes, removing the need to manually close obsolete PRs.

This was done for CAS3 in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/951