### PR TITLE
Fix styling of the Rosh summary component

### DIFF
--- a/assets/scss/components/_rosh-widget.scss
+++ b/assets/scss/components/_rosh-widget.scss
@@ -12,11 +12,6 @@ $very-high-score-border-colour: #942514;
   padding: govuk-spacing(4);
   margin-bottom: govuk-spacing(4);
 
-  & h3 {
-    margin-bottom: govuk-spacing(1);
-    font-weight: 400;
-  }
-
   & :nth-child(2) {
     margin-bottom: govuk-spacing(2);
   }
@@ -25,36 +20,25 @@ $very-high-score-border-colour: #942514;
   }
 }
 
+.rosh-widget__heading {
+  margin-bottom: govuk-spacing(4);
+  font-weight: 400;
+}
+
 .rosh-widget--low {
   border: 2px solid $low-score-border-colour;
-
-  & h3 {
-    color: $low-score-colour;
-  }
 }
 
 .rosh-widget--medium {
   border: 2px solid $medium-score-border-colour;
-
-  & h3 {
-    color: $medium-score-colour;
-  }
 }
 
 .rosh-widget--high {
   border: 2px solid $high-score-border-colour;
-
-  & h3 {
-    color: $high-score-colour;
-  }
 }
 
 .rosh-widget--very-high {
   border: 2px solid $very-high-score-border-colour;
-
-  & h3 {
-    color: $very-high-score-colour;
-  }
 }
 
 .rosh-widget__table {

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -127,9 +127,12 @@ describe('Summary', () => {
       it('sets the risks', () => {
         const page = new Summary({}, applicationWithSummaryData)
         expect(page.riskWidgetData).toEqual({
+          widget: {
+            classes: 'rosh-widget--a-risk',
+          },
           overallRisk: {
             text: 'A RISK',
-            classes: `rosh-widget--a-risk`,
+            classes: `rosh-widget__risk--another-risk`,
           },
           head: [
             {

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -30,6 +30,9 @@ interface Row {
 }
 
 interface RiskWidgetData {
+  widget: {
+    classes: string
+  }
   overallRisk: {
     text: string
     classes: string
@@ -132,9 +135,12 @@ export default class Summary implements TaskListPage {
 
     if (source) {
       return {
+        widget: {
+          classes: `rosh-widget--${source.overallRisk?.toLowerCase().replace(/ /g, '-')}`,
+        },
         overallRisk: {
           text: source.overallRisk?.toUpperCase(),
-          classes: `rosh-widget--${source.overallRisk?.toLowerCase().replace(/ /g, '-')}`,
+          classes: `rosh-widget__risk--${source.riskToChildren?.toLowerCase().replace(/ /g, '-')}`,
         },
         head: [
           {

--- a/server/views/components/roshWidget/macro.njk
+++ b/server/views/components/roshWidget/macro.njk
@@ -2,8 +2,8 @@
 
 {% macro roshWidget(riskWidgetData) %}
   {% if riskWidgetData %}
-    <div class="rosh-widget {{riskWidgetData.overallRisk.classes }}">
-      <h2 class="govuk-heading-m">
+    <div class="rosh-widget {{riskWidgetData.widget.classes }}">
+      <h2 class="govuk-heading-m rosh-widget__heading {{riskWidgetData.overallRisk.classes }}">
         <strong>{{ riskWidgetData.overallRisk.text }}</strong> RoSH
       </h2>
 


### PR DESCRIPTION

# Context
This is an existing bug where the css was relying on markup and the markup did not match, ie using h2 instead of h3. Instead we should be using a class and putting the class on the element that we want to style rather than relying on the nested styling.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/50571570-5c7e-4e72-a034-36154ba378c3)

### After
![image](https://github.com/user-attachments/assets/36263116-ee96-4a23-b79d-ca3241c77beb)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
