### PR TITLE
FM-666 repoint api to cas2 hdc

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -12,7 +12,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/cas2/applications`,
+        url: `/cas2-hdc/applications`,
       },
       response: {
         status: 201,
@@ -24,7 +24,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/cas2/applications`,
+        url: `/cas2-hdc/applications`,
       },
       response: {
         status: 500,
@@ -36,7 +36,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/applications?assignmentType=${args.assignmentType}`,
+        url: `/cas2-hdc/applications?assignmentType=${args.assignmentType}`,
       },
       response: {
         status: 200,
@@ -52,7 +52,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/applications?page=${args.page}&assignmentType=${args.assignmentType}`,
+        url: `/cas2-hdc/applications?page=${args.page}&assignmentType=${args.assignmentType}`,
       },
       response: {
         status: 200,
@@ -70,7 +70,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/applications/${args.application.id}`,
+        url: `/cas2-hdc/applications/${args.application.id}`,
       },
       response: {
         status: 200,
@@ -82,7 +82,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/cas2/applications/${args.application.id}`,
+        url: `/cas2-hdc/applications/${args.application.id}`,
       },
       response: {
         status: 201,
@@ -101,7 +101,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/cas2/submissions`,
+        url: `/cas2-hdc/submissions`,
       },
       response: {
         status: 200,
@@ -112,7 +112,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/cas2/applications/${args.application.id}/abandon`,
+        url: `/cas2-hdc/applications/${args.application.id}/abandon`,
       },
       response: {
         status: 200,
@@ -124,7 +124,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/cas2/applications/${args.application.id}/abandon`,
+        url: `/cas2-hdc/applications/${args.application.id}/abandon`,
       },
       response: {
         status: 400,

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -6,7 +6,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/oasys/risk-to-self`,
+        url: `/cas2-hdc/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 200,
@@ -19,7 +19,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/oasys/risk-to-self`,
+        url: `/cas2-hdc/people/${args.crn}/oasys/risk-to-self`,
       },
       response: {
         status: 404,
@@ -32,7 +32,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/oasys/rosh`,
+        url: `/cas2-hdc/people/${args.crn}/oasys/rosh`,
       },
       response: {
         status: 200,
@@ -45,7 +45,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/oasys/rosh`,
+        url: `/cas2-hdc/people/${args.crn}/oasys/rosh`,
       },
       response: {
         status: 404,
@@ -58,7 +58,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/search?nomsNumber=${args.person.nomsNumber}`,
+        url: `/cas2-hdc/people/search?nomsNumber=${args.person.nomsNumber}`,
       },
       response: {
         status: 201,
@@ -71,7 +71,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/search?nomsNumber=${args.person.nomsNumber}`,
+        url: `/cas2-hdc/people/search?nomsNumber=${args.person.nomsNumber}`,
       },
       response: {
         status: 404,
@@ -82,7 +82,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/search?nomsNumber=${args.person.nomsNumber}`,
+        url: `/cas2-hdc/people/search?nomsNumber=${args.person.nomsNumber}`,
       },
       response: {
         status: 403,
@@ -93,7 +93,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/risks`,
+        url: `/cas2-hdc/people/${args.crn}/risks`,
       },
       response: {
         status: 200,
@@ -106,7 +106,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/people/${args.crn}/risks`,
+        url: `/cas2-hdc/people/${args.crn}/risks`,
       },
       response: {
         status: 404,

--- a/integration_tests/mockApis/submissions.ts
+++ b/integration_tests/mockApis/submissions.ts
@@ -12,7 +12,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/submissions/${args.application.id}`,
+        url: `/cas2-hdc/submissions/${args.application.id}`,
       },
       response: {
         status: 200,
@@ -27,7 +27,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/cas2/submissions?page=${args.page}`,
+        url: `/cas2-hdc/submissions?page=${args.page}`,
       },
       response: {
         status: 200,

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -80,7 +80,7 @@ describeClient('PersonClient', provider => {
         uponReceiving: 'A request to search for a person',
         withRequest: {
           method: 'GET',
-          path: `/cas2/people/search`,
+          path: `/cas2-hdc/people/search`,
           query: {
             nomsNumber: 'nomsNumber',
           },
@@ -111,7 +111,7 @@ describeClient('PersonClient', provider => {
         uponReceiving: 'A request to get the risks for a person',
         withRequest: {
           method: 'GET',
-          path: `/cas2/people/${crn}/risks`,
+          path: `/cas2-hdc/people/${crn}/risks`,
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'cas2',

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -22,7 +22,7 @@ describeClient('ReferenceDataClient', provider => {
         uponReceiving: `A request to get application statuses`,
         withRequest: {
           method: 'GET',
-          path: `/cas2/reference-data/application-status`,
+          path: `/cas2-hdc/reference-data/application-status`,
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'cas2',

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,16 +1,17 @@
 import { path } from 'static-path'
 
-const peoplePath = path('/cas2/people')
+const basePath = path('/cas2-hdc')
+const peoplePath = basePath.path('people')
 const personPath = peoplePath.path(':crn')
 const oasysPath = personPath.path('oasys')
-const applicationsPath = path('/cas2/applications')
+const applicationsPath = basePath.path('applications')
 const abandonPath = applicationsPath.path(':id').path('abandon')
 const singleApplicationPath = applicationsPath.path(':id')
-const singleAssessmentPath = path('/cas2/assessments/:id')
-const submissionsPath = path('/cas2/submissions')
+const singleAssessmentPath = basePath.path('assessments/:id')
+const submissionsPath = basePath.path('submissions')
 const singleSubmissionPath = submissionsPath.path(':id')
-const referenceDataPath = path('/cas2/reference-data')
-const reportsPath = path('/cas2/reports')
+const referenceDataPath = basePath.path('reference-data')
+const reportsPath = basePath.path('reports')
 const singleReportPath = reportsPath.path(':name')
 
 export default {


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-666

Repoint CAS 2 HDC to use new `/cas2-hdc/` controller endpoints (these are a copy of the `/cas2/` endpoints, just renamed so we can free `/cas2/` to be used for bail + custody applications).

**N.B.** 
There is an upcoming API PR which removes `/cas2/` endpoints from the API see [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/4806).

I have run the HDC and Bail end to end tests using this UI branch `feature/FM-666-repoint-API-to-cas2-hdc` and the upcoming API branch `feature/FM-704-remove-cas2-endpoints` which no longer contains `/cas2/` endpoints and both HDC and Bail e2e tests pass.
