### PR TITLE
Suppress Dockerfile syntax warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:22.14-bullseye-slim as base
+FROM node:22.14-bullseye-slim AS base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
@@ -15,7 +15,7 @@ RUN addgroup --gid 2000 --system appgroup && \
 WORKDIR /app
 
 # Cache breaking
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
 
 RUN apt-get update && \
         apt-get upgrade -y && \
@@ -23,7 +23,7 @@ RUN apt-get update && \
         rm -rf /var/lib/apt/lists/*
 
 # Stage: build assets
-FROM base as build
+FROM base AS build
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
This addresses Dockerfile-related warnings found during docker builds:

<img width="1338" alt="Screenshot 2025-06-18 at 10 25 24" src="https://github.com/user-attachments/assets/58b5827e-fdfa-4b46-af1d-1d7d0c5cb154" />
