### PR TITLE
Fix for "create a CAS-2 application with no OASys" local e2e test:

### DIFF
--- a/e2e-tests/testOptions.ts
+++ b/e2e-tests/testOptions.ts
@@ -9,6 +9,11 @@ export type TestOptions = {
     name: string
     nomsNumber: string
   }
+  personWithLaoRestrictions: {
+    crn: string
+    name: string
+    nomsNumber: string
+  }
   pomUser: {
     name: string
     username: string

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,10 +67,15 @@ export default defineConfig<TestOptions>({
           crn: 'X320741',
           nomsNumber: 'A1234AI',
         },
-        personWithoutOasys: {
+        personWithLaoRestrictions: {
           name: 'James Brown',
           crn: 'C246139',
           nomsNumber: 'A1234AJ',
+        },
+        personWithoutOasys: {
+          name: 'Teresa Green',
+          crn: 'S517283',
+          nomsNumber: 'A1237AI',
         },
         pomUser: {
           name: 'Prison Officer',


### PR DESCRIPTION
## PR changes
* Fix for "create a CAS-2 application with no OASys" local e2e test
* Change personWithoutOasys user to Teresa Green
* Create new personWithLaoRestrictions and set them to James Brown

## Screenshots of UI changes

<img width="2048" alt="success" src="https://github.com/user-attachments/assets/dca25d04-8de0-4cc5-9fbb-522cb271eee9" />
