### PR TITLE
Fix heading levels for section summary cards

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -108,7 +108,7 @@ export default abstract class Page {
     sections.forEach(section => {
       cy.get('h2').contains(section.title)
       section.tasks.forEach(task => {
-        cy.get('h2').contains(task.title)
+        cy.get('h3').contains(task.title)
         task.questionsAndAnswers.forEach(question => {
           this.checkTermAndDescription(question.question, question.answer)
         })

--- a/server/views/partials/documentSummaryList.njk
+++ b/server/views/partials/documentSummaryList.njk
@@ -3,12 +3,13 @@
 {% macro documentSummaryList(application) %}
 
   {% for section in application.document.sections %}
-    <h2 class="govuk-heading-l">{{section.title}}</h2>
+    <h2 class="govuk-heading-m">{{section.title}}</h2>
     {% for task in section.tasks %}
       {{
                   govukSummaryList({
                     card: {
                             title: {
+                              headingLevel: 3,
                               text: task.title
                             },
                             attributes: { id: stringToKebabCase(task.title) }


### PR DESCRIPTION


# Context
https://dsdmoj.atlassian.net/browse/CAS-951

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Before the summary cards heading levels where level 2 which is the same as their section headings which is not logical. This change makes the summary card heading level 3 to show that they smaller sections within their section.

```
<h1>Check Catherine Hettinger's Application</h1>
<h2>Contents</h2>
<h2>Application Details</h2>
<h2>Before you apply</h2>
<h3>Confirm Eligibility</h3>
<h3>Confirm consent to share information</h3>
```

There are no visual changes


## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
