### PR TITLE
Fix/cas 1633 referrer details blank through confirm details

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -56,12 +56,14 @@ export const confirmApplicant = async (page: Page) => {
   await confirmApplicantPage.clickButton('Confirm and continue')
 }
 
-export const completeBeforeYouStartSection = async (page: Page, name: string) => {
+export const completeBeforeYouStartSection = async (page: Page, name: string): Promise<string> => {
   await completeEligibilityTask(page, name)
   await completeConsentTask(page, name)
   await completeHDCLicenceDatesTask(page, name)
-  await completeReferrerDetailsTask(page)
+  const userEmail = await completeReferrerDetailsTask(page)
   await completeCheckInformationTask(page)
+
+  return userEmail
 }
 
 export const completeAreaAndFundingSection = async (page: Page, name: string) => {
@@ -92,8 +94,8 @@ export const completeOffenceAndLicenceInformationSection = async (page: Page, na
   await completeCPPDetailsAndHDCLicenceConditionsTask(page, name)
 }
 
-export const completeCheckAnswersSection = async (page: Page, name: string) => {
-  await completeCheckAnswersTask(page, name)
+export const completeCheckAnswersSection = async (page: Page, name: string, user: TestOptions['user']) => {
+  await completeCheckAnswersTask(page, name, user)
 }
 
 export const submitApplication = async (page: Page) => {

--- a/e2e-tests/steps/beforeYouStartSection.ts
+++ b/e2e-tests/steps/beforeYouStartSection.ts
@@ -45,19 +45,23 @@ export const completeHDCLicenceDatesTask = async (page: Page, name: string) => {
   await hdcLicenceDatesPage.clickSave()
 }
 
-export const completeReferrerDetailsTask = async (page: Page) => {
+export const completeReferrerDetailsTask = async (page: Page): Promise<string> => {
   const taskListPage = new TaskListPage(page)
   await taskListPage.clickTask('Add referrer details')
 
-  await completeConfirmDetailsPage(page)
+  const userEmail = await completeConfirmDetailsPage(page)
   await completeJobTitlePage(page)
   await completeContactNumberPage(page)
+
+  return userEmail
 }
 
-async function completeConfirmDetailsPage(page: Page) {
+async function completeConfirmDetailsPage(page: Page): Promise<string> {
   const confirmDetailsPage = await ApplyPage.initialize(page, `Confirm your details`)
+  const email = await page.locator(`dt:has-text("Email address") + dd`).textContent()
 
   await confirmDetailsPage.clickSave()
+  return email?.trim() || ''
 }
 
 async function completeJobTitlePage(page: Page) {

--- a/e2e-tests/steps/checkAnswersSection.ts
+++ b/e2e-tests/steps/checkAnswersSection.ts
@@ -1,12 +1,33 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
+import { TestOptions } from 'e2e-tests/testOptions'
 import { ApplyPage, TaskListPage } from '../pages/apply'
 
-export const completeCheckAnswersTask = async (page: Page, name: string) => {
+export const completeCheckAnswersTask = async (page: Page, name: string, user: TestOptions['pomUser']) => {
   const taskListPage = new TaskListPage(page)
   await taskListPage.clickTask('Check application answers')
+  await verifySectionDetails(page, '#add-referrer-details', [
+    { key: 'Name', value: user.name },
+    { key: 'Email address', value: user.email },
+  ])
+
   const checkAnswersPage = await ApplyPage.initialize(page, `Check ${name}'s application`)
   await checkAnswersPage.checkCheckboxes([
     'I confirm to the best of my knowledge, the information provided in this referral is accurate and, where required, it has been verified by all relevant prison departments.',
   ])
   await checkAnswersPage.clickContinue()
+}
+
+async function verifySectionDetails(
+  page: Page,
+  sectionReference: string,
+  keyValuePairs: Array<{ key: string; value: string }>,
+) {
+  const section = page.locator(sectionReference)
+
+  const sectionDetailChecks = keyValuePairs.map(({ key, value }) => {
+    const valueLocator = section.locator(`dt:has-text("${key}") + dd`)
+    return expect(valueLocator).toHaveText(value)
+  })
+
+  await Promise.all(sectionDetailChecks)
 }

--- a/e2e-tests/testOptions.ts
+++ b/e2e-tests/testOptions.ts
@@ -18,11 +18,13 @@ export type TestOptions = {
     name: string
     username: string
     password: string
+    email?: string
   }
   lcaUser: {
     name: string
     username: string
     password: string
+    email?: string
   }
   adminUser: {
     name: string
@@ -39,4 +41,5 @@ export type TestOptions = {
     username: string
     password: string
   }
+  user: TestOptions['pomUser'] | TestOptions['lcaUser']
 }

--- a/e2e-tests/tests/01_apply_as_pom.spec.ts
+++ b/e2e-tests/tests/01_apply_as_pom.spec.ts
@@ -28,12 +28,14 @@ test('create a CAS-2 application', async ({ page, person, pomUser }) => {
   await startAnApplication(page)
   await enterPrisonerNumber(page, person.nomsNumber)
   await confirmApplicant(page)
-  await completeBeforeYouStartSection(page, person.name)
+  const userEmail = await completeBeforeYouStartSection(page, person.name)
+  const updatedPomUser = { ...pomUser, email: userEmail }
+
   await completeAreaAndFundingSection(page, person.name)
   await completeAboutThePersonSection(page, person.name)
   await completeRisksAndNeedsSection(page, person.name)
   await completeOffenceAndLicenceInformationSection(page, person.name)
-  await completeCheckAnswersSection(page, person.name)
+  await completeCheckAnswersSection(page, person.name, updatedPomUser)
   await expect(page.getByText('You have completed 17 of 17 tasks')).toBeVisible()
   await submitApplication(page)
 })

--- a/e2e-tests/tests/02_apply_as_lca.spec.ts
+++ b/e2e-tests/tests/02_apply_as_lca.spec.ts
@@ -24,12 +24,14 @@ test('create a CAS-2 application', async ({ page, person, lcaUser }) => {
   await startAnApplication(page)
   await enterPrisonerNumber(page, person.nomsNumber)
   await confirmApplicant(page)
-  await completeBeforeYouStartSection(page, person.name)
+  const userEmail = await completeBeforeYouStartSection(page, person.name)
+  const updatedLCAUser = { ...lcaUser, email: userEmail }
+
   await completeAreaAndFundingSection(page, person.name)
   await completeAboutThePersonSection(page, person.name)
   await completeRisksAndNeedsSection(page, person.name)
   await completeOffenceAndLicenceInformationSection(page, person.name)
-  await completeCheckAnswersSection(page, person.name)
+  await completeCheckAnswersSection(page, person.name, updatedLCAUser)
   await expect(page.getByText('You have completed 17 of 17 tasks')).toBeVisible()
   await submitApplication(page)
 })

--- a/integration_tests/tests/apply/before_you_apply/referrer-details/confirm_details.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/referrer-details/confirm_details.cy.ts
@@ -63,13 +63,16 @@ context('Complete "Confirm details" page in "Referrer details" task', () => {
   //  Then I see the 'Job title' page
   it('submits the correct fields and continues to next page', function test() {
     const page = Page.verifyOnPage(ConfirmDetailsPage, this.application)
-  
+
     // Stub the application update API call
-    cy.intercept('POST', `/applications/${this.application.id}/tasks/referrer-details/pages/confirm-details?_method=PUT`).as('applicationUpdate')
-  
+    cy.intercept(
+      'POST',
+      `/applications/${this.application.id}/tasks/referrer-details/pages/confirm-details?_method=PUT`,
+    ).as('applicationUpdate')
+
     // When I click 'Save and continue'
     page.clickSubmit()
-  
+
     // Wait for the application update API call and assert the body contains the expected fields
     cy.wait('@applicationUpdate').then(interception => {
       const requestBody = interception.request.body

--- a/integration_tests/tests/apply/before_you_apply/referrer-details/confirm_details.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/referrer-details/confirm_details.cy.ts
@@ -57,14 +57,27 @@ context('Complete "Confirm details" page in "Referrer details" task', () => {
     Page.verifyOnPage(ConfirmDetailsPage, this.application)
   })
 
-  //  Scenario: Continue to next page
+  //  Scenario: Submits correct fields and continues to next page
   //  When I click 'Save and continue'
+  //  Then API call is made with the correct fields
   //  Then I see the 'Job title' page
-  it('continues to next page', function test() {
+  it('submits the correct fields and continues to next page', function test() {
     const page = Page.verifyOnPage(ConfirmDetailsPage, this.application)
-
-    //  When I click 'Save and continue'
+  
+    // Stub the application update API call
+    cy.intercept('POST', `/applications/${this.application.id}/tasks/referrer-details/pages/confirm-details?_method=PUT`).as('applicationUpdate')
+  
+    // When I click 'Save and continue'
     page.clickSubmit()
+  
+    // Wait for the application update API call and assert the body contains the expected fields
+    cy.wait('@applicationUpdate').then(interception => {
+      const requestBody = interception.request.body
+
+      // Assert that the body includes the correct fields
+      expect(requestBody).to.include(`name=${encodeURIComponent(this.application.createdBy.name).replace(/%20/g, '+')}`)
+      expect(requestBody).to.include(`email=${encodeURIComponent(this.application.createdBy.email)}`)
+    })
 
     // Then I see the 'Job title' page
     Page.verifyOnPage(JobTitlePage, this.application)

--- a/server/views/applications/pages/referrer-details/confirm-details.njk
+++ b/server/views/applications/pages/referrer-details/confirm-details.njk
@@ -28,6 +28,9 @@
         ]
   }) }}
 
+  <input type="hidden" name="name" value="{{ page.referrerDetails.name }}">
+  <input type="hidden" name="email" value="{{ page.referrerDetails.email }}">
+
   {{ govukWarningText({
     text: "If any of these details are wrong, contact the CAS-2 team with the correct details when you submit the application.",
     iconFallbackText: "Warning"


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1633) was to fix an issue with referrer details not being submitted on save.

# Changes in this PR

## Screenshots of UI changes

### Before

<img width="827" alt="image" src="https://github.com/user-attachments/assets/393bdf39-f7fb-47a7-ba9a-ffeac0c67730" />


### After

<img width="830" alt="image" src="https://github.com/user-attachments/assets/caadb9b3-36cb-401d-8f8e-13f7055af394" />


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
