### PR TITLE
update api spec urls.

### DIFF
--- a/script/generate-types
+++ b/script/generate-types
@@ -7,7 +7,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -z "$1" ]; then
-  url="https://approved-premises-api-dev.hmpps.service.justice.gov.uk/v3/api-docs/CAS2Shared"
+  url="https://approved-premises-api-dev.hmpps.service.justice.gov.uk/v3/api-docs/CAS2"
 else
   url=$1
 fi

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -18,7 +18,9 @@ declare global {
 }
 
 const apiSpecPath = path.join(__dirname, '..', '..', 'tmp', 'cas2-api.json')
-const apiSpecUrl = 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk/v3/api-docs/CAS2Shared'
+
+const apiSpecUrl =
+  process.env.CAS2_API_SPEC_URL || 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk/v3/api-docs/CAS2'
 
 /**
  * Returns a local file if it exists, or downloads it and saves it then returns it if it doesn't.


### PR DESCRIPTION
This PR updates the project to use the repository variable to define the api spec url for the pact tests, as well as changing both to the CAS2 spec url (from the CAS2Shared url)
