### PR TITLE
CAS-945 Hide "Change" links when "Download as PDF" or printing

### DIFF
--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -101,6 +101,7 @@ describe('checkYourAnswersUtils', () => {
           key: { html: 'A question' },
           value: { html: 'No' },
           actions: {
+            classes: 'govuk-!-display-none-print',
             items: [
               {
                 href: `/applications/${mockApplication.id}/tasks/task1/pages/page1`,
@@ -114,6 +115,7 @@ describe('checkYourAnswersUtils', () => {
           key: { html: 'Another question' },
           value: { html: 'some answer' },
           actions: {
+            classes: 'govuk-!-display-none-print',
             items: [
               {
                 href: `/applications/${mockApplication.id}/tasks/task1/pages/page2`,
@@ -159,6 +161,7 @@ describe('checkYourAnswersUtils', () => {
           key: { html: 'A question' },
           value: { html: 'No' },
           actions: {
+            classes: 'govuk-!-display-none-print',
             items: [
               {
                 href: `/applications/${mockApplication.id}/tasks/task1/pages/page1`,
@@ -216,6 +219,7 @@ describe('checkYourAnswersUtils', () => {
             key: { html: 'A question' },
             value: { html: 'No' },
             actions: {
+              classes: 'govuk-!-display-none-print',
               items: [
                 {
                   href: `/applications/${mockApplication.id}/tasks/confirm-eligibility/pages/page1`,
@@ -229,6 +233,7 @@ describe('checkYourAnswersUtils', () => {
             key: { html: 'Another question' },
             value: { html: 'an answer' },
             actions: {
+              classes: 'govuk-!-display-none-print',
               items: [
                 {
                   href: `/applications/${mockApplication.id}/tasks/confirm-eligibility/pages/page1`,
@@ -349,6 +354,7 @@ describe('checkYourAnswersUtils', () => {
             key: { html: 'foo' },
             value: { html: 'bar' },
             actions: {
+              classes: 'govuk-!-display-none-print',
               items: [
                 {
                   href: `/applications/${mockApplication.id}/tasks/confirm-eligibility/pages/page1`,
@@ -500,6 +506,7 @@ describe('checkYourAnswersUtils', () => {
         key: { html: 'a question' },
         value: { html: 'an answer' },
         actions: {
+          classes: 'govuk-!-display-none-print',
           items: [
             {
               href: `/applications/${application.id}/tasks/task1/pages/page1`,

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -152,6 +152,7 @@ export const summaryListItemForQuestion = (
   const { question, answer } = questionAndAnswer
 
   const actions = {
+    classes: 'govuk-!-display-none-print',
     items: [
       {
         href: paths.applications.pages.show({ task, page: pageKey, id: application.id }),

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -1,5 +1,4 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% from "../partials/documentSummaryList.njk" import documentSummaryList %}

--- a/server/views/people/confirm-applicant-details.njk
+++ b/server/views/people/confirm-applicant-details.njk
@@ -1,6 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "./partials/personDetails.njk" import personDetails %}
 


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-945


<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
On the "Check your answers" page theres a "Download to PDF" button which uses the browsers print functionality and the user can "Save as a pdf". This page contains a lot of "Change" links against a LONG list of summary list items. These links have been raised as an accessibility issue. Instead of implementing a server side generated PDF, we have decided to hide the change links from printed/pdf media as there is no need for the change links once the application has been downloaded/printed.


## Screenshots of UI changes
Small sample of page
### Before
![image](https://github.com/user-attachments/assets/3d5a05fa-c462-40e1-8ebe-398ae59fc721)

### After
![image](https://github.com/user-attachments/assets/cb37ac93-d0f1-47c0-b691-58504e0c4bd1)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
