### PR TITLE
Fixes for application-client pact issues

### DIFF
--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,6 +1,7 @@
 import { SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
+import { faker } from '@faker-js/faker/locale/en_GB'
 import ApplicationClient from './applicationClient'
-import { applicationFactory } from '../testutils/factories'
+import { applicationFactory, assessmentFactory } from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 
@@ -15,7 +16,10 @@ describeClient('ApplicationClient', provider => {
 
   describe('find', () => {
     it('should return an application', async () => {
-      const application = applicationFactory.build()
+      const application = applicationFactory.build({
+        assessment: assessmentFactory.build(),
+        telephoneNumber: faker.phone.number(),
+      })
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -41,7 +45,10 @@ describeClient('ApplicationClient', provider => {
 
   describe('create', () => {
     it('should return an application when a crn is posted', async () => {
-      const application = applicationFactory.build()
+      const application = applicationFactory.build({
+        assessment: assessmentFactory.build(),
+        telephoneNumber: faker.phone.number(),
+      })
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -138,7 +145,10 @@ describeClient('ApplicationClient', provider => {
 
   describe('update', () => {
     it('should return an application when a PUT request is made', async () => {
-      const application = applicationFactory.build()
+      const application = applicationFactory.build({
+        assessment: assessmentFactory.build(),
+        telephoneNumber: faker.phone.number(),
+      })
       const data = {
         data: application.data,
         type: 'CAS2',


### PR DESCRIPTION
**PR changes:**
* Fix for pact tests 
* caused by changes made to move to child object `CAS2Application` n this BE PR: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3053/files#diff-be6259540a0a2641596f6c3be134afc25cc99d0242980dd8b0ea475eeb6074e9 
