### PR TITLE
Bug Fix for assignment-type params being sent to get CAS2 applications

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -46,14 +46,13 @@ export default {
     }),
   stubPrisonApplications: (args: {
     applications: Array<Application>
-    prisonCode: string
     page: number
     assignmentType: AssignmentType
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/applications?page=${args.page}&prisonCode=${args.prisonCode}&assignmentType=${args.assignmentType}`,
+        url: `/cas2/applications?page=${args.page}&assignmentType=${args.assignmentType}`,
       },
       response: {
         status: 200,

--- a/integration_tests/tests/apply/cancel_in_progress_application.cy.ts
+++ b/integration_tests/tests/apply/cancel_in_progress_application.cy.ts
@@ -79,7 +79,7 @@ context('Cancel an in progress application', () => {
     cy.task('stubFindPerson', { person })
     cy.task('stubApplicationAbandon', { application })
     cy.task('stubApplications', { applications: inProgressApplicationSummaries, assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
     cy.task('stubApplicationGet', { application })
   })

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -56,7 +56,7 @@ context('Applications dashboard', () => {
     })
 
     cy.task('stubApplications', { applications: inProgressApplications, assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the Previous Applications page
@@ -76,7 +76,7 @@ context('Applications dashboard', () => {
     })
 
     cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the submitted applications tab
@@ -97,7 +97,7 @@ context('Applications dashboard', () => {
     })
 
     cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: transferredOutApplications, assignmentType: 'DEALLOCATED' })
 
     // I visit the Transferred Applications tab
@@ -111,7 +111,7 @@ context('Applications dashboard', () => {
   it('hides submitted applications', () => {
     //  There are no transferred out applications in the database
     cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: [], assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: [], assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // I visit the Your Applications page
@@ -129,7 +129,7 @@ context('Applications dashboard', () => {
     })
 
     cy.task('stubApplications', { applications: [], assignmentType: 'IN_PROGRESS' })
-    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'PRISON' })
+    cy.task('stubApplications', { applications: submittedApplications, assignmentType: 'ALLOCATED' })
     cy.task('stubApplications', { applications: [], assignmentType: 'DEALLOCATED' })
 
     // Then I see a tab for my prison's applications

--- a/integration_tests/tests/apply/prison_dashboard.cy.ts
+++ b/integration_tests/tests/apply/prison_dashboard.cy.ts
@@ -33,8 +33,8 @@ context('PrisonDashboard', () => {
 
     //  And there are applications for my prison in the database
     const applications = applicationSummaryFactory.buildList(5)
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 1 })
-    cy.task('stubPrisonApplications', { applications: [], prisonCode, assignmentType: 'UNALLOCATED', page: 1 })
+    cy.task('stubPrisonApplications', { applications, assignmentType: 'PRISON', page: 1 })
+    cy.task('stubPrisonApplications', { applications: [], assignmentType: 'UNALLOCATED', page: 1 })
 
     //  When I visit the prison dashboard
     const page = PrisonDashboardPage.visit()
@@ -45,8 +45,8 @@ context('PrisonDashboard', () => {
     //  And no Transferred In applications
     page.shouldHideTransferredIn()
 
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 2 })
-    cy.task('stubPrisonApplications', { applications: [], prisonCode, assignmentType: 'UNALLOCATED', page: 2 })
+    cy.task('stubPrisonApplications', { applications, assignmentType: 'PRISON', page: 2 })
+    cy.task('stubPrisonApplications', { applications: [], assignmentType: 'UNALLOCATED', page: 2 })
 
     page.clickPageNumber('2')
     page.shouldShowApplications(applications)
@@ -67,14 +67,13 @@ context('PrisonDashboard', () => {
     const transferredInApplication = applicationSummaryFactory.buildList(5)
     cy.task('stubPrisonApplications', {
       applications: transferredInApplication,
-      prisonCode,
       assignmentType: 'UNALLOCATED',
       page: 1,
     })
 
     // And there are allocated applications for my prison in the database
     const applications = applicationSummaryFactory.buildList(5)
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 1 })
+    cy.task('stubPrisonApplications', { applications, assignmentType: 'PRISON', page: 1 })
 
     // When I visit the prison dashboard
     const page = PrisonDashboardPage.visit()
@@ -87,11 +86,10 @@ context('PrisonDashboard', () => {
 
     cy.task('stubPrisonApplications', {
       applications: transferredInApplication,
-      prisonCode,
       assignmentType: 'UNALLOCATED',
       page: 2,
     })
-    cy.task('stubPrisonApplications', { applications, prisonCode, assignmentType: 'PRISON', page: 2 })
+    cy.task('stubPrisonApplications', { applications, assignmentType: 'PRISON', page: 2 })
     page.clickPageNumber('2')
     page.shouldShowApplications(applications)
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -306,17 +306,9 @@ export default class ApplicationsController {
     return async (req: Request, res: Response) => {
       const { pageNumber, hrefPrefix } = getPaginationDetails(req, paths.applications.prison({}))
 
-      const transferredIn = await this.applicationService.getPrisonNewTransferredIn(
-        req.user.token,
-        res.locals.user.activeCaseLoadId,
-        pageNumber,
-      )
+      const transferredIn = await this.applicationService.getPrisonNewTransferredIn(req.user.token, pageNumber)
 
-      const result = await this.applicationService.getAllByPrison(
-        req.user.token,
-        res.locals.user.activeCaseLoadId,
-        pageNumber,
-      )
+      const result = await this.applicationService.getAllByPrison(req.user.token, pageNumber)
 
       return res.render('applications/prison-dashboard', {
         applications: result.data,

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -75,7 +75,7 @@ describeClient('ApplicationClient', provider => {
     })
   })
 
-  describe('getApplicationsForUser', () => {
+  describe('getApplications', () => {
     describe('when returning a list of transferred out applications for the user', () => {
       const assignmentTypes: Array<AssignmentType> = ['IN_PROGRESS', 'PRISON', 'DEALLOCATED']
 
@@ -99,16 +99,16 @@ describeClient('ApplicationClient', provider => {
           },
         })
 
-        const result = await applicationClient.getApplicationsForUser(assignmentType)
+        const result = await applicationClient.getApplications(assignmentType)
         expect(result).toEqual(applicationsForUser)
       })
     })
   })
 
-  describe('getApplicationsForPrison', () => {
+  describe('getPagedApplications', () => {
     describe('when returning a list of allocated applications for a given prison', () => {
       it('should get all allocated applications for a given prison', async () => {
-        const assignmentType = 'IN_PROGRESS'
+        const assignmentType = 'PRISON'
         const applications = applicationFactory.buildList(5)
 
         provider.addInteraction({
@@ -118,7 +118,6 @@ describeClient('ApplicationClient', provider => {
             method: 'GET',
             path: paths.applications.index.pattern,
             query: {
-              prisonCode: '123',
               assignmentType,
               page: '1',
             },
@@ -137,7 +136,7 @@ describeClient('ApplicationClient', provider => {
           },
         })
 
-        const result = await applicationClient.getApplicationsForPrison('123', 1, assignmentType)
+        const result = await applicationClient.getPagedApplications(1, assignmentType)
 
         expect(result).toEqual({
           data: applications,
@@ -160,7 +159,6 @@ describeClient('ApplicationClient', provider => {
             method: 'GET',
             path: paths.applications.index.pattern,
             query: {
-              prisonCode: '123',
               assignmentType: 'UNALLOCATED',
               page: '1',
             },
@@ -179,7 +177,7 @@ describeClient('ApplicationClient', provider => {
           },
         })
 
-        const result = await applicationClient.getApplicationsForPrison('123', 1, 'UNALLOCATED')
+        const result = await applicationClient.getPagedApplications(1, 'UNALLOCATED')
 
         expect(result).toEqual({
           data: applications,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -32,22 +32,21 @@ export default class ApplicationClient {
     })) as Application
   }
 
-  async getApplicationsForUser(assignmentType: AssignmentType): Promise<Array<Cas2ApplicationSummary>> {
+  async getApplications(assignmentType: AssignmentType): Promise<Array<Cas2ApplicationSummary>> {
     return (await this.restClient.get({
       path: paths.applications.index.pattern,
       query: createQueryString({ assignmentType }),
     })) as Array<Cas2ApplicationSummary>
   }
 
-  async getApplicationsForPrison(
-    prisonCode: string,
+  async getPagedApplications(
     pageNumber: number,
     assignmentType: AssignmentType,
   ): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
     return this.restClient.getPaginatedResponse<Cas2ApplicationSummary>({
       path: paths.applications.index.pattern,
       page: pageNumber.toString(),
-      query: { prisonCode, assignmentType },
+      query: { assignmentType },
     })
   }
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -74,11 +74,11 @@ describe('ApplicationService', () => {
     }
 
     it('fetches all applications', async () => {
-      applicationClient.getApplicationsForUser.mockImplementation(arg => {
+      applicationClient.getApplications.mockImplementation(arg => {
         if (arg === 'IN_PROGRESS') {
           return Promise.resolve(Object.values(applications.inProgress).flat())
         }
-        if (arg === 'PRISON') {
+        if (arg === 'ALLOCATED') {
           return Promise.resolve(Object.values(applications.submitted).flat())
         }
         if (arg === 'DEALLOCATED') {
@@ -112,9 +112,9 @@ describe('ApplicationService', () => {
         pageNumber: '2',
       }) as PaginatedResponse<Cas2ApplicationSummary>
 
-      applicationClient.getApplicationsForPrison.mockResolvedValue(paginatedResponse)
+      applicationClient.getPagedApplications.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getAllByPrison(token, '123', 2)
+      const result = await service.getAllByPrison(token, 2)
 
       expect(result.data).toEqual(applications)
       expect(result.pageNumber).toEqual('2')
@@ -123,11 +123,11 @@ describe('ApplicationService', () => {
       expect(result.totalResults).toEqual('500')
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.getApplicationsForPrison).toHaveBeenCalledWith('123', 2, 'PRISON')
+      expect(applicationClient.getPagedApplications).toHaveBeenCalledWith(2, 'PRISON')
     })
   })
 
-  describe('getPrisonNewTransferredIn', () => {
+  describe('getPagedApplications', () => {
     const token = 'SOME_TOKEN'
 
     it('fetches all transferred in applications that are not allocated to a POM for a given prison', async () => {
@@ -153,9 +153,9 @@ describe('ApplicationService', () => {
         pageNumber: '2',
       }) as PaginatedResponse<Cas2ApplicationSummary>
 
-      applicationClient.getApplicationsForPrison.mockResolvedValue(paginatedResponse)
+      applicationClient.getPagedApplications.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getPrisonNewTransferredIn(token, '123', 2)
+      const result = await service.getPrisonNewTransferredIn(token, 2)
 
       expect(result.data).toEqual(newData)
       expect(result.pageNumber).toEqual('2')
@@ -164,7 +164,7 @@ describe('ApplicationService', () => {
       expect(result.totalResults).toEqual('500')
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.getApplicationsForPrison).toHaveBeenCalledWith('123', 2, 'UNALLOCATED')
+      expect(applicationClient.getPagedApplications).toHaveBeenCalledWith(2, 'UNALLOCATED')
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -39,9 +39,9 @@ export default class ApplicationService {
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {
     const applicationClient = this.applicationClientFactory(token)
     const [inProgress, submitted, transferredOut] = await Promise.all([
-      applicationClient.getApplicationsForUser('IN_PROGRESS'),
-      applicationClient.getApplicationsForUser('PRISON'),
-      applicationClient.getApplicationsForUser('DEALLOCATED'),
+      applicationClient.getApplications('IN_PROGRESS'),
+      applicationClient.getApplications('ALLOCATED'),
+      applicationClient.getApplications('DEALLOCATED'),
     ])
 
     return {
@@ -51,24 +51,16 @@ export default class ApplicationService {
     } as GroupedApplications
   }
 
-  async getAllByPrison(
-    token: string,
-    prisonCode: string,
-    pageNumber: number = 1,
-  ): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
+  async getAllByPrison(token: string, pageNumber: number = 1): Promise<PaginatedResponse<Cas2ApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    return applicationClient.getApplicationsForPrison(prisonCode, pageNumber, 'PRISON')
+    return applicationClient.getPagedApplications(pageNumber, 'PRISON')
   }
 
-  async getPrisonNewTransferredIn(
-    token: string,
-    prisonCode: string,
-    pageNumber: number = 1,
-  ): Promise<PaginatedResponseWithFormattedData> {
+  async getPrisonNewTransferredIn(token: string, pageNumber: number = 1): Promise<PaginatedResponseWithFormattedData> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const applications = await applicationClient.getApplicationsForPrison(prisonCode, pageNumber, 'UNALLOCATED')
+    const applications = await applicationClient.getPagedApplications(pageNumber, 'UNALLOCATED')
 
     const newData = applications.data.map(application => {
       return [


### PR DESCRIPTION
# Context

* Found a bug where `Your applications` > `Submitted` is pulling through all applications for your prison (not just "Your applications"). 
* Bug created by me - sorry! - by misinterpreting requirements on this ticket: https://dsdmoj.atlassian.net/browse/CAS-1629

# Changes in this PR

## Screenshots of UI changes
* The `Before` screenshot below is what we see on `DEV` env currently. 
* The `After` screenshot below is what we now see on my `LOCAL` env (my `LOCAL` env is integrated with the `DEV` env API - so pulling data from same datasource)
* The above `LOCAL UI -> DEV API` configuration means we can trust the before and after data comparison (as LOCAL env and DEV env are pointed at the same datasource). 
* Notice on the `After` screenshot below that we only see their submitted applications only (not all submitted applications under their prison)

### Before
<img width="1728" alt="Screenshot 2025-05-21 at 12 14 46" src="https://github.com/user-attachments/assets/926c4674-ff7a-4cc4-99b4-cfcb5c767793" />

### After
<img width="1728" alt="Screenshot 2025-05-21 at 12 22 14" src="https://github.com/user-attachments/assets/4bd8d623-2f95-43a9-9e07-a4bde9d951a2" />
