### PR TITLE
Update CAS2 types

### DIFF
--- a/server/@types/shared/models/Cas2ApplicationNoteEntity.ts
+++ b/server/@types/shared/models/Cas2ApplicationNoteEntity.ts
@@ -2,12 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { Cas2ApplicationEntity } from './Cas2ApplicationEntity';
 import type { Cas2AssessmentEntity } from './Cas2AssessmentEntity';
 import type { ExternalUserEntity } from './ExternalUserEntity';
 import type { NomisUserEntity } from './NomisUserEntity';
 export type Cas2ApplicationNoteEntity = {
-    application: Cas2ApplicationEntity;
+    application: any;
     assessment?: Cas2AssessmentEntity;
     body: string;
     createdAt: string;

--- a/server/@types/shared/models/Cas2StatusUpdateEntity.ts
+++ b/server/@types/shared/models/Cas2StatusUpdateEntity.ts
@@ -2,11 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Cas2ApplicationEntity } from './Cas2ApplicationEntity';
 import type { Cas2AssessmentEntity } from './Cas2AssessmentEntity';
 import type { Cas2StatusUpdateDetailEntity } from './Cas2StatusUpdateDetailEntity';
 import type { ExternalUserEntity } from './ExternalUserEntity';
 export type Cas2StatusUpdateEntity = {
-    application: any;
+    application: Cas2ApplicationEntity;
     assessment?: Cas2AssessmentEntity;
     assessor: ExternalUserEntity;
     createdAt: string;

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,4 +1,4 @@
-import { AssignmentType, SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
+import { AssignmentType, SubmitCas2Application, UpdateCas2Application } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import ApplicationClient from './applicationClient'
 import { applicationFactory, applicationSummaryFactory, assessmentFactory } from '../testutils/factories'
@@ -199,7 +199,7 @@ describeClient('ApplicationClient', provider => {
       const data = {
         data: application.data,
         type: 'CAS2',
-      } as UpdateApplication
+      } as UpdateCas2Application
 
       await provider.addInteraction({
         state: 'Server is healthy',

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,9 +1,8 @@
 import {
+  AssignmentType,
   Cas2Application as Application,
   Cas2ApplicationSummary,
   SubmitCas2Application,
-  UpdateApplication,
-  AssignmentType,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 import { UpdateCas2Application } from '../@types/shared/models/UpdateCas2Application'
@@ -53,7 +52,7 @@ export default class ApplicationClient {
   async update(applicationId: string, updateData: UpdateCas2Application): Promise<Application> {
     return (await this.restClient.put({
       path: paths.applications.update({ id: applicationId }),
-      data: { ...updateData, type: 'CAS2' } as UpdateApplication,
+      data: { ...updateData, type: 'CAS2' } as UpdateCas2Application,
     })) as Application
   }
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -1,10 +1,10 @@
 import { Request } from 'express'
-import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import 'reflect-metadata'
 
 // Use a wildcard import to allow us to use jest.spyOn on functions within this module
 import * as utils from './index'
-import { ApprovedPremisesApplication } from '../../@types/shared'
+import { Cas2Application } from '../../@types/shared'
 
 import { applicationFactory } from '../../testutils/factories'
 import { TaskListPageInterface } from '../taskListPage'
@@ -114,15 +114,13 @@ describe('utils', () => {
     it('if there is userInput it returns it', () => {
       const input = { user: 'input' }
 
-      expect(
-        utils.getBody({} as TaskListPageInterface, {} as ApprovedPremisesApplication, {} as Request, input),
-      ).toEqual(input)
+      expect(utils.getBody({} as TaskListPageInterface, {} as Cas2Application, {} as Request, input)).toEqual(input)
     })
 
     it('if there isnt userInput and there is a request body the request body is returned', () => {
       const request: DeepMocked<Request> = createMock<Request>()
 
-      expect(utils.getBody({} as TaskListPageInterface, {} as ApprovedPremisesApplication, request, {}))
+      expect(utils.getBody({} as TaskListPageInterface, {} as Cas2Application, request, {}))
     })
 
     it('if there is neither a request body or userInput then getPageFromApplicationData is called and returns the data for that page', () => {

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,4 +1,4 @@
-import { Cas2Application as Application, SubmitCas2Application, UpdateApplication } from '@approved-premises/api'
+import { Cas2Application as Application, SubmitCas2Application, UpdateCas2Application } from '@approved-premises/api'
 
 import {
   preferredAreasFromAppData,
@@ -7,7 +7,7 @@ import {
   telephoneNumberFromAppData,
 } from './managementInfoFromAppData'
 
-export const getApplicationUpdateData = (application: Application): UpdateApplication => {
+export const getApplicationUpdateData = (application: Application): UpdateCas2Application => {
   return {
     type: 'CAS2',
     data: application.data,


### PR DESCRIPTION
This updates the use of specific cas2 types in preparation for updating swagger groupings in the API, which will mean a lot of models will be removed from the UI repo.