### PR TITLE
Display Manual RoSH data in 'Check your answers' page

### DIFF
--- a/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
@@ -51,9 +51,14 @@ export default class CheckYourAnswersPage extends ApplyPage {
     this.shouldShowQuestionsAndAnswers('risk-to-self')
   }
 
-  shouldShowRoshAnswers(): void {
+  shouldShowRoshAnswers(manualRosh: boolean): void {
     this.shouldShowCheckYourAnswersTitle('risk-of-serious-harm', 'Add risk of serious harm (RoSH) information')
-    this.shouldShowQuestionsAndAnswers('risk-of-serious-harm')
+    if (manualRosh) {
+      const pageToExclude = ['risk-management-arrangements']
+      this.shouldShowQuestionsAndAnswers('risk-of-serious-harm', pageToExclude)
+    } else {
+      this.shouldShowQuestionsAndAnswers('risk-of-serious-harm')
+    }
   }
 
   shouldShowOffendingHistoryAnswers() {
@@ -67,11 +72,12 @@ export default class CheckYourAnswersPage extends ApplyPage {
     })
   }
 
-  shouldShowQuestionsAndAnswers(task: string) {
+  shouldShowQuestionsAndAnswers(task: string, pagesWithQuestionsToExclude: Array<string> = []) {
+    const pagesWithoutQuestions = ['summary', 'summary-data', 'oasys-import', 'acct']
+    const pagesToExclude = pagesWithoutQuestions.concat(pagesWithQuestionsToExclude)
     const pageKeys = Object.keys(this.application.data[task])
     pageKeys.forEach(pageKey => {
-      const pagesWithoutQuestions = ['summary', 'summary-data', 'oasys-import', 'acct']
-      if (pagesWithoutQuestions.includes(pageKey)) {
+      if (pagesToExclude.includes(pageKey)) {
         return
       }
       const PageClass = getPage(task, pageKey)

--- a/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
+++ b/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
@@ -3,10 +3,42 @@
 //  When I view the 'check your answers' page
 //  Then I see a list of questions and answers for the application
 
+import { Cas2Application } from '@approved-premises/api'
 import Page from '../../../pages/page'
 import CheckYourAnswersPage from '../../../pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage'
 import { personFactory, applicationFactory } from '../../../../server/testutils/factories/index'
 import TaskListPage from '../../../pages/apply/taskListPage'
+
+const manualRoshRiskOfSeriousHarm = {
+  'old-oasys': {
+    hasOldOasys: 'no',
+    'oasysCompletedDate-year': '',
+    'oasysCompletedDate-month': '',
+    'oasysCompletedDate-day': '',
+  },
+  'manual-rosh-information': {
+    riskToChildren: 'Low',
+    riskToPublic: 'Low',
+    riskToKnownAdult: 'Medium',
+    riskToStaff: 'Low',
+    overallRisk: 'High',
+    createdAt: '2025-02-28T10:45:08.528Z',
+  },
+  'risk-to-others': {
+    whoIsAtRisk: 'test',
+    natureOfRisk: 'test',
+    confirmation: 'confirmed',
+  },
+  'risk-management-arrangements': {
+    arrangements: 'no',
+  },
+  'cell-share-information': {
+    hasCellShareComments: 'no',
+  },
+  'additional-risk-information': {
+    hasAdditionalInformation: 'no',
+  },
+}
 
 context('Check your answers page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -24,24 +56,37 @@ context('Check your answers page', () => {
         data: applicationData,
       })
       cy.wrap(application).as('application')
+
+      // mock application with manual RoSH
+      const applicationDataWithManualRosh = applicationData
+      applicationDataWithManualRosh['risk-of-serious-harm'] = manualRoshRiskOfSeriousHarm
+      const applicationWithManualRosh = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationDataWithManualRosh,
+      })
+      cy.wrap(applicationWithManualRosh).as('applicationWithManualRosh')
     })
   })
 
-  beforeEach(function test() {
+  const beforeTest = (application: Cas2Application) => {
     // And an application exists
     // -------------------------
-    cy.task('stubApplicationGet', { application: this.application })
-    cy.task('stubApplicationUpdate', { application: this.application })
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplicationUpdate', { application })
 
     // Given I am logged in
     //---------------------
     cy.signIn()
-  })
+  }
 
   //  Scenario: check my answers
   //  When I view the 'check your answers' page
   //  Then I see a list of questions and answers for the application
   it('presents check your answers page', function test() {
+    const manualRosh = false
+    beforeTest(this.application)
+
     //  When I view the 'check your answers' page
     TaskListPage.visit(this.application)
     const taskListPage = Page.verifyOnPage(TaskListPage)
@@ -61,7 +106,7 @@ context('Check your answers page', () => {
     page.shouldShowEqualityAndDiversityAnswers()
     page.shouldShowHealthNeedsAnswers()
     page.shouldShowRiskToSelfAnswers()
-    page.shouldShowRoshAnswers()
+    page.shouldShowRoshAnswers(manualRosh)
     page.shouldShowOffendingHistoryAnswers()
   })
 
@@ -70,6 +115,7 @@ context('Check your answers page', () => {
   //  And I confirm the information is correct
   //  Then I am taken to the task list page
   it('navigates to the task list page once the referrer confirms details are correct', function test() {
+    beforeTest(this.application)
     //  When I view the 'check your answers' page
     TaskListPage.visit(this.application)
     const taskListPage = Page.verifyOnPage(TaskListPage)
@@ -84,5 +130,36 @@ context('Check your answers page', () => {
 
     //  Then I am taken to the task list page
     Page.verifyOnPage(TaskListPage, this.application)
+  })
+
+  it('presents check your answers page with manual RoSH data', function test() {
+    const manualRosh = true
+    beforeTest(this.applicationWithManualRosh)
+    //  When I view the 'check your answers' page
+    TaskListPage.visit(this.applicationWithManualRosh)
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.visitTask('Check application answers')
+    const page = Page.verifyOnPage(CheckYourAnswersPage, this.applicationWithManualRosh)
+
+    // And I see a list questions and answers for the Manual RoSH data
+    page.shouldShowRoshAnswers(manualRosh)
+  })
+
+  it('navigates to the task list page once the referrer confirms details are correct with manual RoSH data', function test() {
+    beforeTest(this.applicationWithManualRosh)
+    //  When I view the 'check your answers' page
+    TaskListPage.visit(this.applicationWithManualRosh)
+    const taskListPage = Page.verifyOnPage(TaskListPage)
+    taskListPage.visitTask('Check application answers')
+    const page = Page.verifyOnPage(CheckYourAnswersPage, this.applicationWithManualRosh)
+
+    //  When I confirm the information is correct
+    page.checkCheckboxByValue('confirmed')
+
+    //  When I continue to the next task / page
+    page.clickSubmit()
+
+    //  Then I am taken to the task list page
+    Page.verifyOnPage(TaskListPage, this.applicationWithManualRosh)
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.test.ts
@@ -113,4 +113,25 @@ describe('ManualRoshInformation', () => {
         })
       })
   })
+
+  describe('response', () => {
+    const body: ManualRoshBody = {
+      overallRisk: 'Very high',
+      riskToChildren: 'Medium',
+      riskToPublic: 'Low',
+      riskToKnownAdult: 'High',
+      riskToStaff: 'Low',
+    }
+
+    it('returns manual-rosh data', () => {
+      const page = new ManualRoshInformation(body, application)
+      expect(page.response()).toEqual({
+        'Overall risk rating': body.overallRisk,
+        'Risk to children': body.riskToChildren,
+        'Risk to known adult': body.riskToKnownAdult,
+        'Risk to public': body.riskToPublic,
+        'Risk to staff': body.riskToStaff,
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-of-serious-harm/custom-forms/manualRoshInformation.ts
@@ -78,4 +78,14 @@ export default class ManualRoshInformation implements TaskListPage {
 
     return convertKeyValuePairToRadioItems(transformedOptions, this.body[fieldName])
   }
+
+  response() {
+    return {
+      'Overall risk rating': this.body.overallRisk,
+      'Risk to children': this.body.riskToChildren,
+      'Risk to known adult': this.body.riskToKnownAdult,
+      'Risk to public': this.body.riskToPublic,
+      'Risk to staff': this.body.riskToStaff,
+    }
+  }
 }


### PR DESCRIPTION
# Context
`JIRA`: https://dsdmoj.atlassian.net/browse/CAS-1478

# Changes in this PR
* Display the manually entered RoSH data on the 'Check your answers' page
* Unit test coverage
* Integration test coverage

## Screenshots of UI changes

### Before
<img width="2048" alt="no_rosh" src="https://github.com/user-attachments/assets/5e4f7bda-a1d6-4d3b-82f3-cfeb34b10e43" />

### After
![manual_rosh_screenshot](https://github.com/user-attachments/assets/a6bd0930-a524-4f85-9bbd-d4a739f92638)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
