### PR TITLE
Set new AssignmentType values as params when GET Cas2ApplicationSummary

### DIFF
--- a/integration_tests/tests/apply/cancel_in_progress_application.cy.ts
+++ b/integration_tests/tests/apply/cancel_in_progress_application.cy.ts
@@ -78,8 +78,8 @@ context('Cancel an in progress application', () => {
 
     cy.task('stubFindPerson', { person })
     cy.task('stubApplicationAbandon', { application })
-    cy.task('stubApplications', { applications: inProgressApplicationSummaries, assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: inProgressApplicationSummaries, assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
     cy.task('stubApplicationGet', { application })
   })

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -55,8 +55,8 @@ context('Applications dashboard', () => {
       latestStatusUpdate: null,
     })
 
-    cy.task('stubApplications', { applications: inProgressApplications, assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: inProgressApplications, assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the Previous Applications page
@@ -75,8 +75,8 @@ context('Applications dashboard', () => {
       status: 'submitted',
     })
 
-    cy.task('stubApplications', { applications: [], assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the submitted applications tab
@@ -96,8 +96,8 @@ context('Applications dashboard', () => {
       status: 'submitted',
     })
 
-    cy.task('stubApplications', { applications: [], assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: transferredOutApplications, assignmentType: 'DEALLOCATED' })
 
     // I visit the Transferred Applications tab
@@ -110,8 +110,8 @@ context('Applications dashboard', () => {
   //  Scenario: hide submitted applications
   it('hides submitted applications', () => {
     //  There are no transferred out applications in the database
-    cy.task('stubApplications', { applications: [], assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the Your Applications page
@@ -128,8 +128,8 @@ context('Applications dashboard', () => {
       status: 'submitted',
     })
 
-    cy.task('stubApplications', { applications: [], assignmentType: 'CREATED' })
-    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'ALLOCATED' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
+    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'PRISON' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // Then I see a tab for my prison's applications

--- a/integration_tests/tests/apply/prison_dashboard.cy.ts
+++ b/integration_tests/tests/apply/prison_dashboard.cy.ts
@@ -33,7 +33,7 @@ context('PrisonDashboard', () => {
 
     //  And there are applications for my prison in the database
     const applications = applicationSummaryFactory.buildList(5)
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'ALLOCATED', page: 1 })
+    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 1 })
     cy.task('stubPrisonApplications', { applications: [], prisonCode, assignmentType: 'UNALLOCATED', page: 1 })
 
     //  When I visit the prison dashboard
@@ -45,7 +45,7 @@ context('PrisonDashboard', () => {
     //  And no Transferred In applications
     page.shouldHideTransferredIn()
 
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'ALLOCATED', page: 2 })
+    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 2 })
     cy.task('stubPrisonApplications', { applications: [], prisonCode, assignmentType: 'UNALLOCATED', page: 2 })
 
     page.clickPageNumber('2')
@@ -74,7 +74,7 @@ context('PrisonDashboard', () => {
 
     // And there are allocated applications for my prison in the database
     const applications = applicationSummaryFactory.buildList(5)
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'ALLOCATED', page: 1 })
+    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 1 })
 
     // When I visit the prison dashboard
     const page = PrisonDashboardPage.visit()
@@ -91,7 +91,7 @@ context('PrisonDashboard', () => {
       assignmentType: 'UNALLOCATED',
       page: 2,
     })
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'ALLOCATED', page: 2 })
+    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 2 })
     page.clickPageNumber('2')
     page.shouldShowApplications(applications)
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -77,7 +77,7 @@ describeClient('ApplicationClient', provider => {
 
   describe('getApplicationsForUser', () => {
     describe('when returning a list of transferred out applications for the user', () => {
-      const assignmentTypes: Array<AssignmentType> = ['CREATED', 'ALLOCATED', 'DEALLOCATED']
+      const assignmentTypes: Array<AssignmentType> = ['IN_PROGRESS', 'PRISON', 'DEALLOCATED']
 
       it.each(assignmentTypes)('should return applications for given user', async assignmentType => {
         const applicationsForUser = applicationFactory.buildList(5)
@@ -108,6 +108,7 @@ describeClient('ApplicationClient', provider => {
   describe('getApplicationsForPrison', () => {
     describe('when returning a list of allocated applications for a given prison', () => {
       it('should get all allocated applications for a given prison', async () => {
+        const assignmentType = 'IN_PROGRESS'
         const applications = applicationFactory.buildList(5)
 
         provider.addInteraction({
@@ -118,7 +119,7 @@ describeClient('ApplicationClient', provider => {
             path: paths.applications.index.pattern,
             query: {
               prisonCode: '123',
-              assignmentType: 'ALLOCATED',
+              assignmentType,
               page: '1',
             },
             headers: {
@@ -136,7 +137,7 @@ describeClient('ApplicationClient', provider => {
           },
         })
 
-        const result = await applicationClient.getApplicationsForPrison('123', 1, 'ALLOCATED')
+        const result = await applicationClient.getApplicationsForPrison('123', 1, assignmentType)
 
         expect(result).toEqual({
           data: applications,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -75,10 +75,10 @@ describe('ApplicationService', () => {
 
     it('fetches all applications', async () => {
       applicationClient.getApplicationsForUser.mockImplementation(arg => {
-        if (arg === 'CREATED') {
+        if (arg === 'IN_PROGRESS') {
           return Promise.resolve(Object.values(applications.inProgress).flat())
         }
-        if (arg === 'ALLOCATED') {
+        if (arg === 'PRISON') {
           return Promise.resolve(Object.values(applications.submitted).flat())
         }
         if (arg === 'DEALLOCATED') {
@@ -123,7 +123,7 @@ describe('ApplicationService', () => {
       expect(result.totalResults).toEqual('500')
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.getApplicationsForPrison).toHaveBeenCalledWith('123', 2, 'ALLOCATED')
+      expect(applicationClient.getApplicationsForPrison).toHaveBeenCalledWith('123', 2, 'PRISON')
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -39,8 +39,8 @@ export default class ApplicationService {
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {
     const applicationClient = this.applicationClientFactory(token)
     const [inProgress, submitted, transferredOut] = await Promise.all([
-      applicationClient.getApplicationsForUser('CREATED'),
-      applicationClient.getApplicationsForUser('ALLOCATED'),
+      applicationClient.getApplicationsForUser('IN_PROGRESS'),
+      applicationClient.getApplicationsForUser('PRISON'),
       applicationClient.getApplicationsForUser('DEALLOCATED'),
     ])
 
@@ -58,7 +58,7 @@ export default class ApplicationService {
   ): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    return applicationClient.getApplicationsForPrison(prisonCode, pageNumber, 'ALLOCATED')
+    return applicationClient.getApplicationsForPrison(prisonCode, pageNumber, 'PRISON')
   }
 
   async getPrisonNewTransferredIn(


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1629

# Changes in this PR
* Set new `AssignmentType` values as params on the GET Cas2ApplicationSummary endpoint calls so that `CREATED -> IN_PROGRESS` and `ALLOCATED -> PRISON`
* Note thaat the BE behaves the same way as is backwards compatible for now - no new functionality

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
