### PR TITLE
Funding ID checkboxes are not linked to the context

### DIFF
--- a/server/form-pages/apply/area-and-funding/funding-information/alternativeID.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/alternativeID.test.ts
@@ -31,6 +31,7 @@ describe('AlternativeIdentification', () => {
       const conditional = 'some html'
 
       const expected = [
+        { divider: 'Work and employment' },
         { checked: false, text: 'Employer letter/contract of employment', value: 'contract' },
         { checked: false, text: 'Trade union membership card', value: 'tradeUnion' },
         { checked: false, text: 'Invoices (self-employed)', value: 'invoice' },

--- a/server/form-pages/apply/area-and-funding/funding-information/alternativeID.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/alternativeID.ts
@@ -33,12 +33,9 @@ export default class AlternativeIdentification implements TaskListPage {
 
   guidanceHtml = `The applicant needs ID if they are applying for Universal Credit for financial support, and Housing Benefit to cover their rent.<br /><br />If they want to receive an advance payment of Universal Credit on the day of release, they will need a bank account and photo ID.`
 
-  subHeadingHtml = `<div class="govuk-checkboxes__divider-custom">Work and employment</div>`
-
   hintHtml = `<div id="alternativeIDDocuments-hint" class="govuk-hint">
               ${applicationQuestions.alternativeIDDocuments.hint}
-              </div>
-              ${this.subHeadingHtml}`
+              </div>`
 
   constructor(
     body: Partial<AlternativeIdentificationBody>,
@@ -129,6 +126,7 @@ export default class AlternativeIdentification implements TaskListPage {
     const miscellaneousOther = otherItems.pop()
 
     return [
+      { divider: 'Work and employment' },
       ...convertKeyValuePairToCheckboxItems(workAndEmploymentOptions, this.body.alternativeIDDocuments),
       { divider: 'Citizenship and nationality' },
       ...convertKeyValuePairToCheckboxItems(citizenshipOptions, this.body.alternativeIDDocuments),

--- a/server/views/applications/pages/funding-information/alternative-identification.njk
+++ b/server/views/applications/pages/funding-information/alternative-identification.njk
@@ -4,8 +4,6 @@
 {% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{ page.title }}</h1>
-
   {% set otherID %}
   {{  
     formPageInput(
@@ -23,6 +21,13 @@
     formPageCheckboxes(
         {
           fieldName: "alternativeIDDocuments",
+          fieldset: {
+            legend: {
+              text: page.title,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
           hint: {
             html: page.hintHtml
           },
@@ -59,17 +64,17 @@
     document.addEventListener('DOMContentLoaded', function () {
       // 'no' checkbox sets the others to unchecked
       document
-        .getElementById('alternativeIDDocuments-34')
+        .getElementById('alternativeIDDocuments-35')
         .addEventListener('click', () => {
           document
-            .querySelectorAll('.govuk-checkboxes__input:not(#alternativeIDDocuments-34)')
+            .querySelectorAll('.govuk-checkboxes__input:not(#alternativeIDDocuments-35)')
             .forEach(checkbox => checkbox.checked = false)
         });
       // clicking any arrangement checkbox sets 'no' to unchecked
       document
-        .querySelectorAll('.govuk-checkboxes__input:not(#alternativeIDDocuments-34)')
+        .querySelectorAll('.govuk-checkboxes__input:not(#alternativeIDDocuments-35)')
         .forEach(checkbox => {
-          checkbox.addEventListener('click', () => setCheckedToFalseById('alternativeIDDocuments-34'));
+          checkbox.addEventListener('click', () => setCheckedToFalseById('alternativeIDDocuments-35'));
         })
     });
   </script>


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS2-455

The alternative funding checkboxes were not linked to the page heading. I've fixed this now but I've not addressed the other accessibility/ux issues which the audit mentioned like repeating the hint text multiple times. I think linking the checkboxes to the page heading is a huge improvement but anything else like splitting the page up into multiple pages or multiple fieldsets really needs design/content input.


No visual changes
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/a4c17a17-a8fc-475d-b314-7431dcbe5a89)

### After
![image](https://github.com/user-attachments/assets/443cc47c-7cc4-4b76-8185-5a9362d9c99d)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
