### PR TITLE
added service name headers to pact tests

### DIFF
--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -29,6 +29,7 @@ describeClient('ApplicationClient', provider => {
           path: paths.applications.show({ id: application.id }),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -61,6 +62,7 @@ describeClient('ApplicationClient', provider => {
           },
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -91,6 +93,7 @@ describeClient('ApplicationClient', provider => {
             query: { assignmentType },
             headers: {
               authorization: `Bearer ${token}`,
+              'X-Service-Name': 'cas2',
             },
           },
           willRespondWith: {
@@ -123,6 +126,7 @@ describeClient('ApplicationClient', provider => {
             },
             headers: {
               authorization: `Bearer ${token}`,
+              'X-Service-Name': 'cas2',
             },
           },
           willRespondWith: {
@@ -164,6 +168,7 @@ describeClient('ApplicationClient', provider => {
             },
             headers: {
               authorization: `Bearer ${token}`,
+              'X-Service-Name': 'cas2',
             },
           },
           willRespondWith: {
@@ -210,6 +215,7 @@ describeClient('ApplicationClient', provider => {
           body: JSON.stringify(data),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -242,6 +248,7 @@ describeClient('ApplicationClient', provider => {
           body: data,
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -265,6 +272,7 @@ describeClient('ApplicationClient', provider => {
           path: paths.applications.abandon({ id: application.id }),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -24,6 +24,7 @@ describeClient('AssessmentClient', provider => {
           path: paths.assessments.show({ id: assessment.id }),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -52,6 +53,7 @@ describeClient('AssessmentClient', provider => {
           body: JSON.stringify(data),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -82,6 +84,7 @@ describeClient('AssessmentClient', provider => {
           body: data,
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -27,6 +27,7 @@ describeClient('PersonClient', provider => {
           query: {},
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -55,6 +56,7 @@ describeClient('PersonClient', provider => {
           query: {},
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -84,6 +86,7 @@ describeClient('PersonClient', provider => {
           },
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -111,6 +114,7 @@ describeClient('PersonClient', provider => {
           path: `/cas2/people/${crn}/risks`,
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -25,6 +25,7 @@ describeClient('ReferenceDataClient', provider => {
           path: `/cas2/reference-data/application-status`,
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {

--- a/server/data/submittedApplicationClient.test.ts
+++ b/server/data/submittedApplicationClient.test.ts
@@ -25,6 +25,7 @@ describeClient('SubmittedApplicationClient', provider => {
           query: { page: '1' },
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -62,6 +63,7 @@ describeClient('SubmittedApplicationClient', provider => {
           path: paths.submissions.show({ id: submittedApplication.id }),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {
@@ -94,6 +96,7 @@ describeClient('SubmittedApplicationClient', provider => {
           body,
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'cas2',
           },
         },
         willRespondWith: {


### PR DESCRIPTION
These were failing because of the API spec that says they should be provided. They are included by default on regular requests, so adding in to the tests.
