### PR TITLE
CAS2-505 Change filter note from 14 to 32 days.

### DIFF
--- a/server/views/partials/applicationSoftDeleteGuidance.njk
+++ b/server/views/partials/applicationSoftDeleteGuidance.njk
@@ -3,7 +3,7 @@
   <p>Applications which meet the following criteria are not shown in the dashboard:
       <ul>
       <li>those where the Conditional Release Date is in the past</li>
-      <li>submitted applications where more than 14 days has elapsed since the application status was changed to 'Referral withdrawn', 'Referral cancelled' or 'Awaiting arrival'</li>
+      <li>submitted applications where more than 32 days has elapsed since the application status was changed to 'Referral withdrawn', 'Referral cancelled' or 'Awaiting arrival'</li>
     </ul>
   </p>
 


### PR DESCRIPTION

Ref: https://dsdmoj.atlassian.net/browse/CAS2-505

Applications where the status is withdrawn, cancelled or awaiting arrival and created greater than 32 days in the past can be excluded from the applications list (previously 14 days).

Related API PR: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2173
