### PR TITLE
Chore: Only fetch user secrets from K8s for E2E env

### DIFF
--- a/script/generate-dotenv-files.sh
+++ b/script/generate-dotenv-files.sh
@@ -13,7 +13,7 @@ echo "==> Creating .env files and resolving secrets"
 
 touch "$SCRIPT_DIR/../.env"
 
-secret_names=("hmpps-cas-test-users" "hmpps-community-accommodation-tier-2-ui")
+secret_names=("hmpps-cas-test-users")
 resolve_secrets "$SCRIPT_DIR/../e2e.env.template" \
                 "$SCRIPT_DIR/../e2e.env" \
                 "hmpps-community-accommodation-dev" \


### PR DESCRIPTION
The E2E tests do not need any other secrets than the ones from `hmpps-cas-test-users`, so there is no need to fetch all to generate the e2e env file.
