### PR TITLE
Revert "setup Google Tag Manager"

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -102,7 +102,4 @@ export default {
   flags: {
     maintenanceMode: get('IN_MAINTENANCE_MODE', false),
   },
-  analytics: {
-    tagManagerId: get('TAG_MANAGER_ID', null),
-  },
 }

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -31,11 +31,6 @@ export default function setUpWebSecurity(): Router {
           ],
           scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
-          scriptSrcElem: [
-            "'self'",
-            'www.googletagmanager.com',
-            (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
-          ],
           fontSrc: ["'self'"],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
         },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -28,6 +28,7 @@ import { applicationStatusRadios, applicationStatusDetailOptions } from './asses
 import { checkYourAnswersSections, getApplicantDetails } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
 import { dateFieldValues } from './formUtils'
+
 import * as OasysImportUtils from './oasysImportUtils'
 import { statusTag } from './personUtils'
 import * as TaskListUtils from './taskListUtils'
@@ -101,13 +102,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     njkEnv.addFilter(filter, mojFilters[filter])
   })
 
-  const {
-    analytics: { tagManagerId },
-  } = config
-  if (tagManagerId) {
-    njkEnv.addGlobal('tagManagerId', tagManagerId.trim())
-    njkEnv.addGlobal('tagManagerUrl', `https://www.googletagmanager.com/ns.html?id=${tagManagerId.trim()}`)
-  }
 
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -8,27 +8,6 @@
 {% block head %}
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
 
-  {% if tagManagerId %}
-    <!-- Google Tag Manager -->
-    <script nonce="{{ cspNonce }}">
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer'
-            ? '&l=' + l
-            : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f
-          .parentNode
-          .insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', "{{ tagManagerId }}");
-    </script>
-    <!-- End Google Tag Manager -->
-  {% endif %}
-
 {% endblock %}
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}
@@ -67,15 +46,4 @@
   <body>, to avoid blocking the initial render. #}
   <script nonce="{{ cspNonce }}" type="module" src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
-
-  {% if tagManagerId %}
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe nonce="{{ cspNonce }}" src="{{ tagManagerUrl }}"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
-  <script type="module" src="/assets/mojFrontEndInit.js"></script>
-  {% block extraScripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
# Context

Reverts initial PR which adds google tag manager.

This should not have been added, and should have been removed after DXW rolled off. 

[Initial commit](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/commit/4887bd178575dc78ac6eb1ea32a0eac406eab282)


