### PR TITLE
CAS-1221: Add Manual RoSH Information to application

### DIFF
--- a/integration_tests/pages/apply/risks_and_needs/risk-of-serious-harm/manualRoshInformationPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/risk-of-serious-harm/manualRoshInformationPage.ts
@@ -1,0 +1,37 @@
+import { Cas2Application as Application } from '../../../../../server/@types/shared/models/Cas2Application'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class ManualRoshInformationPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Create a RoSH summary for ${nameOrPlaceholderCopy(application.person)}`,
+      application,
+      'risk-of-serious-harm',
+      'manual-rosh-information',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-of-serious-harm',
+        page: 'manual-rosh-information',
+      }),
+    )
+  }
+
+  completeFormWithAllLowRisk(): void {
+    this.checkRadioByNameAndValue('riskToChildren', 'Low')
+    this.checkRadioByNameAndValue('riskToPublic', 'Low')
+    this.checkRadioByNameAndValue('riskToKnownAdult', 'Low')
+    this.checkRadioByNameAndValue('riskToStaff', 'Low')
+    this.checkRadioByNameAndValue('overallRisk', 'Low')
+  }
+
+  shouldHaveTaskListLink(application: Application): void {
+    cy.get('a').contains('Back to task list').should('have.attr', 'href', `/applications/${application.id}`)
+  }
+}

--- a/integration_tests/pages/apply/risks_and_needs/risk-of-serious-harm/oldOasysPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/risk-of-serious-harm/oldOasysPage.ts
@@ -29,4 +29,8 @@ export default class OldOasysPage extends ApplyPage {
     this.getTextInputByIdAndEnterDetails('oasysCompletedDate-month', '1')
     this.getTextInputByIdAndEnterDetails('oasysCompletedDate-year', '2023')
   }
+
+  completeFormForNoOASysData(): void {
+    this.checkRadioByNameAndValue('hasOldOasys', 'no')
+  }
 }

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/manual_rosh_information.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/manual_rosh_information.cy.ts
@@ -1,0 +1,90 @@
+//  Feature: Referrer completes 'manual RoSH information' page
+//    So that I can complete the "Risk of serious harm" task
+//    and have RoSH data
+//    As a referrer
+//    I want to complete the 'manual RoSH Information' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'manual RoSH information' page
+//
+//  Scenario: view 'manual RoSH information' page
+//    Then I see the "manual RoSH information" page
+//    And I can click through to the Task List page
+//
+//  Scenario: submit manual RoSH data
+//    When I submit my answers
+//    Then I am taken to the 'Risk to others' page
+
+import ManualRoshInformationPage from '../../../../pages/apply/risks_and_needs/risk-of-serious-harm/manualRoshInformationPage'
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import RiskToOthersPage from '../../../../pages/apply/risks_and_needs/risk-of-serious-harm/riskToOthersPage'
+
+context('Visit "Manual RoSH Information" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['risk-of-serious-harm'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('applicationWithData')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'Manual RoSH information' page
+    // --------------------------------
+    ManualRoshInformationPage.visit(this.application)
+  })
+
+  //  Scenario: view 'Manual RoSH information' page
+  // ----------------------------------------------
+
+  it('presents manual rosh information page', function test() {
+    //    Then I see the "manual rosh information" page
+    const page = Page.verifyOnPage(ManualRoshInformationPage, this.application)
+
+    // And I can click through to the Task List page
+    page.shouldHaveTaskListLink(this.application)
+  })
+
+  // Scenario: submit manual rosh data
+  // ----------------------------
+  it('continues to risk to others page', function test() {
+    // I submit my answers
+    const page = Page.verifyOnPage(ManualRoshInformationPage, this.application)
+    page.completeFormWithAllLowRisk()
+    page.clickSubmit()
+
+    // I am taken to the 'Risk to others' page
+    Page.verifyOnPage(RiskToOthersPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/old_oasys.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/risk-of-serious-harm/old_oasys.cy.ts
@@ -20,6 +20,7 @@ import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import OldOasysPage from '../../../../pages/apply/risks_and_needs/risk-of-serious-harm/oldOasysPage'
 import RiskToOthersPage from '../../../../pages/apply/risks_and_needs/risk-of-serious-harm/riskToOthersPage'
+import ManualRoshInformationPage from '../../../../pages/apply/risks_and_needs/risk-of-serious-harm/manualRoshInformationPage'
 
 context('Visit "Risks and needs" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -62,17 +63,35 @@ context('Visit "Risks and needs" section', () => {
     Page.verifyOnPage(OldOasysPage, this.application)
   })
 
-  //  Scenario: navigate to next page in "Risk of serious harm" task
-  // ----------------------------------------------
-  it('navigates to the next page', function test() {
-    //  When I give a valid answer
-    const page = Page.verifyOnPage(OldOasysPage, this.application)
-    page.completeForm()
+  describe('when offender has older OASys ROsh Info', () => {
+    //  Scenario: navigate to next page in "Risk of serious harm" task
+    // ----------------------------------------------
+    it('navigates to the next page', function test() {
+      //  When I give a valid answer
+      const page = Page.verifyOnPage(OldOasysPage, this.application)
+      page.completeForm()
 
-    //  And I continue to the next task / page
-    page.clickSubmit()
+      //  And I continue to the next task / page
+      page.clickSubmit()
 
-    //  Then I see the "Risk to others" page
-    Page.verifyOnPage(RiskToOthersPage, this.application)
+      //  Then I see the "Risk to others" page
+      Page.verifyOnPage(RiskToOthersPage, this.application)
+    })
+  })
+
+  describe('when offender does not have older OASys ROsh Info', () => {
+    //  Scenario: navigate to next page in "Risk of serious harm" task
+    // ----------------------------------------------
+    it('navigates to the next page', function test() {
+      //  When I give a valid answer
+      const page = Page.verifyOnPage(OldOasysPage, this.application)
+      page.completeFormForNoOASysData()
+
+      //  And I continue to the next task / page
+      page.clickSubmit()
+
+      //  Then I see the "Manual Rosh Info" page
+      Page.verifyOnPage(ManualRoshInformationPage, this.application)
+    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
@@ -1,0 +1,114 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../../shared-examples'
+import { personFactory, applicationFactory } from '../../../../../testutils/factories/index'
+import ManualRoshInformation from './manualRoshInformation'
+import type { ManualRoshBody } from './manualRoshInformation'
+
+describe('ManualRoshInformation', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new ManualRoshInformation({}, application)
+
+      expect(page.title).toEqual(`Create a RoSH summary for Roger Smith`)
+    })
+  })
+
+  describe('documentTitle', () => {
+    it('personalises the document title', () => {
+      const page = new ManualRoshInformation({}, application)
+
+      expect(page.documentTitle).toEqual(`Create a RoSH summary for this person`)
+    })
+  })
+
+  describe('selectText', () => {
+    it('personalises the hint text on the page', () => {
+      const page = new ManualRoshInformation({}, application)
+
+      expect(page.selectText).toEqual(`Select the risk levels for Roger Smith in the community.`)
+    })
+  })
+
+  describe('questions', () => {
+    const page = new ManualRoshInformation({}, application)
+
+    describe('riskToChildren', () => {
+      it('has a question', () => {
+        expect(page.questions.riskToChildren.question).toBeDefined()
+      })
+    })
+
+    describe('riskToPublic', () => {
+      it('has a question', () => {
+        expect(page.questions.riskToPublic.question).toBeDefined()
+      })
+    })
+
+    describe('riskToKnownAdult', () => {
+      it('has a question', () => {
+        expect(page.questions.riskToKnownAdult.question).toBeDefined()
+      })
+    })
+
+    describe('riskToStaff', () => {
+      it('has a question', () => {
+        expect(page.questions.riskToStaff.question).toBeDefined()
+      })
+    })
+
+    describe('overallRisk', () => {
+      it('has a question', () => {
+        expect(page.questions.overallRisk.question).toBeDefined()
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new ManualRoshInformation({}, application), 'risk-to-others')
+  itShouldHavePreviousValue(new ManualRoshInformation({}, application), 'taskList')
+
+  describe('errors', () => {
+    it('returns an error when required fields are blank', () => {
+      const page = new ManualRoshInformation({}, application)
+      expect(page.errors()).toEqual({
+        overallRisk: 'Select they risk they pose overall',
+        riskToChildren: 'Select the risk they pose to children',
+        riskToKnownAdult: 'Select they risk they pose to a known adult',
+        riskToPublic: 'Select the risk they pose to the public',
+        riskToStaff: 'Select they risk they pose to staff',
+      })
+    })
+  })
+
+  describe('items', () => {
+    Object.keys(new ManualRoshInformation({}, application).body).forEach((fieldName: keyof ManualRoshBody) => {
+      it(`returns the radio with the expected label text for ${fieldName} `, () => {
+        const data = { [fieldName]: 'Low' }
+        const page = new ManualRoshInformation(data, application)
+
+        expect(page.items(fieldName)).toEqual([
+          {
+            checked: true,
+            text: 'Low',
+            value: 'Low',
+          },
+          {
+            checked: false,
+            text: 'Medium',
+            value: 'Medium',
+          },
+          {
+            checked: false,
+            text: 'High',
+            value: 'High',
+          },
+          {
+            checked: false,
+            text: 'Very High',
+            value: 'Very High',
+          },
+        ])
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
@@ -1,0 +1,81 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../../utils/decorators'
+import TaskListPage from '../../../../taskListPage'
+import { nameOrPlaceholderCopy } from '../../../../../utils/utils'
+import { getQuestions } from '../../../../utils/questions'
+import { convertKeyValuePairToRadioItems } from '../../../../../utils/formUtils'
+import errorLookups from '../../../../../i18n/en/errors.json'
+
+export type ManualRoshBody = {
+  riskToChildren: string
+  riskToPublic: string
+  riskToKnownAdult: string
+  riskToStaff: string
+  overallRisk: string
+}
+
+const applicationQuestions = getQuestions('')
+
+export const options = applicationQuestions['risk-of-serious-harm']['manual-rosh-information']
+
+@Page({
+  name: 'manual-rosh-information',
+  bodyProperties: ['riskToChildren', 'riskToPublic', 'riskToKnownAdult', 'riskToStaff', 'overallRisk'],
+})
+export default class ManualRoshInformation implements TaskListPage {
+  documentTitle = `Create a RoSH summary for this person`
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `Create a RoSH summary for ${this.personName}`
+
+  selectText = `Select the risk levels for ${this.personName} in the community.`
+
+  body: ManualRoshBody
+
+  questions = getQuestions(this.personName)['risk-of-serious-harm']['manual-rosh-information']
+
+  taskName = 'risk-of-serious-harm'
+
+  createdAt = new Date().toISOString()
+
+  constructor(
+    body: Partial<ManualRoshBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as ManualRoshBody
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    return 'risk-to-others'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    Object.keys(this.body).forEach(key => {
+      const typedKey = key as keyof ManualRoshBody
+
+      if (!this.body[typedKey]) {
+        errors[typedKey] = errorLookups.manualRoshInformation[typedKey].empty
+      }
+    })
+
+    return errors
+  }
+
+  items(fieldName: keyof ManualRoshBody) {
+    const originalOptions = this.questions[fieldName].answers
+
+    const transformedOptions = Object.fromEntries(
+      Object.entries(originalOptions).map(([_key, value]) => [value, value]),
+    )
+
+    return convertKeyValuePairToRadioItems(transformedOptions, this.body[fieldName])
+  }
+}

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/index.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/index.ts
@@ -6,6 +6,7 @@ import RiskManagementArrangements from './riskManagementArrangements'
 import CellShareInformation from './cellShareInformation'
 import AdditionalRiskInformation from './additionalRiskInformation'
 import OldOasys from './oldOasys'
+import ManualRoshInformation from './custom-forms/manualRoshInformation'
 
 @Task({
   name: 'Add risk of serious harm (RoSH) information',
@@ -14,6 +15,7 @@ import OldOasys from './oldOasys'
     OasysImport,
     Summary,
     OldOasys,
+    ManualRoshInformation,
     RiskToOthers,
     RiskManagementArrangements,
     CellShareInformation,

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.test.ts
@@ -23,7 +23,6 @@ describe('OldOasys', () => {
     })
   })
 
-  itShouldHaveNextValue(new OldOasys({}, application), 'risk-to-others')
   itShouldHavePreviousValue(new OldOasys({}, application), 'taskList')
 
   describe('errors', () => {
@@ -90,5 +89,13 @@ describe('OldOasys', () => {
         'No, they do not have an OASys',
     }
     expect(page.response()).toEqual(expected)
+  })
+
+  describe('next', () => {
+    itShouldHaveNextValue(new OldOasys({}, application), 'manual-rosh-information')
+
+    describe('when hasOldOasys is yes', () => {
+      itShouldHaveNextValue(new OldOasys({ hasOldOasys: 'yes' }, application), 'risk-to-others')
+    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/oldOasys.ts
@@ -38,7 +38,7 @@ export default class OldOasys implements TaskListPage {
   }
 
   next() {
-    return 'risk-to-others'
+    return this.body.hasOldOasys === 'yes' ? 'risk-to-others' : 'manual-rosh-information'
   }
 
   response() {

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -58,7 +58,7 @@ describe('Summary', () => {
     })
   })
 
-  describe('risks', () => {
+  describe('riskData', () => {
     describe('imported OASys data', () => {
       describe('if the risks have not been found', () => {
         it('sets the risks to undefined', () => {
@@ -75,7 +75,7 @@ describe('Summary', () => {
             },
           )
 
-          expect(page.risks).toBe(undefined)
+          expect(page.riskData).toBe(undefined)
         })
       })
 
@@ -94,14 +94,14 @@ describe('Summary', () => {
             },
           )
 
-          expect(page.risks.value).toBe(undefined)
+          expect(page.riskData).toBe(roshSummaryDataWithoutValue)
         })
       })
 
       describe('if risk values exists', () => {
         it('sets the risks', () => {
           const page = new Summary({}, applicationWithSummaryData)
-          expect(page.risks).toEqual(roshSummaryData)
+          expect(page.riskData).toEqual(roshSummaryData)
         })
       })
 
@@ -109,7 +109,7 @@ describe('Summary', () => {
         it('sets the risks to undefined', () => {
           const page = new Summary({}, applicationWithoutSummaryData)
 
-          expect(page.risks).toBe(undefined)
+          expect(page.riskData).toBe(undefined)
         })
       })
     })
@@ -117,7 +117,7 @@ describe('Summary', () => {
     describe('manually entered RoSH data', () => {
       it('sets the risks in the same format as OASys value format', () => {
         const page = new Summary({}, applicationWithManualRoSHSummaryData)
-        expect(page.risks.value).toEqual(manualRoSHSummaryData)
+        expect(page.riskData).toEqual(manualRoSHSummaryData)
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -1,10 +1,10 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Cas2Application as Application, RoshRisks, RoshRisksEnvelope } from '@approved-premises/api'
+import { Cas2Application as Application, RoshRisks, RoshRisksEnvelope, Unit } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { DateFormats } from '../../../../utils/dateUtils'
-import { getRiskDataCreatedDate, getRiskDetails, getRiskDataSource } from '../../../utils'
+import { getRiskDataCreatedDate } from '../../../utils'
 import { getQuestions } from '../../../utils/questions'
 
 export type SummaryBody = {
@@ -15,8 +15,11 @@ export type SummaryData = RoshRisksEnvelope & {
   oasysImportedDate?: Date
   oasysStartedDate?: string
   oasysCompletedDate?: string
-  method?: string
 }
+
+type OASysSummaryData = SummaryData
+
+type ManualRoshData = RoshRisks
 
 interface Column {
   text: string
@@ -48,7 +51,7 @@ export default class Summary implements TaskListPage {
 
   body: SummaryBody
 
-  risks?: SummaryData
+  riskData: OASysSummaryData | ManualRoshData
 
   riskWidgetData: RiskWidgetData
 
@@ -65,14 +68,14 @@ export default class Summary implements TaskListPage {
     this.body = body as SummaryBody
     this.application = application
 
-    const riskData = getRiskDataSource(this.application)
+    // Get All RoSH Data if it exists else returns undefined
+    const roshData = this.getRoSHData(this.application)
 
-    if (riskData) {
-      this.riskWidgetData = this.getRiskWidgetData(riskData)
+    if (roshData) {
+      this.riskData = this.getRiskDataSource(roshData)
 
-      this.risks = {
-        ...riskData,
-        value: this.getRiskValues(riskData),
+      if (this.riskData) {
+        this.riskWidgetData = this.getRiskWidgetData(this.riskData)
       }
     }
 
@@ -98,18 +101,22 @@ export default class Summary implements TaskListPage {
   response() {
     let response: Record<string, string | undefined> = {}
 
-    if (this.risks) {
+    if (this.riskData) {
       response = {
-        'OASys created': DateFormats.isoDateToUIDate(this.risks.oasysStartedDate, { format: 'medium' }),
-        'OASys completed': this.risks.oasysCompletedDate
-          ? DateFormats.isoDateToUIDate(this.risks.oasysCompletedDate, { format: 'medium' })
+        'OASys created': DateFormats.isoDateToUIDate((this.riskData as OASysSummaryData).oasysStartedDate, {
+          format: 'medium',
+        }),
+        'OASys completed': (this.riskData as OASysSummaryData).oasysCompletedDate
+          ? DateFormats.isoDateToUIDate((this.riskData as OASysSummaryData).oasysCompletedDate, { format: 'medium' })
           : 'Unknown',
-        'OASys imported': DateFormats.dateObjtoUIDate(this.risks.oasysImportedDate, { format: 'medium' }),
-        'Overall risk rating': this.risks.value.overallRisk,
-        'Risk to children': this.risks.value.riskToChildren,
-        'Risk to known adult': this.risks.value.riskToKnownAdult,
-        'Risk to public': this.risks.value.riskToPublic,
-        'Risk to staff': this.risks.value.riskToStaff,
+        'OASys imported': DateFormats.dateObjtoUIDate((this.riskData as OASysSummaryData).oasysImportedDate, {
+          format: 'medium',
+        }),
+        'Overall risk rating': (this.riskData as OASysSummaryData).value.overallRisk,
+        'Risk to children': (this.riskData as OASysSummaryData).value.riskToChildren,
+        'Risk to known adult': (this.riskData as OASysSummaryData).value.riskToKnownAdult,
+        'Risk to public': (this.riskData as OASysSummaryData).value.riskToPublic,
+        'Risk to staff': (this.riskData as OASysSummaryData).value.riskToStaff,
       }
     }
 
@@ -121,11 +128,13 @@ export default class Summary implements TaskListPage {
   }
 
   getRiskWidgetData(riskData: Pick<RoshRisksEnvelope, 'value'>): RiskWidgetData {
-    if (riskData.value) {
+    const source = (riskData.value || riskData) as RoshRisks
+
+    if (source) {
       return {
         overallRisk: {
-          text: riskData.value.overallRisk.toUpperCase(),
-          classes: `rosh-widget--${riskData.value.overallRisk.toLowerCase().replace(/ /g, '-')}`,
+          text: source.overallRisk?.toUpperCase(),
+          classes: `rosh-widget--${source.overallRisk?.toLowerCase().replace(/ /g, '-')}`,
         },
         head: [
           {
@@ -141,8 +150,8 @@ export default class Summary implements TaskListPage {
               text: 'Children',
             },
             {
-              text: riskData.value.riskToChildren,
-              classes: `rosh-widget__risk--${riskData.value.riskToChildren.toLowerCase().replace(/ /g, '-')}`,
+              text: source.riskToChildren || 'No Data',
+              classes: `rosh-widget__risk--${source.riskToChildren?.toLowerCase().replace(/ /g, '-')}`,
             },
           ],
           [
@@ -150,8 +159,8 @@ export default class Summary implements TaskListPage {
               text: 'Public',
             },
             {
-              text: riskData.value.riskToPublic,
-              classes: `rosh-widget__risk--${riskData.value.riskToPublic.toLowerCase().replace(/ /g, '-')}`,
+              text: source.riskToPublic || 'No Data',
+              classes: `rosh-widget__risk--${source.riskToPublic?.toLowerCase().replace(/ /g, '-')}`,
             },
           ],
           [
@@ -159,8 +168,8 @@ export default class Summary implements TaskListPage {
               text: 'Known adult',
             },
             {
-              text: riskData.value.riskToKnownAdult,
-              classes: `rosh-widget__risk--${riskData.value.riskToKnownAdult.toLowerCase().replace(/ /g, '-')}`,
+              text: source.riskToKnownAdult || 'No Data',
+              classes: `rosh-widget__risk--${source.riskToKnownAdult?.toLowerCase().replace(/ /g, '-')}`,
             },
           ],
           [
@@ -168,8 +177,8 @@ export default class Summary implements TaskListPage {
               text: 'Staff',
             },
             {
-              text: riskData.value.riskToStaff,
-              classes: `rosh-widget__risk--${riskData.value.riskToStaff.toLowerCase().replace(/ /g, '-')}`,
+              text: source.riskToStaff || 'No Data',
+              classes: `rosh-widget__risk--${source.riskToStaff?.toLowerCase().replace(/ /g, '-')}`,
             },
           ],
         ],
@@ -178,34 +187,20 @@ export default class Summary implements TaskListPage {
     return undefined
   }
 
-  getRiskValues(riskData: SummaryData | RoshRisks | never) {
-    // Function to extract risk details from a risk object
-    const getRiskValue = (data: RoshRisks | SummaryData, key: keyof RoshRisks | keyof SummaryData) => {
-      return getRiskDetails((data as any)?.value?.[key] ?? (data as any)[key] ?? '')
+  private getRoSHData(application: Application) {
+    return application.data['risk-of-serious-harm']
+  }
+
+  private getRiskDataSource(roshData: Unit): SummaryData | null {
+    const riskData = roshData
+
+    if (riskData['summary-data']?.status === 'retrieved') {
+      return riskData['summary-data']
     }
 
-    // If riskData is SummaryData with a 'value' property
-    if ('value' in riskData && riskData.value && Object.keys(riskData.value).length > 0) {
-      return {
-        overallRisk: getRiskValue(riskData, 'overallRisk'),
-        riskToChildren: getRiskValue(riskData, 'riskToChildren'),
-        riskToPublic: getRiskValue(riskData, 'riskToPublic'),
-        riskToKnownAdult: getRiskValue(riskData, 'riskToKnownAdult'),
-        riskToStaff: getRiskValue(riskData, 'riskToStaff'),
-      }
+    if (riskData['manual-rosh-information']) {
+      return riskData['manual-rosh-information']
     }
-
-    // If riskData is RoshRisks or contains keys
-    if (Object.keys(riskData).length > 0) {
-      return {
-        overallRisk: getRiskValue(riskData, 'overallRisk'),
-        riskToChildren: getRiskValue(riskData, 'riskToChildren'),
-        riskToPublic: getRiskValue(riskData, 'riskToPublic'),
-        riskToKnownAdult: getRiskValue(riskData, 'riskToKnownAdult'),
-        riskToStaff: getRiskValue(riskData, 'riskToStaff'),
-      }
-    }
-
     return undefined
   }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Cas2Application as Application, RoshRisksEnvelope } from '@approved-premises/api'
+import { Cas2Application as Application, RoshRisks, RoshRisksEnvelope } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
@@ -12,8 +12,8 @@ export type SummaryBody = {
 }
 
 export type SummaryData = RoshRisksEnvelope & {
-  oasysImportedDate: Date
-  oasysStartedDate: string
+  oasysImportedDate?: Date
+  oasysStartedDate?: string
   oasysCompletedDate?: string
   method?: string
 }
@@ -72,16 +72,7 @@ export default class Summary implements TaskListPage {
 
       this.risks = {
         ...riskData,
-        value:
-          riskData.value && Object.keys(riskData.value).length > 0
-            ? {
-                overallRisk: getRiskDetails(riskData.value?.overallRisk ?? ''),
-                riskToChildren: getRiskDetails(riskData.value?.riskToChildren ?? ''),
-                riskToPublic: getRiskDetails(riskData.value?.riskToPublic ?? ''),
-                riskToKnownAdult: getRiskDetails(riskData.value?.riskToKnownAdult ?? ''),
-                riskToStaff: getRiskDetails(riskData.value?.riskToStaff ?? ''),
-              }
-            : undefined,
+        value: this.getRiskValues(riskData),
       }
     }
 
@@ -184,6 +175,37 @@ export default class Summary implements TaskListPage {
         ],
       }
     }
+    return undefined
+  }
+
+  getRiskValues(riskData: SummaryData | RoshRisks | never) {
+    // Function to extract risk details from a risk object
+    const getRiskValue = (data: RoshRisks | SummaryData, key: keyof RoshRisks | keyof SummaryData) => {
+      return getRiskDetails((data as any)?.value?.[key] ?? (data as any)[key] ?? '')
+    }
+
+    // If riskData is SummaryData with a 'value' property
+    if ('value' in riskData && riskData.value && Object.keys(riskData.value).length > 0) {
+      return {
+        overallRisk: getRiskValue(riskData, 'overallRisk'),
+        riskToChildren: getRiskValue(riskData, 'riskToChildren'),
+        riskToPublic: getRiskValue(riskData, 'riskToPublic'),
+        riskToKnownAdult: getRiskValue(riskData, 'riskToKnownAdult'),
+        riskToStaff: getRiskValue(riskData, 'riskToStaff'),
+      }
+    }
+
+    // If riskData is RoshRisks or contains keys
+    if (Object.keys(riskData).length > 0) {
+      return {
+        overallRisk: getRiskValue(riskData, 'overallRisk'),
+        riskToChildren: getRiskValue(riskData, 'riskToChildren'),
+        riskToPublic: getRiskValue(riskData, 'riskToPublic'),
+        riskToKnownAdult: getRiskValue(riskData, 'riskToKnownAdult'),
+        riskToStaff: getRiskValue(riskData, 'riskToStaff'),
+      }
+    }
+
     return undefined
   }
 }

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -146,5 +146,9 @@ export function getRiskDataSource(application: Application): SummaryData | null 
     return riskData['summary-data']
   }
 
+  if (riskData?.['manual-rosh-information']) {
+    return riskData['manual-rosh-information']
+  }
+
   return null
 }

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -4,7 +4,6 @@ import type { FormArtifact, JourneyType, UiTask } from '@approved-premises/ui'
 import logger from '../../../logger'
 import { TaskListPageInterface } from '../taskListPage'
 import { DateFormats } from '../../utils/dateUtils'
-import type { SummaryData } from '../apply/risks-and-needs/risk-of-serious-harm/summary'
 
 export const getTask = <T>(task: T) => {
   const taskPages = {}
@@ -130,25 +129,4 @@ export function pageBodyShallowEquals(body1: Record<string, unknown>, body2: Rec
 
 export const dateBodyProperties = (root: string) => {
   return [root, `${root}-year`, `${root}-month`, `${root}-day`]
-}
-
-export function getRiskDetails(level: string) {
-  if (level === 'Very High') {
-    return 'Very high'
-  }
-  return level || 'No data'
-}
-
-export function getRiskDataSource(application: Application): SummaryData | null {
-  const riskData = application.data['risk-of-serious-harm']
-
-  if (riskData?.['summary-data']?.status === 'retrieved') {
-    return riskData['summary-data']
-  }
-
-  if (riskData?.['manual-rosh-information']) {
-    return riskData['manual-rosh-information']
-  }
-
-  return null
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1,6 +1,7 @@
 export const getQuestions = (name: string) => {
   const yesOrNo = { yes: 'Yes', no: 'No' }
   const yesNoOrIDontKnow = { yes: 'Yes', no: 'No', dontKnow: `I don't know` }
+  const riskLevel = { low: 'Low', medium: 'Medium', high: 'High', veryHigh: 'Very High' }
 
   const dateExample = '27 3 2023'
 
@@ -717,6 +718,28 @@ export const getQuestions = (name: string) => {
         riskToKnownAdult: { question: 'Risk to a known adult' },
         riskToStaff: { question: 'Risk to staff' },
         additionalComments: { question: 'Additional comments (optional)' },
+      },
+      'manual-rosh-information': {
+        riskToChildren: {
+          question: `What risk do they pose to children?`,
+          answers: riskLevel,
+        },
+        riskToPublic: {
+          question: `What risk do they pose to the public?`,
+          answers: riskLevel,
+        },
+        riskToKnownAdult: {
+          question: `What risk do they pose to a known adult?`,
+          answers: riskLevel,
+        },
+        riskToStaff: {
+          question: `What risk do they pose to staff?`,
+          answers: riskLevel,
+        },
+        overallRisk: {
+          question: `What’s the overall risk?`,
+          answers: riskLevel,
+        },
       },
       'old-oasys': {
         hasOldOasys: {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -91,5 +91,22 @@
     "cancelled": {
       "empty": "Select why the referral was cancelled"
     }
+  },
+  "manualRoshInformation": {
+    "riskToChildren": {
+      "empty": "Select the risk they pose to children"
+    },
+    "riskToPublic": {
+      "empty": "Select the risk they pose to the public"
+    },
+    "riskToKnownAdult": {
+      "empty": "Select they risk they pose to a known adult"
+    },
+    "riskToStaff": {
+      "empty": "Select they risk they pose to staff"
+    },
+    "overallRisk": {
+      "empty": "Select they risk they pose overall"
+    }
   }
 }

--- a/server/views/applications/pages/risk-of-serious-harm/manual-rosh-information.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/manual-rosh-information.njk
@@ -1,0 +1,51 @@
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../layout.njk" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      {{ showErrorSummary(errorSummary) }}
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
+      <p class="govuk-body">{{ page.selectText }}</p>
+      <p class="govuk-body">If you do not have this information, contact the relevant probation officer.</p>
+
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="pageName" value="{{ page.name }}"/>
+        <input type="hidden" name="taskName" value="{{ page.taskName }}"/>
+        <input type="hidden" name="createdAt" value="{{ page.createdAt }}"/>
+
+        {% block questions %}
+          {% for fieldName, questionData in page.questions %}
+            {{
+              formPageRadios(
+                {
+                  fieldName: fieldName,
+                  fieldset: {
+                    legend: {
+                      text: questionData.question,
+                      classes: "govuk-fieldset__legend--m"
+                    }
+                  },
+                  items: page.items(fieldName)
+                },
+                fetchContext()
+              )
+            }}
+          {% endfor %}
+
+          {% block button %}
+            <div class="govuk-button-group">
+              {{ govukButton({ text: "Save and continue"})}}
+
+              <a href="{{ paths.applications.show({ id: applicationId }) }}">Back to task list</a>
+            </div>
+          {% endblock %}
+        {% endblock %}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds a new journey to "Create an application" process. If the POM selects, 'No' to the `Does offender have an older OASys with risk of serious harm (RoSH) information?`, they will be taken to a new page where they will fill in the manual rosh data themselves. The rest of the process is exactly the same and the RoSH summary table should return the data that was entered.

OUT OF SCOPE: Updating "Check your answers" before submitting the application. this will be done as a separate PR.

## Screenshots of UI changes

### Manual form to input RoSH Data
![image](https://github.com/user-attachments/assets/ea3e856e-2924-4460-b92f-d72898bcbc90)


### RoSH summary widget updated to support both OASyS or Manual Data input

![image](https://github.com/user-attachments/assets/c3a2013b-5529-4825-a2f8-174a5029e475)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
