### PR TITLE
Fix in Allocated Applications - Application owner was showing wrong name

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -180,7 +180,7 @@ describe('prisonDashboardTableRows', () => {
           text: applicationA.nomsNumber,
         },
         {
-          text: applicationA.createdByUserName,
+          text: applicationA.allocatedPomName,
         },
         {
           text: '10 December 2024',
@@ -197,7 +197,7 @@ describe('prisonDashboardTableRows', () => {
           text: applicationB.nomsNumber,
         },
         {
-          text: applicationB.createdByUserName,
+          text: applicationB.allocatedPomName,
         },
         {
           text: '11 December 2024',
@@ -230,7 +230,7 @@ describe('prisonDashboardTableRows', () => {
           text: applicationA.nomsNumber,
         },
         {
-          text: applicationA.createdByUserName,
+          text: applicationA.allocatedPomName,
         },
         null,
         {
@@ -245,7 +245,7 @@ describe('prisonDashboardTableRows', () => {
           text: applicationB.nomsNumber,
         },
         {
-          text: applicationB.createdByUserName,
+          text: applicationB.allocatedPomName,
         },
         {
           text: '11 December 2024',

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -136,7 +136,7 @@ export const prisonDashboardTableRows = (applications: Array<Cas2ApplicationSumm
     return [
       nameAnchorElement(application.personName, application.id),
       textValue(application.nomsNumber),
-      textValue(application.createdByUserName),
+      textValue(application.allocatedPomName),
       application.hdcEligibilityDate
         ? textValue(DateFormats.isoDateToUIDate(application.hdcEligibilityDate, { format: 'medium' }))
         : null,


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1594

# Changes in this PR
- always use the `allocatedPomName` value  on the `CAS2Application` in the "Application Owner" column (instead of the `createdByUserName` value)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
