### PR TITLE
Fix container registry path

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-ui/values.yaml
@@ -5,7 +5,7 @@ generic-service:
   replicaCount: 4
 
   image:
-    repository: ghcr.io/hmpps/hmpps-community-accommodation-tier-2-ui
+    repository: ghcr.io/ministryofjustice/hmpps-community-accommodation-tier-2-ui
     tag: app_version # override at deployment time
     port: 3000
 


### PR DESCRIPTION
Container registry was updated to `ghcr.io` but path to organisation was still incorrect 🤦‍♂️ ... This now matches the path used for other CAS UIs:

- CAS1: https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/helm_deploy/hmpps-approved-premises-ui/values.yaml#L8
- CAS3: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml#L9