### PR TITLE
Stop test deployments from tagging image as latest

### DIFF
--- a/.github/workflows/deploy_to_test.yml
+++ b/.github/workflows/deploy_to_test.yml
@@ -12,6 +12,7 @@ jobs:
       registry_org: 'ministryofjustice'
       push: true
       docker_multiplatform: false
+      tag_latest: false
 
   deploy_test:
     name: Deploy to the test environment


### PR DESCRIPTION
This stops the 'Deploy to test' docker build from tagging the image as `latest`.

All parts of the deployment processes require a specific version, so no image with the tag `latest` is ever deployed to any of the environments.

Ref: https://github.com/ministryofjustice/hmpps-github-actions/blob/54d81a8b849a002c39a07f7e555562f259c3b22b/.github/workflows/docker_build.yml#L18