### PR TITLE
Fix 'Generate types' script

### DIFF
--- a/script/generate-types
+++ b/script/generate-types
@@ -14,7 +14,7 @@ fi
 
 echo "==> Generating types using: $url"
 
-npx openapi-typescript-codegen -i "$url" -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
+npx openapi-typescript-codegen -i "$url" -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes
 
 echo "==> Renaming the declaration file..."
 


### PR DESCRIPTION
This fixes the `Generate Types` Github action that has been failing since late-December.

`npx` is using `openapi-typescript-codegen` `0.30.0`, which was failing due to an extra `true` argument

Based on Bob's CAS1 PR https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2761
