### PR TITLE
Move unshared oasys types 

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -207,3 +207,27 @@ export type PaginatedResponse<T> = {
 export type PaginatedResponseWithFormattedData = Omit<PaginatedResponse, 'data'> & {
   data: ({ html: string; text?: undefined } | { text: string; html?: undefined })[][]
 }
+
+export type OASysSupportingInformationQuestion = {
+  answer?: string
+  label: string
+  linkedToHarm?: boolean
+  linkedToReOffending?: boolean
+  questionNumber: string
+  sectionNumber?: number
+}
+
+export type OASysSections = {
+  /**
+   * The ID of assessment being used. This should always be the latest Layer 3 assessment, regardless of state.
+   */
+  assessmentId: number
+  assessmentState: OASysAssessmentState
+  dateCompleted?: string
+  dateStarted: string
+  offenceDetails: Array<OASysQuestion>
+  riskManagementPlan: Array<OASysQuestion>
+  riskToSelf: Array<OASysQuestion>
+  roshSummary: Array<OASysQuestion>
+  supportingInformation: Array<OASysSupportingInformationQuestion>
+}

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -1,7 +1,8 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import { OASysQuestion, OASysSections, OASysSupportingInformationQuestion } from '@approved-premises/api'
+import { OASysQuestion } from '@approved-premises/api'
+import { OASysSections, OASysSupportingInformationQuestion } from '@approved-premises/ui'
 import { DateFormats } from '../../utils/dateUtils'
 import oasysSelectionFactory from './oasysSelection'
 

--- a/server/testutils/factories/oasysSelection.ts
+++ b/server/testutils/factories/oasysSelection.ts
@@ -1,6 +1,6 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import { OASysSupportingInformationQuestion } from '@approved-premises/api'
+import { OASysSupportingInformationQuestion } from '@approved-premises/ui'
 
 class OasysSelectionFactory extends Factory<OASysSupportingInformationQuestion> {
   needsLinkedToHarm() {


### PR DESCRIPTION
See: https://dsdmoj.atlassian.net/browse/CAS-1845, required for work related to: https://dsdmoj.atlassian.net/browse/FM-557

Moves unshared types `OASysSections` and `OASysSupportingInformationQuestion` outside shared folder and into ui (non shared) type folder.

We have a [dummy controller](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/8fa7b1e0c5a2ce7b2f2904637a8cadcdf1c6860a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2DummyController.kt#L18) in the API which handles a request body bound to `OASysSections` and `OASysSupportingInformationQuestion` which we'd like to remove.  These types are not used to communicate with the API and if we remove this controller and shared types from the API without refactoring these types in the UI first, when the types are updated in the UI, `OASysSections` and `OASysSupportingInformationQuestion` will be removed and break the UI typechecks via `npm run typecheck`.

Moving these two types outside the shared folder to the ui folder and updated imports so that we can remove the dummy controller on the API side without breaking type generation and checking UI side.