### PR TITLE
BUG Timeline entries not correctly formatted

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -175,7 +175,7 @@ export type UiTimelineEvent = {
   label: { text: string }
   byline: { text: string }
   datetime: { timestamp: string; type: string }
-  text: string
+  html: string
 }
 
 export type PersonStatus = 'InCustody' | 'InCommunity'

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -155,7 +155,7 @@ describe('utils', () => {
               timestamp: '2023-06-22T08:54:50',
               type: 'datetime',
             },
-            text: 'the status description',
+            html: 'the status description',
             label: {
               text: 'a status update',
             },
@@ -168,7 +168,7 @@ describe('utils', () => {
               timestamp: '2023-06-21T07:54:50',
               type: 'datetime',
             },
-            text: 'The application was received by an assessor.',
+            html: 'The application was received by an assessor.',
             label: {
               text: 'Application submitted',
             },
@@ -240,7 +240,7 @@ describe('utils', () => {
               }),
             ],
           })
-          expect(getApplicationTimelineEvents(application)[0].text).toEqual(
+          expect(getApplicationTimelineEvents(application)[0].html).toEqual(
             'the status description<br>and another<br>and another',
           )
         })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -76,7 +76,7 @@ export const getTimelineEvents = (timelineEvents: Array<Cas2TimelineEvent>): Arr
             timestamp: sortedTimelineEvents.occurredAt,
             type: 'datetime',
           },
-          text: description,
+          html: description,
         }
       })
   }


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-1347
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Caused by changes introduced in https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/845

For user notes, we automatically format their paragraphs. Using MOJ timeline text attribute meant that nunjucks would escape html tags and replace them with HTML entries. It should be noted that the actual users notes is escaped before being processed so there is no risk of a potential XSS attack

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/ab8b2383-a9d8-4f56-b87c-a1bca65183e5)

### After

![image](https://github.com/user-attachments/assets/7bedf3c8-e6ac-4166-91a5-17aa59a85f1b)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
