### PR TITLE
improve "Remove" links

### DIFF
--- a/server/views/applications/pages/current-offences/current-offences.njk
+++ b/server/views/applications/pages/current-offences/current-offences.njk
@@ -35,7 +35,7 @@
                 {
                   href: offence.removeLink,
                   text: "Remove",
-                  visuallyHiddenText: "remove this offence"
+                  visuallyHiddenText: offence.titleAndNumber +" offence"
                 }
               ]
             }  

--- a/server/views/applications/pages/risk-to-self/acct.njk
+++ b/server/views/applications/pages/risk-to-self/acct.njk
@@ -22,7 +22,7 @@
             {
               href: acct.removeLink,
               text: "Remove",
-              visuallyHiddenText: "remove this ACCT"
+              visuallyHiddenText: 'ACCT note "' + acct.title + '"'
             }
           ]
         }  


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS2-452

"remove was being read out twice for screen reader users because the visual text is "Remove" and then  repeated again in the visually hidden text. Although not mentioned in the audit report screenreader users would struggle to navigate the links if there were multiple links with the same text but taking them to different pages. I've tried to improve it by giving more context to the Remove link in the visually hidden text and will double check with content design


No visual differences for the user.