### PR TITLE
Remove mailto from support link

### DIFF
--- a/server/views/static/accessibility-statement.njk
+++ b/server/views/static/accessibility-statement.njk
@@ -38,7 +38,7 @@
 
       <h2 class="govuk-heading-m">Feedback, contact information and reporting accessibility problems with this website</h2>
       <p>We are always looking to improve our service, including its accessibility.</p>
-      <p>If you find any problems that are not listed on this page or you think we’re not meeting the accessibility requirements, please raise a <a href="mailto:{{ PhaseBannerUtils.supportDeskLink }}" class="govuk-link">support ticket</a> to get help or raise a bug.</p>
+      <p>If you find any problems that are not listed on this page or you think we’re not meeting the accessibility requirements, please raise a <a href="{{ PhaseBannerUtils.serviceDeskLink }}" class="govuk-link">support ticket</a> to get help or raise a bug.</p>
 
       <h2 class="govuk-heading-m">Enforcement procedure</h2>
       <p>


### PR DESCRIPTION
# Context

This fixes the service link in the accessibility statement as part of this [ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1489?selectedIssue=CAS-2072).

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
