### PR TITLE
CAS-1221: Add audit information above the rosh summary table

### DIFF
--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
@@ -81,34 +81,36 @@ describe('ManualRoshInformation', () => {
   })
 
   describe('items', () => {
-    Object.keys(new ManualRoshInformation({}, application).body).forEach((fieldName: keyof ManualRoshBody) => {
-      it(`returns the radio with the expected label text for ${fieldName} `, () => {
-        const data = { [fieldName]: 'Low' }
-        const page = new ManualRoshInformation(data, application)
+    Object.keys(new ManualRoshInformation({}, application).body)
+      .filter(item => item !== 'createdAt')
+      .forEach((fieldName: keyof ManualRoshBody) => {
+        it(`returns the radio with the expected label text for ${fieldName} `, () => {
+          const data = { [fieldName]: 'Low' }
+          const page = new ManualRoshInformation(data, application)
 
-        expect(page.items(fieldName)).toEqual([
-          {
-            checked: true,
-            text: 'Low',
-            value: 'Low',
-          },
-          {
-            checked: false,
-            text: 'Medium',
-            value: 'Medium',
-          },
-          {
-            checked: false,
-            text: 'High',
-            value: 'High',
-          },
-          {
-            checked: false,
-            text: 'Very High',
-            value: 'Very High',
-          },
-        ])
+          expect(page.items(fieldName)).toEqual([
+            {
+              checked: true,
+              text: 'Low',
+              value: 'Low',
+            },
+            {
+              checked: false,
+              text: 'Medium',
+              value: 'Medium',
+            },
+            {
+              checked: false,
+              text: 'High',
+              value: 'High',
+            },
+            {
+              checked: false,
+              text: 'Very High',
+              value: 'Very High',
+            },
+          ])
+        })
       })
-    })
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
@@ -21,7 +21,7 @@ export const options = applicationQuestions['risk-of-serious-harm']['manual-rosh
 
 @Page({
   name: 'manual-rosh-information',
-  bodyProperties: ['riskToChildren', 'riskToPublic', 'riskToKnownAdult', 'riskToStaff', 'overallRisk'],
+  bodyProperties: ['riskToChildren', 'riskToPublic', 'riskToKnownAdult', 'riskToStaff', 'overallRisk', 'createdAt'],
 })
 export default class ManualRoshInformation implements TaskListPage {
   documentTitle = `Create a RoSH summary for this person`

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.test.ts
@@ -1,7 +1,7 @@
-import { RoshRisks } from '@approved-premises/api'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import Summary, { SummaryData } from './summary'
+
+import Summary, { ManualRoshData, SummaryData } from './summary'
 
 describe('Summary', () => {
   const roshSummaryData = {
@@ -24,7 +24,8 @@ describe('Summary', () => {
     riskToPublic: 'Low',
     riskToKnownAdult: 'High',
     riskToStaff: 'Low',
-  } as RoshRisks
+    createdAt: new Date('2025-02-27T13:15:00.245Z'),
+  } as ManualRoshData
 
   const person = personFactory.build({ name: 'Roger Smith' })
 
@@ -50,11 +51,21 @@ describe('Summary', () => {
     })
   })
 
-  describe('import date', () => {
-    it('sets importDate to null where application contains no OASys import date', () => {
-      const page = new Summary({}, applicationWithSummaryData)
+  describe('auditInfo', () => {
+    describe('OASys import date', () => {
+      it('sets importDate to null where application contains no OASys import date', () => {
+        const page = new Summary({}, applicationWithSummaryData)
 
-      expect(page.riskDataCreatedDate).toEqual(null)
+        expect(page.auditInfo).toEqual(`Imported from OASys on <strong>15 September 2023</strong>`)
+      })
+    })
+
+    describe('manual rosh information created date copy', () => {
+      it('returns information on when the RoSh information was created/updated last', () => {
+        const page = new Summary({}, applicationWithManualRoSHSummaryData)
+
+        expect(page.auditInfo).toEqual(`Created by prison offender manager on <strong>27 February 2025</strong>`)
+      })
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/summary.ts
@@ -19,7 +19,9 @@ export type SummaryData = RoshRisksEnvelope & {
 
 type OASysSummaryData = SummaryData
 
-type ManualRoshData = RoshRisks
+export type ManualRoshData = RoshRisks & {
+  createdAt?: Date
+}
 
 interface Column {
   text: string
@@ -59,7 +61,7 @@ export default class Summary implements TaskListPage {
     additionalComments: string
   }
 
-  riskDataCreatedDate = getRiskDataCreatedDate(this.application, 'risk-of-serious-harm', 'OASys')
+  auditInfo: string
 
   constructor(
     body: Partial<SummaryBody>,
@@ -73,6 +75,8 @@ export default class Summary implements TaskListPage {
 
     if (roshData) {
       this.riskData = this.getRiskDataSource(roshData)
+
+      this.auditInfo = this.getAuditInfo(this.riskData)
 
       if (this.riskData) {
         this.riskWidgetData = this.getRiskWidgetData(this.riskData)
@@ -201,6 +205,26 @@ export default class Summary implements TaskListPage {
     if (riskData['manual-rosh-information']) {
       return riskData['manual-rosh-information']
     }
+    return undefined
+  }
+
+  private getAuditInfo(roshData: Unit): string | never {
+    if ((roshData as OASysSummaryData).oasysImportedDate) {
+      return `Imported from OASys on <strong>${DateFormats.dateObjtoUIDate(
+        (roshData as OASysSummaryData).oasysImportedDate,
+        { format: 'medium' },
+      )}</strong>`
+    }
+
+    if ((roshData as ManualRoshData).createdAt) {
+      return `Created by prison offender manager on <strong>${DateFormats.dateObjtoUIDate(
+        (roshData as ManualRoshData).createdAt,
+        {
+          format: 'medium',
+        },
+      )}</strong>`
+    }
+
     return undefined
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -107,6 +107,9 @@
     },
     "overallRisk": {
       "empty": "Select they risk they pose overall"
+    },
+    "createdAt": {
+      "createdAt": "Please provide today's date"
     }
   }
 }

--- a/server/views/applications/pages/risk-of-serious-harm/summary.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/summary.njk
@@ -22,9 +22,9 @@
 
   <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-  {% if page.riskDataCreatedDate %}
+  {% if page.auditInfo %}
     <p class="govuk-hint">
-        Imported from OASys on <strong>{{page.riskDataCreatedDate}}</strong>
+        {{ page.auditInfo | safe }}
     </p>
   {% endif %}
 


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### OASys Import (No changes)

![image](https://github.com/user-attachments/assets/bef68ca2-9174-41bc-8e97-49b0951494b5)


### Before Manual Rosh
![image](https://github.com/user-attachments/assets/0c8ee751-b799-45bd-9f85-2c5b91054f26)


### After Manual Rosh
![image](https://github.com/user-attachments/assets/9988e9b5-a16c-4941-9b54-76e01981c72f)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
