### PR TITLE
FM-1026 - Add cas2 service closure banner

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -19,6 +19,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
+    CLOSURE_BANNER_ENABLED: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
+    CLOSURE_BANNER_ENABLED: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,6 +18,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
+    CLOSURE_BANNER_ENABLED: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -20,6 +20,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
+    CLOSURE_BANNER_ENABLED: true
     # required so hmpps-audit-client doesn't raise an error
     AUDIT_SQS_QUEUE_URL: ""
     AUDIT_SQS_QUEUE_NAME: ""

--- a/server/config.ts
+++ b/server/config.ts
@@ -102,5 +102,6 @@ export default {
   flags: {
     maintenanceMode: get('IN_MAINTENANCE_MODE', 'false') === 'true',
     plannedMaintenance: get('PLANNED_MAINTENANCE_BANNER', 'false') === 'true',
+    closureBanner: get('CLOSURE_BANNER_ENABLED', 'false') === 'true',
   },
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -71,6 +71,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('plannedMaintenance', config.flags.plannedMaintenance)
 
+  njkEnv.addGlobal('closureBanner', config.flags.closureBanner)
+
   njkEnv.addFilter('initialiseName', initialiseName)
 
   njkEnv.addGlobal('fetchContext', function fetchContext() {

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -8,6 +8,8 @@
 
     {% include 'partials/plannedMaintenanceBanner.njk' %}
 
+    {% include 'partials/closureBanner.njk' %}
+
     <h1>{{ pageHeading }}</h1>
 
     <div class="card-container">

--- a/server/views/partials/closureBanner.njk
+++ b/server/views/partials/closureBanner.njk
@@ -3,7 +3,7 @@
 {% if closureBanner %}
     {% set html %}
         <h3 class="govuk-notification-banner__heading">You can apply for CAS2 for HDC until 26 August 2026</h3>
-        <p class="govuk-body">From 5pm on 26 August 2026, you will no longer be able to submit new applications and receive an offer online. There will be a separate application for people on youth sentences.</p>
+        <p class="govuk-body">From Thursday 27 August 2026, you will no longer be able to submit new applications and receive an offer online. There will be a separate application for people on youth sentences.</p>
     {% endset %}
 
     {{ govukNotificationBanner({

--- a/server/views/partials/closureBanner.njk
+++ b/server/views/partials/closureBanner.njk
@@ -1,0 +1,13 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% if closureBanner %}
+    {% set html %}
+        <h3 class="govuk-notification-banner__heading">You can apply for CAS2 for HDC until 26 August 2026</h3>
+        <p class="govuk-body">From 5pm on 26 August 2026, you will no longer be able to submit new applications and receive an offer online. There will be a separate application for people on youth sentences.</p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+        html: html,
+        classes: 'govuk-!-width-two-thirds'
+    }) }}
+{% endif %}


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-1026

# Changes in this PR

Added the service closure banner. Date/time may change but this can happen in a later PR.
Currently as discussed the feature flag is enabled only on pre-prod and test environments

## Screenshots of UI changes

<img width="619" height="365" alt="Screenshot 2026-08-11 at 17 01 35" src="https://github.com/user-attachments/assets/e0a147a1-b047-4de9-891b-361976976741" />


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge checklist

Once we've merged it will be auto-deployed to the dev environment.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui).

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
