### PR TITLE
CAS-950 Make the first nav link focusable for "back to top"

### DIFF
--- a/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
@@ -126,6 +126,9 @@ export default class CheckYourAnswersPage extends ApplyPage {
   shouldShowSideNavBar() {
     const sections = getSections()
 
+    // First nav link should have an id for "back to top" functionality
+    cy.get('.side-nav ul li').first().find('a').should('have.attr', 'id', 'top')
+
     sections.forEach(section => {
       section.tasks.forEach(task => {
         cy.get(`a[href="#${stringToKebabCase(task.title)}"]`)

--- a/server/views/components/sideNav/macro.njk
+++ b/server/views/components/sideNav/macro.njk
@@ -5,7 +5,7 @@
   <ul class="govuk-list govuk-list--spaced">
     {% for item in navItems %}
       <li class="govuk-!-font-size-16">
-        <a href="{{ item.href }}" class="govuk-link govuk-link--no-visited-state">{{ item.text }}</a>
+        <a href="{{ item.href }}" {% if loop.first %} id="top" {% endif %} class="govuk-link govuk-link--no-visited-state">{{ item.text }}</a>
       </li>
     {% endfor %}
     <li class="govuk-!-font-size-16">


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-950

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
In the sidebar, we have a long list of navigation items and the last one says "Back to top". Currently it sets the viewport to the top of page but does not focus any element. There is no anchor point with an id of `top` which is why the viewport takes the user to the top instead of top of the navigation list.

This commit ensures that the first link in the sidebar will now have an id of `top` which the `Back to top` can go to and focus the user on.
## Screenshots of UI changes

### Before

https://github.com/user-attachments/assets/38413c25-4dc5-434d-bc49-8948c0e4f9ba


### After

https://github.com/user-attachments/assets/5790929e-ab8c-4fa5-877f-8b4292ad81f6


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
