### PR TITLE
Switch to fetching image to ghcr.io for deployment

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -5,7 +5,7 @@ generic-service:
   replicaCount: 4
 
   image:
-    repository: quay.io/hmpps/hmpps-community-accommodation-tier-2-ui
+    repository: ghcr.io/hmpps/hmpps-community-accommodation-tier-2-ui
     tag: app_version # override at deployment time
     port: 3000
 


### PR DESCRIPTION
This should fix the failed deployment: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/actions/runs/14728190892/job/41338147167

Note: SRE will be adding this to the guidance on moving to Github Actions.