### PR TITLE
FM-710 Use OAuth Token for Snyk Jobs

### DIFF
--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -22,5 +22,6 @@ jobs:
       slack_include_summary: true
       snyk_policy_path: '' # Optional path to a custom Snyk policy file
     secrets:
-      HMPPS_SNYK_API_KEY: ${{ secrets.HMPPS_SNYK_API_KEY }}
+      HMPPS_SNYK_CLIENT_SECRET: ${{ secrets.HMPPS_SNYK_CLIENT_SECRET }}
+      HMPPS_SNYK_CLIENT_ID: ${{ secrets.HMPPS_SNYK_CLIENT_ID }}
       HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Updated Snyk Workflow to use OAuth tokens instead of API tokens.

Ran the SNYK workflow on this branch and it passed.
