### PR TITLE
Fix/1805 validation for add health needs

### DIFF
--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_guidance_page.cy.ts
@@ -100,7 +100,7 @@ context('Visit "Risks and needs" section', () => {
 
     // When I continue to the next task/page
     const page = new HealthNeedsGuidancePage(this.application)
-    page.clickContinue()
+    page.clickSubmit('Continue')
 
     //  Then I should be on the substance misuse page
     Page.verifyOnPage(SubstanceMisusePage, this.application)

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/substance_misuse.cy.ts
@@ -55,7 +55,7 @@ context('Visit "Substance misuse" page', () => {
     // --------------------------------
     HealthNeedsGuidancePage.visit(this.application)
     const guidancePage = new HealthNeedsGuidancePage(this.application)
-    guidancePage.clickContinue()
+    guidancePage.clickSubmit('Continue')
   })
 
   //  Scenario: view substance misuse questions

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -74,14 +74,12 @@
     classes: 'copy-text'
     }) }}
 
-      {{ govukButton({
-    text: "Continue",
-    href: paths.applications.pages.show({
-          id: page.application.id,
-          task: 'health-needs',
-          page: 'substance-misuse'
-        })
-    }) }}
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: 'health-needs', page: 'guidance' }) }}?_method=PUT" method="post" autocomplete="off">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+      </form>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1489?selectedIssue=CAS-1805) was to fix an issue where you was able to skip questions in the "Add health needs" section.



# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
