### PR TITLE
CHORE: Add GITHUB_TOKEN to action env to avoid rate limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Running shell scripts linting checks
         run: npm run shellcheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   unit_test:
     name: "Unit testing 🧪"


### PR DESCRIPTION
As per the Shellcheck readme [0].

[0] https://github.com/gunar/shellcheck?tab=readme-ov-file#usage
